### PR TITLE
chore(ci/cd): disable update commit digest on github action

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -126,7 +126,10 @@
         "^codecov/codecov-action$",
         "^codecov/test-results-action$",
         "^codacy/codacy-coverage-reporter-action$"
-      ]
+      ],
+      digest: {
+        enabled: false
+      }
     },
     {
       groupName: "GitHub Actions",
@@ -140,7 +143,10 @@
       excludePackagePatterns: [
         "^codecov/",
         "^codacy/"
-      ]
+      ],
+      digest: {
+        enabled: false
+      }
     },
     {
       matchUpdateTypes: [


### PR DESCRIPTION
### Changes Made

- Added `digest: { enabled: false }` to both GitHub Actions groups to prevents Renovate from updating commit digests and forces it to only update release tags.
- Closes #154 