### PR TITLE
chore: use full length commit SHA  for third-party actions

### DIFF
--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -93,7 +93,7 @@ jobs:
           cache: 'gradle'
 
       - name: Run instrumentation test
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d
         with:
           api-level: 29
           arch: x86


### PR DESCRIPTION
### Changes Made

- Use GitHub recommendation to use full length commit SHA on third-party actions [https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)