### PR TITLE
chore: add comments on third-party actions

### DIFF
--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -92,6 +92,8 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
+      # https://github.com/ReactiveCircus/android-emulator-runner/commit/62dbb605bba737720e10b196cb4220d374026a6d
+      # v2.33.0
       - name: Run instrumentation test
         uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d
         with:
@@ -145,18 +147,24 @@ jobs:
       - name: Generate JaCoCo
         run: ./gradlew createDebugCombinedCoverageReport
 
+      # https://github.com/codecov/codecov-action/commit/0565863a31f2c772f9f0395002a31e3f06189574
+      # v5.4.0
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           files: ${{ github.workspace }}/**/build/reports/jacoco/createDebugCombinedCoverageReport/createDebugCombinedCoverageReport.xml
           token: ${{ secrets.CODECOV_TOKEN }}
-      
+
+      # https://github.com/codacy/codacy-coverage-reporter-action/commit/55c3b57cb3bb6833c8c1a6614fee4cebb140de2d
+      # v1.3.0
       - name: Upload coverage reports to Codacy
         uses: codacy/codacy-coverage-reporter-action@55c3b57cb3bb6833c8c1a6614fee4cebb140de2d
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: ${{ github.workspace }}/**/build/reports/jacoco/createDebugCombinedCoverageReport/createDebugCombinedCoverageReport.xml
 
+      # https://github.com/codecov/test-results-action/commit/f2dba722c67b86c6caa034178c6e4d35335f6706
+      # v1.1.0
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -79,7 +79,7 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: manual
 
-      # Custom build steps instead of autobuild
+      # Custom build steps instead of auto-build
       - name: Build with Gradle
         run: |
           ./gradlew clean


### PR DESCRIPTION
### Changes Made

- Add comment (including `url repo` and `version` used) on top of every third-party actions to makes version maintenance easier.