### PR TITLE
fix: resolve unlimited load on search fragment when error

### DIFF
--- a/core/designsystem/src/main/res/layout/illustration_error.xml
+++ b/core/designsystem/src/main/res/layout/illustration_error.xml
@@ -41,16 +41,15 @@
     style="@style/ButtonTryAgain"
     android:layout_gravity="center"
     android:layout_marginTop="4dp"
-    android:text="@string/try_again"
-    android:textColor="@color/gray_1000" />
+    android:text="@string/try_again" />
 
   <ProgressBar
     android:id="@+id/progress_circular"
     style="@style/MyProgressBar"
-    android:visibility="gone"
-    android:layout_marginTop="8dp"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_marginTop="8dp"
+    android:visibility="gone"
     app:indicatorColor="@color/yellow" />
 
 </LinearLayout>

--- a/feature/search/src/main/kotlin/com/waffiq/bazz_movies/feature/search/ui/SearchFragment.kt
+++ b/feature/search/src/main/kotlin/com/waffiq/bazz_movies/feature/search/ui/SearchFragment.kt
@@ -70,6 +70,8 @@ class SearchFragment : Fragment() {
   private var lastQuery: String? = null
   private var mSnackbar: Snackbar? = null
 
+  private var lastRefreshErrorMessage: String? = null
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     searchAdapter = SearchAdapter(navigator)
@@ -94,6 +96,7 @@ class SearchFragment : Fragment() {
     binding.rvSearch.layoutManager = initLinearLayoutManagerVertical(requireContext())
 
     binding.illustrationError.btnTryAgain.setOnClickListener {
+      lastRefreshErrorMessage = null
       searchAdapter.refresh()
       binding.illustrationError.btnTryAgain.isVisible = false
       binding.illustrationError.progressCircular.isVisible = true
@@ -196,8 +199,6 @@ class SearchFragment : Fragment() {
   }
 
   private fun adapterLoadStateListener() {
-    var lastRefreshErrorMessage: String? = null
-
     lifecycleScope.launch {
       searchAdapter.loadStateFlow
         .debounce(DEBOUNCE_SHORT)


### PR DESCRIPTION
### Changes Made

- Resolve endless loading on "Try Again" button in SearchFragment after error state
- Fix retry button causing infinite loading on search error screen