### PR TITLE
fix: resolve cross project violation

### DIFF
--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -13,8 +13,9 @@ android {
   buildFeatures.buildConfig = true
 
   defaultConfig {
+    val localPropertiesFile = File(project.rootDir, "local.properties")
     val properties = Properties().apply {
-      load(project.rootProject.file("local.properties").inputStream())
+      localPropertiesFile.inputStream().use { load(it) }
     }
 
     // API KEY


### PR DESCRIPTION
### Changes Made

- Resolve cross-project access violation on `:core:network` module. Part of #127 
  - run 
     ```terminal
     ./gradlew build --dry-run -Dorg.gradle.unsafe.isolated-projects=true
     ``` 
     Result: no error on gradle configuration cache (Project `:core:network` cannot access `Project.file` functionality on another project)
     
     Before:
     ![Screenshot (3927)](https://github.com/user-attachments/assets/805c57cc-e407-4701-999c-69e3508075de)
     
     After:   
     ![Screenshot (3928)](https://github.com/user-attachments/assets/c8c5c15c-0bd8-4197-ab34-ea9702f937bb)
