### PR TITLE
chore: exclude response class from duplicate Codacy

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,3 +1,9 @@
 exclude_paths:
   - "**/*.md"
   - "*.md"
+
+engines:
+  duplication:
+    enabled: true
+    exclude_paths:
+      - '**/*Response.kt'


### PR DESCRIPTION
### Changes Made

- Exclude any `Response.kt` class from duplicate Codacy analysis