### PR TITLE
refactor: rename test use snake case and camel case

### DIFF
--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/data/model/UserPreferenceMemTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/data/model/UserPreferenceMemTest.kt
@@ -3,7 +3,6 @@ package com.waffiq.bazz_movies.core.user.data.model
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
 import com.waffiq.bazz_movies.core.user.testutils.HelperVariableTest.userModelPref
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -12,8 +11,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.verify
 import java.io.File
 
 class UserPreferenceMemTest {
@@ -22,15 +19,14 @@ class UserPreferenceMemTest {
 
   @Before
   fun setup() {
-    // Use a test-specific in-memory DataStore implementation
+    // use a test-specific in-memory DataStore implementation
     val testDataStoreFile = File.createTempFile("test_datastore", ".preferences_pb")
     dataStore = PreferenceDataStoreFactory.create { testDataStoreFile }
     userPreference = UserPreference(dataStore)
   }
 
   @Test
-  fun `saveUser with all data available should stores correct data`() = runTest {
-    // Save initial user data
+  fun saveUser_withAllDataAvailable_storesCorrectData() = runTest {
     val severalData = UserModelPref(
       userId = 123456789,
       name = "John Doe",
@@ -44,7 +40,6 @@ class UserPreferenceMemTest {
     )
     userPreference.saveUser(severalData)
 
-    // Verify that all data is saved correctly
     val savedUser = userPreference.getUser().first()
     assertEquals(123456789, savedUser.userId)
     assertEquals("John Doe", savedUser.name)
@@ -58,11 +53,9 @@ class UserPreferenceMemTest {
   }
 
   @Test
-  fun `saveUser with only several data available should stores correct data`() = runTest {
-    // Save initial user data
+  fun saveUser_withPartialDataAvailable_storesCorrectData() = runTest {
     userPreference.saveUser(userModelPref)
 
-    // Verify that all data is saved correctly
     val savedUser = userPreference.getUser().first()
     assertEquals(123456789, savedUser.userId)
     assertEquals("John Doe", savedUser.name)
@@ -76,35 +69,28 @@ class UserPreferenceMemTest {
   }
 
   @Test
-  fun `saveRegion should updated region correctly`() = runTest {
-    // Save initial user data
+  fun saveRegion_updatesRegionCorrectly() = runTest {
     userPreference.saveUser(userModelPref)
 
-    // Verify that data is saved correctly
     val savedUser = userPreference.getUser().first()
     assertEquals(123456789, savedUser.userId)
     assertEquals("John Doe", savedUser.name)
 
-    // Save updated region
     userPreference.saveRegion("ID")
     val updatedRegion = userPreference.getRegion().first()
     assertEquals("ID", updatedRegion)
   }
 
   @Test
-  fun `removeUserData should clears all data correctly`() = runTest {
-    // Save initial user data
+  fun removeUserData_clearsAllDataCorrectly() = runTest {
     userPreference.saveUser(userModelPref)
 
-    // Verify that data is saved correctly
     val savedUser = userPreference.getUser().first()
     assertEquals(123456789, savedUser.userId)
     assertEquals("John Doe", savedUser.name)
 
-    // Call removeUserData
     userPreference.removeUserData()
 
-    // Verify that all fields are cleared
     val clearedUser = userPreference.getUser().first()
     assertEquals(0, clearedUser.userId)
     assertEquals("", clearedUser.name)

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/data/model/UserPreferenceMockTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/data/model/UserPreferenceMockTest.kt
@@ -4,7 +4,6 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import app.cash.turbine.test
-import com.ibm.icu.impl.ValidIdentifiers.Datatype.unit
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -43,7 +42,7 @@ class UserPreferenceMockTest {
   }
 
   @Test
-  fun `getUser should returns correct UserModel`() = runTest {
+  fun getUser_returnsCorrectUserModel() = runTest {
     `when`(mockDataStore.data).thenReturn(flowOf(mockPreferences))
 
     val user = userPreference.getUser().first()
@@ -67,7 +66,7 @@ class UserPreferenceMockTest {
   }
 
   @Test
-  fun `getToken should returns correct token`() = runTest {
+  fun getToken_returnsCorrectToken() = runTest {
     `when`(mockDataStore.data).thenReturn(flowOf(mockPreferences))
 
     val token = userPreference.getToken().first()
@@ -76,7 +75,6 @@ class UserPreferenceMockTest {
 
     val listOfToken = userPreference.getToken().toList()
 
-    // Assert that the transformation was applied
     assertEquals(listOf("sampleToken"), listOfToken)
 
     // inline test
@@ -89,7 +87,7 @@ class UserPreferenceMockTest {
   }
 
   @Test
-  fun `getRegion should returns correct region`() = runTest {
+  fun getRegion_returnsCorrectRegion() = runTest {
     `when`(mockDataStore.data).thenReturn(flowOf(mockPreferences))
 
     val region = userPreference.getRegion().first().toString().uppercase()
@@ -104,7 +102,7 @@ class UserPreferenceMockTest {
   }
 
   @Test
-  fun `getRegion should handles null region`() = runTest {
+  fun getRegion_handlesNullRegion() = runTest {
     `when`(mockDataStore.data).thenReturn(flowOf(mockPreferences))  // Explicitly mock preferences object
 
     // Inline test with Turbine
@@ -116,7 +114,7 @@ class UserPreferenceMockTest {
   }
 
   @Test
-  fun `saveRegion edit should call edit`() = runTest {
+  fun saveRegion_edit_callsEdit() = runTest {
     `when`(mockDataStore.data).thenReturn(flowOf(mockPreferences))  // Explicitly mock preferences object
     `when`(mockDataStore.edit(any())).thenAnswer {
       // Simulate that edit does nothing (since it returns Unit)

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/data/model/UserPreferenceMockTwoTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/data/model/UserPreferenceMockTwoTest.kt
@@ -1,14 +1,11 @@
 package com.waffiq.bazz_movies.core.user.data.model
 
 import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.mutablePreferencesOf
-import app.cash.turbine.test
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -30,50 +27,28 @@ class UserPreferenceMockTwoTest {
     mockDataStore = mock<DataStore<Preferences>>()
     mockPreferences = mock<Preferences>()
 
-    // Mock dataStore.data to emit an initial preference (region is "US")
+    // mock dataStore.data to emit an initial preference (region is "US")
     val initialPreferencesFlow = flowOf(mutablePreferencesOf(UserPreference.REGION_KEY to "US"))
     `when`(mockDataStore.data).thenReturn(initialPreferencesFlow)
-
-    // Mock the edit function to update preferences when saveRegion is called
-    `when`(mockDataStore.edit(any())).thenAnswer { invocation ->
-      // Capture the block passed to edit()
-      val block = invocation.getArgument<suspend (MutablePreferences) -> Unit>(0)
-
-      // Create a mutable preferences map with initial "US" region
-      val mutablePreferences = mutablePreferencesOf(UserPreference.REGION_KEY to "US")
-
-      // Run the block and apply the region change
-      runBlocking { block(mutablePreferences) }
-
-      // Modify the region to "ID" inside the block
-      mutablePreferences[UserPreference.REGION_KEY] = "ID"
-
-      // Return the modified preferences
-      mutablePreferences
-    }
 
     userPreference = UserPreference(mockDataStore)
   }
 
   @Test
-  fun `saveRegion should save the correct region`() = runTest {
-    // Call saveRegion to update region to "ID"
+  fun saveRegion_savesCorrectRegion() = runTest {
     userPreference.saveRegion("ID")
 
-    // Mock dataStore.data to emit updated preferences
     val updatedPreferencesFlow = flowOf(mutablePreferencesOf(UserPreference.REGION_KEY to "ID"))
     `when`(mockDataStore.data).thenReturn(updatedPreferencesFlow)
 
-    // Verify that getRegion() emits the correct updated region
     val savedRegion = userPreference.getRegion().first() // This should return "ID"
     assertEquals("ID", savedRegion)
 
-    // Verify that edit was called with the correct key
     verify(mockDataStore).edit(any())
   }
 
   @Test
-  fun `saveRegion should update region when key exists`() = runTest {
+  fun saveRegion_updatesRegionWhenKeyExists() = runTest {
     userPreference.saveRegion("US")
     `when`(mockDataStore.data).thenReturn(flowOf(mutablePreferencesOf(UserPreference.REGION_KEY to "US")))
     val firstRegion = userPreference.getRegion().first()

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/data/model/UserPreferenceNonMockTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/data/model/UserPreferenceNonMockTest.kt
@@ -39,7 +39,7 @@ class UserPreferenceNonMockTest {
 
 
   @Test
-  fun `saveUser and getUser should stores and return same data`() = runTest {
+  fun saveUser_and_getUser_storeAndReturnSameData() = runTest {
     userPreference.saveUser(userModelPref)
 
     val savedUser = userPreference.getUser().first()
@@ -47,7 +47,7 @@ class UserPreferenceNonMockTest {
   }
 
   @Test
-  fun `saveRegion should stores correct region`() = runTest {
+  fun saveRegion_storesCorrectRegion() = runTest {
     userPreference.saveUser(userModelPref)
     userPreference.saveRegion("MY")
 
@@ -56,14 +56,14 @@ class UserPreferenceNonMockTest {
   }
 
   @Test
-  fun `saveRegion empty region should stores empty region`() = runTest {
+  fun saveRegion_emptyRegion_storesEmptyRegion() = runTest {
     userPreference.saveUser(userModelPref)
     userPreference.saveRegion("")
     assertEquals("", userPreference.getUser().first().region)
   }
 
   @Test
-  fun `getToken should return correct token`() = runTest {
+  fun getToken_returnsCorrectToken() = runTest {
     userPreference.saveUser(userModelPref)
 
     val userToken = userPreference.getToken().first()
@@ -71,7 +71,7 @@ class UserPreferenceNonMockTest {
   }
 
   @Test
-  fun `getRegion should return correct region`() = runTest {
+  fun getRegion_returnsCorrectRegion() = runTest {
     userPreference.saveUser(userModelPref)
 
     val userToken = userPreference.getRegion().first()
@@ -79,7 +79,7 @@ class UserPreferenceNonMockTest {
   }
 
   @Test
-  fun `removeDataUser should remove all data`() = runTest {
+  fun removeDataUser_removesAllData() = runTest {
     userPreference.saveUser(userModelPref)
 
     // check first if data is valid

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/data/repository/UserRepositoryTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/data/repository/UserRepositoryTest.kt
@@ -80,7 +80,7 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `createToken success should return mapped result`() = runTest {
+  fun createToken_success_returnsMappedResult() = runTest {
     val createTokenResponse = AuthenticationResponse(
       success = true,
       expireAt = "date_expired",
@@ -109,7 +109,7 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `login success should return mapped authentication`() = runTest {
+  fun login_success_returnsMappedAuthentication() = runTest {
     val loginResponse = AuthenticationResponse(
       success = true,
       expireAt = "date_expired",
@@ -137,7 +137,7 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `create session login success should return mapped session`() = runTest {
+  fun createSession_loginSuccess_returnsMappedSession() = runTest {
     val sessionResponse = CreateSessionResponse(
       success = true,
       sessionId = "session_id"
@@ -163,7 +163,7 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `delete session success should return success`() = runTest {
+  fun deleteSession_success_returnsSuccess() = runTest {
     val deleteSessionResponse = PostResponse(
       success = true,
       statusCode = 200,
@@ -189,7 +189,7 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `delete session failed should return error message`() = runTest {
+  fun deleteSession_failed_returnsErrorMessage() = runTest {
     val failedResponse = PostResponse(
       success = false,
       statusCode = 11,
@@ -210,7 +210,7 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `get detail user should return mapped user detail`() = runTest {
+  fun getDetailUser_returnsMappedUserDetail() = runTest {
     val accountDetailsResponse = AccountDetailsResponse(
       includeAdult = false,
       iso31661 = "en",
@@ -254,7 +254,7 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `createToken error should return error message correctly`() = runTest {
+  fun createToken_error_returnsErrorMessage() = runTest {
     val errorMessage = "Network error"
     val errorFlow = flowOf(NetworkResult.Error(errorMessage))
     coEvery { mockUserDataSource.createToken() } returns errorFlow
@@ -267,21 +267,21 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `saveUserPref should invoke UserPreference saveUser`() = runTest {
+  fun saveUserPref_invokesUserPreferenceSaveUser() = runTest {
     coEvery { mockUserPreference.saveUser(userModelPref) } just Runs
     userRepository.saveUserPref(user)
     coVerify { mockUserPreference.saveUser(userModelPref) }
   }
 
   @Test
-  fun `saveRegionPref should invoke UserPreference saveRegion`() = runTest {
+  fun saveRegionPref_invokesUserPreferenceSaveRegion() = runTest {
     coEvery { mockUserPreference.saveRegion("ID") } just Runs
     userRepository.saveRegionPref("ID")
     coVerify { mockUserPreference.saveRegion("ID") }
   }
 
   @Test
-  fun `getUserPref should emit user model`() = runTest {
+  fun getUserPref_emitsUserModel() = runTest {
     val flowResult = flowOf(userModelPref)
     every { mockUserPreference.getUser() } returns flowResult
 
@@ -301,7 +301,7 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `getUserToken should emit user token`() = runTest {
+  fun getUserToken_emitsUserToken() = runTest {
     val token = "token"
     val flowResult = flowOf(token)
     every { mockUserPreference.getToken() } returns flowResult
@@ -315,7 +315,7 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `getUserRegionPref should emit user region`() = runTest {
+  fun getUserRegionPref_emitsUserRegion() = runTest {
     val region = "ID"
     val flowResult = flowOf(region)
     every { mockUserPreference.getRegion() } returns flowResult
@@ -329,14 +329,14 @@ class UserRepositoryTest {
   }
 
   @Test
-  fun `removeUserDataPref should call removeUserData in UserPreference`() = runTest {
+  fun removeUserDataPref_callsRemoveUserDataInUserPreference() = runTest {
     coEvery { mockUserPreference.removeUserData() } just Runs
     userRepository.removeUserDataPref()
     coVerify { mockUserPreference.removeUserData() }
   }
 
   @Test
-  fun `getCountryCode should return mapped country code`() = runTest {
+  fun getCountryCode_returnsMappedCountryCode() = runTest {
     val countryIPResponse = CountryIPResponse(
       country = "ID"
     )

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/di/DatastoreModuleTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/di/DatastoreModuleTest.kt
@@ -18,7 +18,7 @@ class DatastoreModuleTest {
   private val datastoreModule : DatastoreModule = DatastoreModule()
 
   @Test
-  fun `provideDataStore should return a DataStore instance`() = runTest {
+  fun provideDataStore_returnsDataStoreInstance() = runTest {
     val actualDatastore = datastoreModule.provideDataStore(mockContext)
     val expectedDatastore = PreferenceDataStoreFactory.create(produceFile = {
       mockContext.preferencesDataStoreFile(DATASTORE_NAME)
@@ -30,7 +30,7 @@ class DatastoreModuleTest {
 
 
   @Test
-  fun `provideUserPreference should return a UserPreference instance`() = runTest {
+  fun provideUserPreference_returnsUserPreferenceInstance() = runTest {
     val dataStore: DataStore<Preferences> = datastoreModule.provideDataStore(mockContext)
     val userPreference = datastoreModule.provideUserPreference(dataStore)
 

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/model/account/AuthenticationTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/model/account/AuthenticationTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 class AuthenticationTest {
 
   @Test
-  fun `test Authentication creation all properties set`() {
+  fun authentication_WithAllPropertiesSet() {
     val authentication = Authentication(
       success = true,
       expireAt = "expire_date",
@@ -21,7 +21,7 @@ class AuthenticationTest {
   }
 
   @Test
-  fun `test Authentication creation only some properties are provided`() {
+  fun authentication_WithSomePropertiesProvided() {
     val authentication = Authentication(success = false, expireAt = null, requestToken = null)
     assertFalse(authentication.success)
     assertNull(authentication.expireAt)
@@ -29,7 +29,7 @@ class AuthenticationTest {
   }
 
   @Test
-  fun `test Authentication with all default values`() {
+  fun authentication_WithWithDefaultValues() {
     val authentication = Authentication(success = true)
     assertTrue(authentication.success)
     assertNull(authentication.expireAt)

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/model/account/AvatarTMDbTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/model/account/AvatarTMDbTest.kt
@@ -7,19 +7,19 @@ import org.junit.Test
 class AvatarTMDbTest {
 
   @Test
-  fun `test AvatarTMDb creation with all properties set`() {
+  fun avatarTMDb_creationWithAllPropertiesSet() {
     val avatarTmdb = AvatarTMDb(avatarPath = "/1243513451443.jpg")
     assertEquals("/1243513451443.jpg", avatarTmdb.avatarPath)
   }
 
   @Test
-  fun `test AvatarTMDb creation with all properties null`() {
+  fun avatarTMDb_creationWithAllPropertiesNull() {
     val avatarTmdb = AvatarTMDb(avatarPath = null)
     assertNull(avatarTmdb.avatarPath)
   }
 
   @Test
-  fun `test AvatarTMDb creation with all default values`() {
+  fun avatarTMDb_creationWithDefaultValues() {
     val avatarTmdb = AvatarTMDb()
     assertNull(avatarTmdb.avatarPath)
   }

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/model/account/CountryIPTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/model/account/CountryIPTest.kt
@@ -7,28 +7,28 @@ import org.junit.Test
 class CountryIPTest {
 
   @Test
-  fun `test CountryIP creation with all properties set`() {
+  fun countryIP_WithAllPropertiesSet() {
     val avatarTmdb = CountryIP(country = "ID", ip = "117.25.82.134")
     assertEquals("ID", avatarTmdb.country)
     assertEquals("117.25.82.134", avatarTmdb.ip)
   }
 
   @Test
-  fun `test CountryIP creation with all properties null`() {
+  fun countryIP_WithAllPropertiesNull() {
     val avatarTmdb = CountryIP(null, null)
     assertNull(avatarTmdb.country)
     assertNull(avatarTmdb.ip)
   }
 
   @Test
-  fun `test CountryIP creation only some properties are provided`() {
+  fun countryIP_WithSomePropertiesProvided() {
     val avatarTmdb = CountryIP("US", null)
     assertEquals("US", avatarTmdb.country)
     assertNull(avatarTmdb.ip)
   }
 
   @Test
-  fun `test CountryIP creation with all default values`() {
+  fun countryIP_WithDefaultValues() {
     val avatarTmdb = CountryIP()
     assertNull(avatarTmdb.country)
     assertNull(avatarTmdb.ip)

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/model/account/GravatarTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/model/account/GravatarTest.kt
@@ -7,19 +7,19 @@ import org.junit.Test
 class GravatarTest {
 
   @Test
-  fun `test Gravatar creation with all properties set`() {
+  fun gravatar_WithAllPropertiesSet() {
     val gravatar = Gravatar(hash = "/536978543976.jpg")
     assertEquals("/536978543976.jpg", gravatar.hash)
   }
 
   @Test
-  fun `test Gravatar creation with all properties null`() {
+  fun gravatar_WithAllPropertiesNull() {
     val gravatar = Gravatar(hash = null)
     assertNull(gravatar.hash)
   }
 
   @Test
-  fun `test Gravatar creation with all default values`() {
+  fun gravatar_WithDefaultValues() {
     val gravatar = Gravatar()
     assertNull(gravatar.hash)
   }

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/authtmdbaccount/AuthTMDbAccountInteractorTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/authtmdbaccount/AuthTMDbAccountInteractorTest.kt
@@ -39,7 +39,7 @@ class AuthTMDbAccountInteractorTest {
   }
 
   @Test
-  fun `login success should returns success result`() = runTest {
+  fun login_SuccessReturnsSuccessResult() = runTest {
     val response = Authentication(
       success = true,
       expireAt = "date_expire",
@@ -64,7 +64,7 @@ class AuthTMDbAccountInteractorTest {
   }
 
   @Test
-  fun `login failed should returns error message`() = runTest {
+  fun login_FailedReturnsErrorMessage() = runTest {
     val username = "username"
     val pass = "password"
     val sessionId = "session_id"
@@ -83,7 +83,7 @@ class AuthTMDbAccountInteractorTest {
   }
 
   @Test
-  fun `create token success should returns success result`() = runTest {
+  fun createToken_SuccessReturnsSuccessResult() = runTest {
     val response =
       Authentication(success = true, expireAt = "date_expire", requestToken = "request_token")
 
@@ -103,7 +103,7 @@ class AuthTMDbAccountInteractorTest {
   }
 
   @Test
-  fun `create token failed should returns error message`() = runTest {
+  fun createToken_FailedReturnsErrorMessage() = runTest {
     val flow = flowOf(Outcome.Error(message = errorMessage))
     whenever(mockRepository.createToken()).thenReturn(flow)
 
@@ -118,7 +118,7 @@ class AuthTMDbAccountInteractorTest {
   }
 
   @Test
-  fun `delete session success should returns success result`() = runTest {
+  fun deleteSession_SuccessReturnsSuccessResult() = runTest {
     val response = Post(success = true, statusCode = 200, statusMessage = "Delete session success")
     val flow = flowOf(Outcome.Success(response))
     whenever(mockRepository.deleteSession(sessionId)).thenReturn(flow)
@@ -136,7 +136,7 @@ class AuthTMDbAccountInteractorTest {
   }
 
   @Test
-  fun `delete session failed should returns error message`() = runTest {
+  fun deleteSession_FailedReturnsErrorMessage() = runTest {
     val flow = flowOf(Outcome.Error(message = errorMessage))
     whenever(mockRepository.deleteSession(sessionId)).thenReturn(flow)
 
@@ -150,7 +150,7 @@ class AuthTMDbAccountInteractorTest {
   }
 
   @Test
-  fun `create session login success should returns success result`() = runTest {
+  fun createSession_LoginSuccessReturnsSuccessResult() = runTest {
     val response = CreateSession(success = true, sessionId = "session_id")
 
     val flow = flowOf(Outcome.Success(response))
@@ -167,7 +167,7 @@ class AuthTMDbAccountInteractorTest {
   }
 
   @Test
-  fun `create session login failed should returns error message`() = runTest {
+  fun createSession_LoginFailedReturnsErrorMessage() = runTest {
     val flow = flowOf(Outcome.Error(message = errorMessage))
     whenever(mockRepository.createSessionLogin(requestToken)).thenReturn(flow)
 
@@ -181,7 +181,7 @@ class AuthTMDbAccountInteractorTest {
   }
 
   @Test
-  fun `get user details success should returns success result`() = runTest {
+  fun getUserDetails_SuccessReturnsSuccessResult() = runTest {
     val response = AccountDetails(
       includeAdult = false,
       iso31661 = "en",
@@ -219,7 +219,7 @@ class AuthTMDbAccountInteractorTest {
   }
 
   @Test
-  fun `get user details failed should returns error message`() = runTest {
+  fun getUserDetails_FailedReturnsErrorMessage() = runTest {
     val flow = flowOf(Outcome.Error(message = errorMessage))
     whenever(mockRepository.getUserDetail(sessionId)).thenReturn(flow)
 

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/getregion/GetRegionInteractorTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/getregion/GetRegionInteractorTest.kt
@@ -19,7 +19,6 @@ import org.junit.Test
  */
 class GetRegionInteractorTest {
 
-  // Mock dependencies
   private val mockRepository: IUserRepository = mockk()
   private lateinit var getRegionInteractor: GetRegionInteractor
 
@@ -29,28 +28,28 @@ class GetRegionInteractorTest {
   }
 
   @Test
-  fun `getCountryCode emits success`() = runTest {
+  fun getCountryCode_EmitsSuccess() = runTest {
     val expectedCountryIP = CountryIP(country = "US")
     val flow = flowOf(Outcome.Success(expectedCountryIP))
     coEvery { mockRepository.getCountryCode() } returns flow
 
     getRegionInteractor.getCountryCode().test {
-      // Assert the first emission is success with correct data
+      // assert the first emission is success with correct data
       val emission = awaitItem()
       assertTrue(emission is Outcome.Success)
       assertEquals("US", (emission as Outcome.Success).data.country)
 
-      // Assert no further emissions
+      // assert no further emissions
       awaitComplete()
     }
 
-    // Verify repository interaction
+    // verify repository interaction
     coVerify(exactly = 1) { mockRepository.getCountryCode() }
     coVerify { mockRepository.getCountryCode() }
   }
 
   @Test
-  fun `getCountryCode emits error`() = runTest {
+  fun getCountryCode_EmitsError() = runTest {
     val errorMessage = "Network error"
     val flow = flowOf(Outcome.Error(message = errorMessage))
     coEvery { mockRepository.getCountryCode() } returns flow

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/userpreference/UserPrefInteractorTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/userpreference/UserPrefInteractorTest.kt
@@ -37,7 +37,7 @@ class UserPrefInteractorTest {
   }
 
   @Test
-  fun `getUserPref emits user data`() = runTest {
+  fun getUserPref_EmitsUserData() = runTest {
     val userModel = UserModel(
       userId = 3,
       name = "Alice",
@@ -74,7 +74,7 @@ class UserPrefInteractorTest {
   }
 
   @Test
-  fun `getUserRegionPref emits user region`() = runTest {
+  fun getUserRegionPref_EmitsUserRegion() = runTest {
     val region = "ID"
     val flow = flowOf(region)
     every { mockRepository.getUserRegionPref() } returns flow
@@ -87,7 +87,7 @@ class UserPrefInteractorTest {
   }
 
   @Test
-  fun `getUserToken emits user token`() = runTest {
+  fun getUserToken_EmitsUserToken() = runTest {
     val userToken = "user_token"
     val flow = flowOf(userToken)
     every { mockRepository.getUserToken() } returns flow
@@ -100,7 +100,7 @@ class UserPrefInteractorTest {
   }
 
   @Test
-  fun `saveRegionPref saves user region`() = runTest {
+  fun saveRegionPref_SavesUserRegion() = runTest {
     val region = "ID"
     coEvery { mockRepository.saveRegionPref(region) } just Runs
     userPrefInteractor.saveRegionPref(region)
@@ -108,7 +108,7 @@ class UserPrefInteractorTest {
   }
 
   @Test
-  fun `saveUserPref saves user data`() = runTest {
+  fun saveUserPref_SavesUserData() = runTest {
     val userModel = UserModel(
       userId = 3,
       name = "Alice",
@@ -126,7 +126,7 @@ class UserPrefInteractorTest {
   }
 
   @Test
-  fun `removeUserDataPref removes user data`() = runTest {
+  fun removeUserDataPref_RemovesUserData() = runTest {
     coEvery { mockRepository.removeUserDataPref() } just Runs
     userPrefInteractor.removeUserDataPref()
     coVerify { mockRepository.removeUserDataPref() }

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/ui/viewmodel/RegionViewModelTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/ui/viewmodel/RegionViewModelTest.kt
@@ -38,7 +38,7 @@ class RegionViewModelTest {
   }
 
   @Test
-  fun `getCountryCode emits country code when use case returns success`() = runTest {
+  fun getCountryCode_EmitsCountryCodeWhenUseCaseReturnsSuccess() = runTest {
     val mockCountryIP = CountryIP(country = "US", ip = "192.168.0.1")
     val mockResult = Outcome.Success(mockCountryIP)
     `when`(getRegionUseCase.getCountryCode()).thenReturn(flow { emit(mockResult) })
@@ -53,7 +53,7 @@ class RegionViewModelTest {
   }
 
   @Test
-  fun `getCountryCode emits error state when use case returns error`() = runTest {
+  fun getCountryCode_EmitsErrorStateWhenUseCaseReturnsError() = runTest {
     val mockResult = Outcome.Error(message = "Network error")
     `when`(getRegionUseCase.getCountryCode()).thenReturn(flow { emit(mockResult) })
 
@@ -67,7 +67,7 @@ class RegionViewModelTest {
   }
 
   @Test
-  fun `getCountryCode processes loading state`() = runTest {
+  fun getCountryCode_ProcessesLoadingState() = runTest {
     val mockResult = Outcome.Loading
     `when`(getRegionUseCase.getCountryCode()).thenReturn(flow { emit(mockResult) })
 
@@ -82,7 +82,7 @@ class RegionViewModelTest {
   }
 
   @Test
-  fun `getCountryCode sets countryCode to empty when use case returns error`() = runTest {
+  fun getCountryCode_SetsCountryCodeToEmptyWhenUseCaseReturnsError() = runTest {
     val mockResult = Outcome.Error(message = "Error")
     `when`(getRegionUseCase.getCountryCode()).thenReturn(flow { emit(mockResult) })
 
@@ -96,7 +96,7 @@ class RegionViewModelTest {
   }
 
   @Test
-  fun `getCountryCode sets countryCode to empty when country is null`() = runTest {
+  fun getCountryCode_SetsCountryCodeToEmptyWhenCountryIsNull() = runTest {
     val mockCountryIP = CountryIP(country = null, ip = "192.168.0.1")
     val mockResult = Outcome.Success(mockCountryIP)
     `when`(getRegionUseCase.getCountryCode()).thenReturn(flow { emit(mockResult) })

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/ui/viewmodel/UserPreferenceViewModelTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/ui/viewmodel/UserPreferenceViewModelTest.kt
@@ -46,7 +46,7 @@ class UserPreferenceViewModelTest {
   }
 
   @Test
-  fun `getUserPref emits UserModel`() = runTest {
+  fun getUserPref_emitsUserModel() = runTest {
     every { userPrefUseCase.getUser() } returns flowOf(userModel) // Mocking getUser()
 
     val observer = mockk<Observer<UserModel>>(relaxed = true) // Relaxed mock for observer
@@ -57,7 +57,7 @@ class UserPreferenceViewModelTest {
   }
 
   @Test
-  fun `getUserRegionPref emits region string`() = runTest {
+  fun getUserRegionPref_emitsRegionString() = runTest {
     val region = "US"
     every { userPrefUseCase.getUserRegionPref() } returns flowOf(region)
 
@@ -68,7 +68,7 @@ class UserPreferenceViewModelTest {
   }
 
   @Test
-  fun `saveUserPref calls use case with correct data`() = runTest {
+  fun saveUserPref_callsUseCaseWithCorrectData() = runTest {
     coEvery { userPrefUseCase.saveUserPref(userModel) } just Runs
     viewModel.saveUserPref(userModel)
     advanceUntilIdle()
@@ -76,7 +76,7 @@ class UserPreferenceViewModelTest {
   }
 
   @Test
-  fun `saveRegionPref calls saveRegionPref on UserPrefUseCase`() = runTest {
+  fun saveRegionPref_callsSaveRegionPrefOnUserPrefUseCase() = runTest {
     val region = "US"
     viewModel.saveRegionPref(region)
     advanceUntilIdle()
@@ -84,7 +84,7 @@ class UserPreferenceViewModelTest {
   }
 
   @Test
-  fun `removeUserDataPref calls use case`() = runTest {
+  fun removeUserDataPref_callsUseCase() = runTest {
     coEvery { userPrefUseCase.removeUserDataPref() } just Runs
     viewModel.removeUserDataPref()
     advanceUntilIdle()

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/utils/mappers/AccountMapperTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/utils/mappers/AccountMapperTest.kt
@@ -34,7 +34,7 @@ import org.junit.Test
 class AccountMapperTest {
 
   @Test
-  fun `map UserModelPref to UserModel`() {
+  fun mapUserModelPref_ToUserModel() {
     val userModelPref = UserModelPref(
       userId = 34567,
       name = "name",
@@ -60,7 +60,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map UserModel to UserModelPref`() {
+  fun mapUserModel_ToUserModelPref() {
     val userMode = UserModel(
       userId = 12345,
       name = "name_model",
@@ -86,7 +86,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map AuthenticationResponse to Authentication non null response`() {
+  fun mapAuthenticationResponse_ToAuthenticationNonNullResponse() {
     val response = AuthenticationResponse(
       success = true,
       expireAt = "date_expire",
@@ -100,7 +100,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map AuthenticationResponse to Authentication null response`() {
+  fun mapAuthenticationResponse_ToAuthenticationNullResponse() {
     val response = AuthenticationResponse(
       success = true,
       expireAt = null,
@@ -114,7 +114,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map CreateSessionResponse to CreateSession`() {
+  fun mapCreateSessionResponse_ToCreateSession() {
     val response = CreateSessionResponse(success = true, sessionId = "session_id")
 
     val authentication: CreateSession = response.toCreateSession()
@@ -123,7 +123,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map AccountDetailsResponse to AccountDetails with non-null responses`() {
+  fun mapAccountDetailsResponse_ToAccountDetailsWithNonNullResponses() {
     val response = AccountDetailsResponse(
       includeAdult = false,
       iso31661 = "en",
@@ -154,7 +154,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map AccountDetailsResponse to AccountDetails with null avatarItemResponse`() {
+  fun mapAccountDetailsResponse_ToAccountDetailsWithNullAvatarItemResponse() {
     val response = AccountDetailsResponse(
       includeAdult = false,
       iso31661 = "id",
@@ -176,7 +176,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map AccountDetailsResponse to AccountDetails null responses`() {
+  fun mapAccountDetailsResponse_ToAccountDetailsNullResponses() {
     val response = AccountDetailsResponse(
       includeAdult = null,
       iso31661 = null,
@@ -199,7 +199,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map AvatarItemResponse to AvatarItem with non-null responses`() {
+  fun mapAvatarItemResponse_ToAvatarItemWithNonNullResponses() {
     val response = AvatarItemResponse(
       gravatarResponse = GravatarResponse(hash = "/617956749353.jpg"),
       avatarTMDbResponse = AvatarTMDbResponse(avatarPath = "/27359679153253.jpg")
@@ -211,7 +211,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map AvatarItemResponse to AvatarItem with null gravatarResponse`() {
+  fun mapAvatarItemResponse_ToAvatarItemWithNullGravatarResponse() {
     val response = AvatarItemResponse(
       gravatarResponse = null,
       avatarTMDbResponse = AvatarTMDbResponse(avatarPath = "/27359679153253.jpg")
@@ -224,7 +224,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map AvatarItemResponse to AvatarItem with null avatarTMDbResponse`() {
+  fun mapAvatarItemResponse_ToAvatarItemWithNullAvatarTMDbResponse() {
     val response = AvatarItemResponse(
       gravatarResponse = GravatarResponse(hash = "/617956749353.jpg"),
       avatarTMDbResponse = null
@@ -237,7 +237,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map AvatarItemResponse to AvatarItem with null responses`() {
+  fun mapAvatarItemResponse_ToAvatarItemWithNullResponses() {
     val response = AvatarItemResponse(gravatarResponse = null, avatarTMDbResponse = null)
 
     val avatarItem: AvatarItem = response.toAvatarItem()
@@ -247,7 +247,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map AvatarTMDbResponse to AvatarTMD`() {
+  fun mapAvatarTMDbResponse_ToAvatarTMDb() {
     val response = AvatarTMDbResponse(avatarPath = "/32154543587943.jpg")
 
     val avatarTmdb: AvatarTMDb = response.toAvatarTMDb()
@@ -255,7 +255,7 @@ class AccountMapperTest {
   }
 
   @Test
-  fun `map GravatarResponse to Gravatar`() {
+  fun mapGravatarResponse_ToGravatar() {
     val response = GravatarResponse(hash = "/325987423659432.jpg")
 
     val gravatar: Gravatar = response.toGravatar()
@@ -264,7 +264,7 @@ class AccountMapperTest {
 
 
   @Test
-  fun `map CountryIPResponse to CountryIP`() {
+  fun mapCountryIPResponse_ToCountryIP() {
     val response = CountryIPResponse(
       country = "ID",
       ip = "ip_country"

--- a/feature/search/src/test/kotlin/com/waffiq/bazz_movies/feature/search/data/repository/SearchRepositoryImplTest.kt
+++ b/feature/search/src/test/kotlin/com/waffiq/bazz_movies/feature/search/data/repository/SearchRepositoryImplTest.kt
@@ -88,15 +88,12 @@ class SearchRepositoryImplTest {
       PagingData.from(listOf(resultsItemSearchResponse, resultsItemSearchResponse2))
     every { movieDataSource.getPagingSearch(QUERY) } returns flowOf(fakePagingData)
 
-    val resultFlow = repository.getPagingSearch(QUERY)
-    // act & assert: Collect the flow and check the results
-    resultFlow.test {
+    repository.getPagingSearch(QUERY).test {
       val pagingData = awaitItem() // Collect first item
       val job = launch { differ.submitData(pagingData) }
       advanceUntilIdle()
 
-      // assert on the actual items
-      val pagingList = differ.snapshot().items // this is the data you wanted
+      val pagingList = differ.snapshot().items
       assertTrue(pagingList.isEmpty().not())
       job.cancel()
 


### PR DESCRIPTION
### Changes Made

- Rename test name to use snake case and camel case to follow [google preference](https://developer.android.com/training/testing/local-tests)
- Also [here](https://softwareengineering.stackexchange.com/a/237576) is good explanation why use that preference