### PR TITLE
chore(deps): update lifecycle, datastore, room, and paging

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <entry_points version="2.0">
+      <entry_point TYPE="field" FQNAME="com.waffiq.bazz_movies.pages.detail.DetailMovieActivity userPreferenceViewModel$delegate" />
+    </entry_points>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ viewpager2 = "1.1.0"
 kotlinxCoroutines = "1.10.1"
 
 # Lifecycle Libraries
-lifecycle = "2.8.7"
+lifecycle = "2.9.0"
 
 # Datastore
 datastore = "1.1.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,7 @@ lifecycle = "2.9.0"
 datastore = "1.1.2"
 
 # Room Libraries
-room = "2.6.1"
+room = "2.7.1"
 
 # Paging3
 paging = "3.3.5"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ datastore = "1.1.2"
 room = "2.7.1"
 
 # Paging3
-paging = "3.3.5"
+paging = "3.3.6"
 
 # UI components
 material = "1.12.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ kotlinxCoroutines = "1.10.1"
 lifecycle = "2.9.0"
 
 # Datastore
-datastore = "1.1.2"
+datastore = "1.1.4"
 
 # Room Libraries
 room = "2.7.1"


### PR DESCRIPTION
### Changes Made

- Update lifecycle to [v2.9.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.9.0)
- Update room to [v2.7.1](https://developer.android.com/jetpack/androidx/releases/room#2.7.1)
- Update paging to [v3.3.6](https://developer.android.com/jetpack/androidx/releases/paging#3.3.6)
- Update datastore to [v1.1.4](https://developer.android.com/jetpack/androidx/releases/datastore#1.1.4)

Note:
- DataStore [v1.1.5](https://developer.android.com/jetpack/androidx/releases/datastore#1.1.5) has a known issue ([tracker](https://issuetracker.google.com/issues/413061399)) that has been fixed on [v1.1.6](https://developer.android.com/jetpack/androidx/releases/datastore#1.1.6), but still includes an unresolved R8 issue ([tracker](https://issuetracker.google.com/issues/413078297)).
- [v1.1.6](https://developer.android.com/jetpack/androidx/releases/datastore#1.1.6) also has R8-related problems.
- Tested [v1.2.0-alpha02](https://developer.android.com/jetpack/androidx/releases/datastore#1.2.0-alpha02); no issues so far, but will wait for a stable release before upgrading.