### PR TITLE
chore(network): use Hilt to inject DebugConfig dependency

### DIFF
--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/movie/DetailMovieResponse.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/movie/DetailMovieResponse.kt
@@ -6,7 +6,7 @@ import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovi
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.ProductionCountriesItemResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.releasedates.ReleaseDatesResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.ProductionCompaniesItemResponse
-import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.SpokenLanguagesItemReponse
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.SpokenLanguagesItemResponse
 
 @JsonClass(generateAdapter = false)
 data class DetailMovieResponse(
@@ -63,7 +63,7 @@ data class DetailMovieResponse(
   val posterPath: String? = null,
 
   @Json(name = "spoken_languages")
-  val listSpokenLanguagesItemResponse: List<SpokenLanguagesItemReponse?>? = null,
+  val listSpokenLanguagesItemResponse: List<SpokenLanguagesItemResponse?>? = null,
 
   @Json(name = "production_companies")
   val listProductionCompaniesItemResponse: List<ProductionCompaniesItemResponse?>? = null,

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/tv/DetailTvResponse.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/tv/DetailTvResponse.kt
@@ -66,7 +66,7 @@ data class DetailTvResponse(
   val originCountry: List<String?>? = null,
 
   @Json(name = "spoken_languages")
-  val spokenLanguagesResponse: List<SpokenLanguagesItemReponse?>? = null,
+  val spokenLanguagesResponse: List<SpokenLanguagesItemResponse?>? = null,
 
   @Json(name = "production_companies")
   val productionCompaniesResponse: List<ProductionCompaniesItemResponse?>? = null,

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/tv/SpokenLanguagesItemResponse.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/tv/SpokenLanguagesItemResponse.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = false)
-data class SpokenLanguagesItemReponse(
+data class SpokenLanguagesItemResponse(
 
   @Json(name = "name")
   val name: String? = null,

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/interceptors/ApiKeyInterceptor.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/interceptors/ApiKeyInterceptor.kt
@@ -1,4 +1,4 @@
-package com.waffiq.bazz_movies.core.network.data.remote.retrofit
+package com.waffiq.bazz_movies.core.network.data.remote.retrofit.interceptors
 
 import okhttp3.Interceptor
 import okhttp3.Response

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/di/NetworkConfigModule.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/di/NetworkConfigModule.kt
@@ -1,0 +1,18 @@
+package com.waffiq.bazz_movies.core.network.di
+
+import com.waffiq.bazz_movies.core.network.domain.DebugConfigImpl
+import com.waffiq.bazz_movies.core.network.domain.IDebugConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkConfigModule {
+
+  @Singleton
+  @Provides
+  fun provideDebugConfig(): IDebugConfig = DebugConfigImpl()
+}

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/di/NetworkModule.kt
@@ -2,17 +2,17 @@ package com.waffiq.bazz_movies.core.network.di
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.waffiq.bazz_movies.core.network.BuildConfig.DEBUG
 import com.waffiq.bazz_movies.core.network.BuildConfig.OMDB_API_KEY
 import com.waffiq.bazz_movies.core.network.BuildConfig.OMDb_API_URL
 import com.waffiq.bazz_movies.core.network.BuildConfig.TMDB_API_KEY
 import com.waffiq.bazz_movies.core.network.BuildConfig.TMDB_API_URL
-import com.waffiq.bazz_movies.core.network.data.remote.retrofit.ApiKeyInterceptorOMDb
-import com.waffiq.bazz_movies.core.network.data.remote.retrofit.ApiKeyInterceptorTMDB
 import com.waffiq.bazz_movies.core.network.data.remote.retrofit.adapter.RatedResponseAdapter
+import com.waffiq.bazz_movies.core.network.data.remote.retrofit.interceptors.ApiKeyInterceptorOMDb
+import com.waffiq.bazz_movies.core.network.data.remote.retrofit.interceptors.ApiKeyInterceptorTMDB
 import com.waffiq.bazz_movies.core.network.data.remote.retrofit.services.CountryIPApiService
 import com.waffiq.bazz_movies.core.network.data.remote.retrofit.services.OMDbApiService
 import com.waffiq.bazz_movies.core.network.data.remote.retrofit.services.TMDBApiService
+import com.waffiq.bazz_movies.core.network.domain.IDebugConfig
 import com.waffiq.bazz_movies.core.network.utils.common.Constants.COUNTRY_API_LINK
 import dagger.Module
 import dagger.Provides
@@ -28,15 +28,14 @@ import java.util.concurrent.TimeUnit
 @InstallIn(SingletonComponent::class)
 class NetworkModule {
 
-  private val loggingInterceptor: HttpLoggingInterceptor = HttpLoggingInterceptor()
-
-  init {
-    if (DEBUG) {
-      // Enable logging for debug builds
-      loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
-    } else {
-      // Disable logging for release builds
-      loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.NONE)
+  @Provides
+  fun provideLoggingInterceptor(debugConfig: IDebugConfig): HttpLoggingInterceptor {
+    return HttpLoggingInterceptor().apply {
+      level = if (debugConfig.isDebug()) {
+        HttpLoggingInterceptor.Level.BODY
+      } else {
+        HttpLoggingInterceptor.Level.NONE
+      }
     }
   }
 
@@ -49,7 +48,7 @@ class NetworkModule {
   }
 
   @Provides
-  fun provideOkHttpClient(): OkHttpClient {
+  fun provideOkHttpClient(loggingInterceptor: HttpLoggingInterceptor): OkHttpClient {
     return OkHttpClient.Builder()
       .connectTimeout(TIME_OUT, TimeUnit.SECONDS)
       .readTimeout(TIME_OUT, TimeUnit.SECONDS)

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/domain/DebugConfigImpl.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/domain/DebugConfigImpl.kt
@@ -1,0 +1,11 @@
+package com.waffiq.bazz_movies.core.network.domain
+
+import com.waffiq.bazz_movies.core.network.BuildConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DebugConfigImpl @Inject constructor(private val isDebug: Boolean = BuildConfig.DEBUG) : IDebugConfig {
+
+  override fun isDebug(): Boolean = isDebug
+}

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/domain/IDebugConfig.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/domain/IDebugConfig.kt
@@ -1,0 +1,5 @@
+package com.waffiq.bazz_movies.core.network.domain
+
+interface IDebugConfig {
+  fun isDebug(): Boolean
+}

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/DetailMovieTvMapper.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/DetailMovieTvMapper.kt
@@ -5,7 +5,7 @@ import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovi
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.ProductionCountriesItemResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.castcrew.MovieTvCreditsResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.ProductionCompaniesItemResponse
-import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.SpokenLanguagesItemReponse
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.SpokenLanguagesItemResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.videomedia.VideoItemResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.videomedia.VideoResponse
 import com.waffiq.bazz_movies.feature.detail.domain.model.MovieTvCredits
@@ -48,7 +48,7 @@ object DetailMovieTvMapper {
     id = id
   )
 
-  fun SpokenLanguagesItemReponse.toSpokenLanguagesItem() = SpokenLanguagesItem(
+  fun SpokenLanguagesItemResponse.toSpokenLanguagesItem() = SpokenLanguagesItem(
     name = name,
     iso6391 = iso6391,
     englishName = englishName


### PR DESCRIPTION
### Description

This pull request refactors the DebugConfig implementation to utilize Hilt for dependency injection, improving scalability, testability, and adherence to clean architecture principles.

### Changes Made

- DebugConfig Injection:
   - Replaced manual instantiation of `DebugConfig` with Hilt-based injection.
   - Created a Hilt module (`NetworkConfigModule`) to provide `IDebugConfig`.
- NetworkModule Update:
   - Updated `NetworkModule` to accept IDebugConfig as a constructor dependency.
   - Leveraged Hilt to handle the injection of `DebugConfig` into `NetworkModule`.

### Why is this needed?
- Scalability:
   - Using Hilt for dependency injection ensures better modularity and easier scalability across the application.
- Testability:
   - Injecting DebugConfig allows mocking its behavior in tests, enabling robust and isolated testing.
- Separation of Concerns:
   - Delegating dependency management to Hilt improves code maintainability and aligns with clean architecture principles.