### PR TITLE
chore: set JaCoCo 0.8.13 via AGP api

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationJacocoConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationJacocoConventionPlugin.kt
@@ -1,6 +1,7 @@
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.waffiq.bazz_movies.configureJacoco
+import com.waffiq.bazz_movies.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
@@ -15,6 +16,10 @@ class AndroidApplicationJacocoConventionPlugin : Plugin<Project> {
       androidExtension.buildTypes.configureEach {
         enableAndroidTestCoverage = true
         enableUnitTestCoverage = true
+      }
+
+      androidExtension.testCoverage {
+        jacocoVersion = libs.findVersion("jacoco").get().toString()
       }
 
       configureJacoco(extensions.getByType<ApplicationAndroidComponentsExtension>())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,4 +13,5 @@ plugins {
   alias(libs.plugins.detekt) apply false
   alias(libs.plugins.room) apply false
   alias(libs.plugins.ksp) apply false
+  jacoco
 }


### PR DESCRIPTION
### Changes Made

- Set JaCoCo version via AGP api with:
  ```kotlin
  testCoverage {
     jacocoVersion = libs.findVersion("jacoco").get().toString()
  }
  ```
  > https://developer.android.com/reference/tools/gradle-api/8.10/com/android/build/api/dsl/TestCoverage
- Resolve issue JaCoCo on intrumentation test. #158