### PR TITLE
chore(ci/cd): use full length commit SHA for third-party GitHub Actions

### DIFF
--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -145,7 +145,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96
 
       - name: AVD cache
         uses: actions/cache@v4


### PR DESCRIPTION
### Changes Made

- Use full length commit SHA for third-party GitHub Actions