### PR TITLE
feat(detail): add support for watch providers

### DIFF
--- a/core/common/src/main/kotlin/com/waffiq/bazz_movies/core/common/utils/Constants.kt
+++ b/core/common/src/main/kotlin/com/waffiq/bazz_movies/core/common/utils/Constants.kt
@@ -41,5 +41,6 @@ object Constants {
   const val FAQ_LINK =
     "https://docs.google.com/document/d/1HNrj5i3Rnpr50Ldwgfz5ODpaJoWF17TXIop7xwtXkiU/edit?usp=sharing"
   const val TMDB_LINK_MAIN = "https://www.themoviedb.org/"
+  const val JUSTWATCH_LINK_MAIN = "https://www.justwatch.com/"
   const val BAZZ_MOVIES_LINK = "https://waffiqaziz.github.io/bazzmovies"
 }

--- a/core/common/src/main/kotlin/com/waffiq/bazz_movies/core/common/utils/Constants.kt
+++ b/core/common/src/main/kotlin/com/waffiq/bazz_movies/core/common/utils/Constants.kt
@@ -7,6 +7,7 @@ object Constants {
   const val TMDB_IMG_LINK_BACKDROP_W780 = "https://image.tmdb.org/t/p/w780/"
   const val TMDB_IMG_LINK_POSTER_W185 = "https://image.tmdb.org/t/p/w185/"
   const val TMDB_IMG_LINK_POSTER_W500 = "https://image.tmdb.org/t/p/w500/"
+  const val TMDB_IMG_LINK_ORIGINAL = "https://www.themoviedb.org/t/p/original"
   const val YOUTUBE_LINK_VIDEO = "https://www.youtube.com/watch?v="
   const val TMDB_IMG_LINK_AVATAR = "https://image.tmdb.org/t/p/w200/"
   const val GRAVATAR_LINK = "https://secure.gravatar.com/avatar/"

--- a/core/designsystem/src/main/res/values-night/themes.xml
+++ b/core/designsystem/src/main/res/values-night/themes.xml
@@ -237,6 +237,42 @@
     <item name="android:paddingBottom">8dp</item>
   </style>
 
+  <style name="RecyclerViewWatchProviders">
+    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:clipToPadding">false</item>
+    <item name="android:orientation">horizontal</item>
+    <item name="android:overScrollMode">never</item>
+    <item name="android:paddingStart">@dimen/default_margin_parent_20</item>
+  </style>
+
+  <style name="LayoutWatchProviders">
+    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_marginBottom">12dp</item>
+    <item name="android:orientation">vertical</item>
+    <item name="android:visibility">gone</item>
+  </style>
+
+  <style name="LabelWatchProviders">
+    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_marginStart">@dimen/default_margin_parent_20</item>
+    <item name="android:layout_alignEnd">@dimen/default_margin_parent_20</item>
+    <item name="android:layout_marginBottom">8dp</item>
+    <item name="android:fontFamily">@font/nunito_sans_regular</item>
+    <item name="android:textColor">@color/gray_200</item>
+    <item name="android:textAppearance">@style/TextAppearance.Material3.TitleSmall</item>
+  </style>
+
+  <style name="GroupWatchProviders">
+    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_marginTop">16dp</item>
+    <item name="android:orientation">vertical</item>
+    <item name="android:visibility">gone</item>
+  </style>
+
   <!-- Style button on more page -->
   <style name="ButtonMoreStyle">
     <item name="android:paddingStart">@dimen/default_margin_parent_20</item>

--- a/core/designsystem/src/main/res/values-night/themes.xml
+++ b/core/designsystem/src/main/res/values-night/themes.xml
@@ -211,15 +211,30 @@
     <item name="android:textAppearance">@style/TextAppearance.Material3.BodyLarge</item>
     <item name="android:textColor">@color/gray_100</item>
     <item name="fontFamily">@font/nunito_sans_regular</item>
+    <item name="android:layout_gravity">center</item>
+    <item name="android:text">@string/not_available</item>
   </style>
 
   <style name="TextScoreHeader">
+    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_marginTop">4dp</item>
     <item name="android:textAppearance">@style/TextAppearance.Material3.BodySmall</item>
     <item name="android:textColor">@color/gray_400</item>
     <item name="fontFamily">@font/nunito_sans_regular</item>
+    <item name="android:layout_gravity">center</item>
     <item name="android:gravity">center</item>
+  </style>
+
+  <style name="GroupScore">
     <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_marginEnd">16dp</item>
+    <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
+    <item name="android:minWidth">48dp</item>
+    <item name="android:minHeight">48dp</item>
+    <item name="android:orientation">vertical</item>
+    <item name="android:paddingBottom">8dp</item>
   </style>
 
   <!-- Style button on more page -->

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -100,6 +100,8 @@
   <string name="invalid_url">Invalid URL</string>
   <string name="backdrop_not_found">*Official backdrop has not been released yet</string>
   <string name="_divider">|</string>
+  <string name="data_powered_by">*Data powered by</string>
+  <string name="justwatch">JustWatch</string>
   <string name="overview">Overview</string>
   <string name="no_overview">Theres no overview translated in English</string>
   <string name="watch_trailer">Watch Trailer</string>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -101,6 +101,12 @@
   <string name="backdrop_not_found">*Official backdrop has not been released yet</string>
   <string name="_divider">|</string>
   <string name="data_powered_by">*Data powered by</string>
+  <string name="where_to_watch_down">Where to watch  ▾</string>
+  <string name="where_to_watch_up">Where to watch  ▴</string>
+  <string name="buy">Buy</string>
+  <string name="rent">Rent</string>
+  <string name="free">Free</string>
+  <string name="streaming">Streaming</string>
   <string name="justwatch">JustWatch</string>
   <string name="overview">Overview</string>
   <string name="no_overview">Theres no overview translated in English</string>

--- a/core/designsystem/src/main/res/values/themes.xml
+++ b/core/designsystem/src/main/res/values/themes.xml
@@ -237,6 +237,41 @@
     <item name="android:paddingBottom">8dp</item>
   </style>
 
+  <style name="RecyclerViewWatchProviders">
+    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:clipToPadding">false</item>
+    <item name="android:orientation">horizontal</item>
+    <item name="android:overScrollMode">never</item>
+    <item name="android:paddingStart">@dimen/default_margin_parent_20</item>
+  </style>
+
+  <style name="LayoutWatchProviders">
+    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_marginBottom">12dp</item>
+    <item name="android:orientation">vertical</item>
+    <item name="android:visibility">gone</item>
+  </style>
+
+  <style name="LabelWatchProviders">
+    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_marginStart">@dimen/default_margin_parent_20</item>
+    <item name="android:layout_alignEnd">@dimen/default_margin_parent_20</item>
+    <item name="android:layout_marginBottom">8dp</item>
+    <item name="android:fontFamily">@font/nunito_sans_regular</item>
+    <item name="android:textColor">@color/gray_200</item>
+    <item name="android:textAppearance">@style/TextAppearance.Material3.TitleSmall</item>
+  </style>
+
+  <style name="GroupWatchProviders">
+    <item name="android:layout_width">match_parent</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:orientation">vertical</item>
+    <item name="android:visibility">gone</item>
+  </style>
+
   <!-- Style button on more page -->
   <style name="ButtonMoreStyle">
     <item name="android:paddingStart">20dp</item>

--- a/core/designsystem/src/main/res/values/themes.xml
+++ b/core/designsystem/src/main/res/values/themes.xml
@@ -211,15 +211,30 @@
     <item name="android:textAppearance">@style/TextAppearance.Material3.BodyLarge</item>
     <item name="android:textColor">@color/gray_100</item>
     <item name="fontFamily">@font/nunito_sans_regular</item>
+    <item name="android:layout_gravity">center</item>
+    <item name="android:text">@string/not_available</item>
   </style>
 
   <style name="TextScoreHeader">
+    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_marginTop">4dp</item>
     <item name="android:textAppearance">@style/TextAppearance.Material3.BodySmall</item>
     <item name="android:textColor">@color/gray_400</item>
     <item name="fontFamily">@font/nunito_sans_regular</item>
+    <item name="android:layout_gravity">center</item>
     <item name="android:gravity">center</item>
+  </style>
+
+  <style name="GroupScore">
     <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_marginEnd">16dp</item>
+    <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
+    <item name="android:minWidth">48dp</item>
+    <item name="android:minHeight">48dp</item>
+    <item name="android:orientation">vertical</item>
+    <item name="android:paddingBottom">8dp</item>
   </style>
 
   <!-- Style button on more page -->

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/MovieDataSource.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/MovieDataSource.kt
@@ -16,6 +16,7 @@ import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovi
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.DetailTvResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.ExternalIdResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.videomedia.VideoResponse
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.watchproviders.WatchProvidersResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.CombinedCreditResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.DetailPersonResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ExternalIDPersonResponse
@@ -39,7 +40,7 @@ import javax.inject.Singleton
 class MovieDataSource @Inject constructor(
   private val tmdbApiService: TMDBApiService,
   private val omDbApiService: OMDbApiService,
-  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : MovieDataSourceInterface {
 
   // region PAGING FUNCTION
@@ -133,7 +134,7 @@ class MovieDataSource @Inject constructor(
 
   override fun getPagingPopularTv(
     region: String,
-    twoWeeksFromToday: String
+    twoWeeksFromToday: String,
   ): Flow<PagingData<ResultItemResponse>> {
     return Pager(
       config = PagingConfig(pageSize = PAGE_SIZE),
@@ -148,7 +149,7 @@ class MovieDataSource @Inject constructor(
   override fun getPagingAiringThisWeekTv(
     region: String,
     airDateLte: String,
-    airDateGte: String
+    airDateGte: String,
   ): Flow<PagingData<ResultItemResponse>> {
     return Pager(
       config = PagingConfig(pageSize = PAGE_SIZE),
@@ -315,7 +316,7 @@ class MovieDataSource @Inject constructor(
 
   override suspend fun getStatedMovie(
     sessionId: String,
-    id: Int
+    id: Int,
   ): Flow<NetworkResult<StatedResponse>> = flow {
     emit(NetworkResult.Loading)
     emit(
@@ -327,12 +328,24 @@ class MovieDataSource @Inject constructor(
 
   override suspend fun getStatedTv(
     sessionId: String,
-    id: Int
+    id: Int,
   ): Flow<NetworkResult<StatedResponse>> = flow {
     emit(NetworkResult.Loading)
     emit(
       safeApiCall {
         tmdbApiService.getStatedTv(id, sessionId)
+      }
+    )
+  }.flowOn(ioDispatcher)
+
+  override suspend fun getWatchProviders(
+    params: String,
+    id: Int,
+  ): Flow<NetworkResult<WatchProvidersResponse>> = flow {
+    emit(NetworkResult.Loading)
+    emit(
+      safeApiCall {
+        tmdbApiService.getWatchProviders(params, id)
       }
     )
   }.flowOn(ioDispatcher)
@@ -380,7 +393,7 @@ class MovieDataSource @Inject constructor(
   override suspend fun postFavorite(
     sessionId: String,
     fav: FavoritePostModel,
-    userId: Int
+    userId: Int,
   ): Flow<NetworkResult<PostFavoriteWatchlistResponse>> =
     flow {
       emit(NetworkResult.Loading)
@@ -394,7 +407,7 @@ class MovieDataSource @Inject constructor(
   override suspend fun postWatchlist(
     sessionId: String,
     wtc: WatchlistPostModel,
-    userId: Int
+    userId: Int,
   ): Flow<NetworkResult<PostFavoriteWatchlistResponse>> =
     flow {
       emit(NetworkResult.Loading)
@@ -408,7 +421,7 @@ class MovieDataSource @Inject constructor(
   override suspend fun postTvRate(
     sessionId: String,
     rating: Float,
-    tvId: Int
+    tvId: Int,
   ): Flow<NetworkResult<PostResponse>> =
     flow {
       emit(NetworkResult.Loading)
@@ -422,7 +435,7 @@ class MovieDataSource @Inject constructor(
   override suspend fun postMovieRate(
     sessionId: String,
     rating: Float,
-    movieId: Int
+    movieId: Int,
   ): Flow<NetworkResult<PostResponse>> =
     flow {
       emit(NetworkResult.Loading)

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/MovieDataSourceInterface.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/MovieDataSourceInterface.kt
@@ -10,6 +10,7 @@ import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovi
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.DetailTvResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.ExternalIdResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.videomedia.VideoResponse
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.watchproviders.WatchProvidersResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.CombinedCreditResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.DetailPersonResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ExternalIDPersonResponse
@@ -33,7 +34,7 @@ interface MovieDataSourceInterface {
   fun getPagingWatchlistMovies(sessionId: String): Flow<PagingData<ResultItemResponse>>
   fun getPagingPopularTv(
     region: String,
-    twoWeeksFromToday: String
+    twoWeeksFromToday: String,
   ): Flow<PagingData<ResultItemResponse>>
 
   fun getPagingAiringThisWeekTv(
@@ -66,6 +67,10 @@ interface MovieDataSourceInterface {
   suspend fun getExternalTvId(id: Int): Flow<NetworkResult<ExternalIdResponse>>
   suspend fun getStatedMovie(sessionId: String, id: Int): Flow<NetworkResult<StatedResponse>>
   suspend fun getStatedTv(sessionId: String, id: Int): Flow<NetworkResult<StatedResponse>>
+  suspend fun getWatchProviders(
+    params: String,
+    id: Int,
+  ): Flow<NetworkResult<WatchProvidersResponse>>
 
   // PERSON
   suspend fun getDetailPerson(id: Int): Flow<NetworkResult<DetailPersonResponse>>
@@ -77,24 +82,24 @@ interface MovieDataSourceInterface {
   suspend fun postFavorite(
     sessionId: String,
     fav: FavoritePostModel,
-    userId: Int
+    userId: Int,
   ): Flow<NetworkResult<PostFavoriteWatchlistResponse>>
 
   suspend fun postWatchlist(
     sessionId: String,
     wtc: WatchlistPostModel,
-    userId: Int
+    userId: Int,
   ): Flow<NetworkResult<PostFavoriteWatchlistResponse>>
 
   suspend fun postTvRate(
     sessionId: String,
     rating: Float,
-    tvId: Int
+    tvId: Int,
   ): Flow<NetworkResult<PostResponse>>
 
   suspend fun postMovieRate(
     sessionId: String,
     rating: Float,
-    movieId: Int
+    movieId: Int,
   ): Flow<NetworkResult<PostResponse>>
 }

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/watchproviders/CountryProviderDataResponse.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/watchproviders/CountryProviderDataResponse.kt
@@ -1,0 +1,23 @@
+package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.watchproviders
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
+data class CountryProviderDataResponse(
+
+  @Json(name = "link")
+  val link: String?,
+
+  @Json(name = "flatrate")
+  val flatrate: List<ProviderResponse>?,
+
+  @Json(name = "rent")
+  val rent: List<ProviderResponse>?,
+
+  @Json(name = "buy")
+  val buy: List<ProviderResponse>?,
+
+  @Json(name = "free")
+  val free: List<ProviderResponse>?,
+)

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/watchproviders/ProviderResponse.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/watchproviders/ProviderResponse.kt
@@ -1,0 +1,19 @@
+package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.watchproviders
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
+data class ProviderResponse(
+  @Json(name = "logo_path")
+  val logoPath: String?,
+
+  @Json(name = "provider_id")
+  val providerId: Int?,
+
+  @Json(name = "provider_name")
+  val providerName: String?,
+
+  @Json(name = "display_priority")
+  val displayPriority: Int?
+)

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/watchproviders/WatchProvidersResponse.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/watchproviders/WatchProvidersResponse.kt
@@ -1,0 +1,14 @@
+package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.watchproviders
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
+data class WatchProvidersResponse(
+
+  @Json(name = "id")
+  val id: Int?,
+
+  @Json(name = "results")
+  val results: Map<String, CountryProviderDataResponse>?,
+)

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/TMDBApiService.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/TMDBApiService.kt
@@ -12,6 +12,7 @@ import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovi
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.DetailTvResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.tv.ExternalIdResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.videomedia.VideoResponse
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.watchproviders.WatchProvidersResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.CombinedCreditResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.DetailPersonResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ExternalIDPersonResponse
@@ -57,37 +58,37 @@ interface TMDBApiService {
   @GET("3/trending/all/week")
   suspend fun getTrendingWeek(
     @Query("region") region: String,
-    @Query("page") page: Int
+    @Query("page") page: Int,
   ): MovieTvResponse
 
   @GET("3/trending/all/day")
   suspend fun getTrendingDay(
     @Query("region") region: String,
-    @Query("page") page: Int
+    @Query("page") page: Int,
   ): MovieTvResponse
   // endregion TRENDING
 
   // region MOVIE
   @GET("3/movie/popular?language=en-US")
   suspend fun getPopularMovies(
-    @Query("page") page: Int
+    @Query("page") page: Int,
   ): MovieTvResponse
 
   @GET("3/movie/upcoming?language=en-US&with_release_type=2|3")
   suspend fun getUpcomingMovies(
     @Query("region") region: String,
-    @Query("page") page: Int
+    @Query("page") page: Int,
   ): MovieTvResponse
 
   @GET("3/movie/now_playing?language=en-US")
   suspend fun getPlayingNowMovies(
     @Query("region") region: String,
-    @Query("page") page: Int
+    @Query("page") page: Int,
   ): MovieTvResponse
 
   @GET("3/movie/top_rated?language=en-US")
   suspend fun getTopRatedMovies(
-    @Query("page") page: Int
+    @Query("page") page: Int,
   ): MovieTvResponse
   // endregion
 
@@ -102,7 +103,7 @@ interface TMDBApiService {
   suspend fun getPopularTv(
     @Query("page") page: Int,
     @Query("watch_region") region: String,
-    @Query("air_date.lte") dateTime: String
+    @Query("air_date.lte") dateTime: String,
   ): MovieTvResponse
 
   @GET(
@@ -116,12 +117,12 @@ interface TMDBApiService {
     @Query("watch_region") region: String,
     @Query("air_date.lte") airDateLte: String,
     @Query("air_date.gte") airDateGte: String,
-    @Query("page") page: Int
+    @Query("page") page: Int,
   ): MovieTvResponse
 
   @GET("3/tv/top_rated?language=en-US")
   suspend fun getTopRatedTv(
-    @Query("page") page: Int
+    @Query("page") page: Int,
   ): MovieTvResponse
   // endregion TV
 
@@ -129,13 +130,13 @@ interface TMDBApiService {
   @GET("3/movie/{movieId}/recommendations")
   suspend fun getRecommendedMovie(
     @Path("movieId") movieId: Int,
-    @Query("page") page: Int
+    @Query("page") page: Int,
   ): MovieTvResponse
 
   @GET("3/tv/{tvId}/recommendations")
   suspend fun getRecommendedTv(
     @Path("tvId") movieId: Int,
-    @Query("page") page: Int
+    @Query("page") page: Int,
   ): MovieTvResponse
   // endregion RECOMMENDATION
 
@@ -169,70 +170,76 @@ interface TMDBApiService {
   @GET("3/movie/{movieId}/account_states")
   suspend fun getStatedMovie(
     @Path("movieId") movieId: Int,
-    @Query("session_id") sessionId: String
+    @Query("session_id") sessionId: String,
   ): Response<StatedResponse>
 
   @GET("3/tv/{tvId}/account_states")
   suspend fun getStatedTv(
     @Path("tvId") tvId: Int,
-    @Query("session_id") sessionId: String
+    @Query("session_id") sessionId: String,
   ): Response<StatedResponse>
 
   @GET("3/movie/{movieId}/credits?language=en-US")
   suspend fun getCreditMovies(
-    @Path("movieId") movieId: Int
+    @Path("movieId") movieId: Int,
   ): Response<MovieTvCreditsResponse>
 
   @GET("3/tv/{tvId}/credits?language=en-US")
   suspend fun getCreditTv(
-    @Path("tvId") tvId: Int
+    @Path("tvId") tvId: Int,
   ): Response<MovieTvCreditsResponse>
 
   @GET("3/movie/{movieId}?language=en-US&append_to_response=releasedates")
   suspend fun getDetailMovie(
-    @Path("movieId") movieId: Int
+    @Path("movieId") movieId: Int,
   ): Response<DetailMovieResponse>
 
   @GET("3/tv/{tvId}?language=en-US&append_to_response=content_ratings")
   suspend fun getDetailTv(
-    @Path("tvId") tvId: Int
+    @Path("tvId") tvId: Int,
   ): Response<DetailTvResponse>
 
   @GET("3/movie/{id}/videos?language=en-US")
   suspend fun getVideoMovies(
-    @Path("id") id: Int
+    @Path("id") id: Int,
   ): Response<VideoResponse>
 
   @GET("3/tv/{id}/videos?language=en-US")
   suspend fun getVideoTv(
-    @Path("id") id: Int
+    @Path("id") id: Int,
   ): Response<VideoResponse>
 
   @GET("3/tv/{tvId}/external_ids?language=en-US")
   suspend fun getExternalId(
-    @Path("tvId") tvId: Int
+    @Path("tvId") tvId: Int,
   ): Response<ExternalIdResponse>
+
+  @GET("3/{params}/{id}/watch/providers")
+  suspend fun getWatchProviders(
+    @Path("params") params: String,
+    @Path("id") id: Int,
+  ): Response<WatchProvidersResponse>
   // endregion
 
   // region PERSON
   @GET("3/person/{personId}?language=en-US")
   suspend fun getDetailPerson(
-    @Path("personId") personId: Int
+    @Path("personId") personId: Int,
   ): Response<DetailPersonResponse>
 
   @GET("3/person/{personId}/images?language=en-US")
   suspend fun getImagePerson(
-    @Path("personId") personId: Int
+    @Path("personId") personId: Int,
   ): Response<ImagePersonResponse>
 
   @GET("3/person/{personId}/external_ids")
   suspend fun getExternalIdPerson(
-    @Path("personId") personId: Int
+    @Path("personId") personId: Int,
   ): Response<ExternalIDPersonResponse>
 
   @GET("3/person/{personId}/combined_credits?language=en-US")
   suspend fun getKnownForPersonCombinedMovieTv(
-    @Path("personId") personId: Int
+    @Path("personId") personId: Int,
   ): Response<CombinedCreditResponse>
   // endregion
 
@@ -242,7 +249,7 @@ interface TMDBApiService {
   suspend fun postFavoriteTMDB(
     @Path("accountId") accountId: Int,
     @Query("session_id") sessionId: String,
-    @Body data: FavoritePostModel
+    @Body data: FavoritePostModel,
   ): Response<PostFavoriteWatchlistResponse>
 
   @Headers("Content-Type: application/json;charset=utf-8")
@@ -250,7 +257,7 @@ interface TMDBApiService {
   suspend fun postWatchlistTMDB(
     @Path("accountId") accountId: Int,
     @Query("session_id") sessionId: String,
-    @Body data: WatchlistPostModel
+    @Body data: WatchlistPostModel,
   ): Response<PostFavoriteWatchlistResponse>
 
   @Headers("Content-Type: application/json;charset=utf-8")
@@ -258,7 +265,7 @@ interface TMDBApiService {
   suspend fun postMovieRate(
     @Path("movieId") movieId: Int,
     @Query("session_id") sessionId: String,
-    @Body data: RatePostModel
+    @Body data: RatePostModel,
   ): Response<PostResponse>
 
   @Headers("Content-Type: application/json;charset=utf-8")
@@ -266,13 +273,13 @@ interface TMDBApiService {
   suspend fun postTvRate(
     @Path("tvId") tvId: Int,
     @Query("session_id") sessionId: String,
-    @Body data: RatePostModel
+    @Body data: RatePostModel,
   ): Response<PostResponse>
 
   @Headers("Content-Type: application/json;charset=utf-8")
   @DELETE("3/authentication/session")
   suspend fun delSession(
-    @Query("session_id") sessionId: String
+    @Query("session_id") sessionId: String,
   ): Response<PostResponse>
   // endregion
 

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/data/repository/DetailRepositoryImpl.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/data/repository/DetailRepositoryImpl.kt
@@ -13,6 +13,7 @@ import com.waffiq.bazz_movies.feature.detail.domain.model.movie.DetailMovie
 import com.waffiq.bazz_movies.feature.detail.domain.model.omdb.OMDbDetails
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.DetailTv
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.ExternalTvID
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
 import com.waffiq.bazz_movies.feature.detail.domain.repository.IDetailRepository
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.DetailMovieTvMapper.toMovieTvCredits
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.DetailMovieTvMapper.toVideo
@@ -20,12 +21,13 @@ import com.waffiq.bazz_movies.feature.detail.utils.mappers.MovieMapper.toDetailM
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.OMDbMapper.toOMDbDetails
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toDetailTv
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toExternalTvID
+import com.waffiq.bazz_movies.feature.detail.utils.mappers.WatchProvidersMapper.toWatchProviders
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class DetailRepositoryImpl @Inject constructor(
-  private val movieDataSource: MovieDataSource
+  private val movieDataSource: MovieDataSource,
 ) : IDetailRepository {
   override suspend fun getDetailOMDb(imdbId: String): Flow<Outcome<OMDbDetails>> =
     movieDataSource.getDetailOMDb(imdbId).map { networkResult ->
@@ -100,16 +102,28 @@ class DetailRepositoryImpl @Inject constructor(
     }
 
   override fun getPagingMovieRecommendation(
-    movieId: Int
+    movieId: Int,
   ): Flow<PagingData<ResultItem>> =
     movieDataSource.getPagingMovieRecommendation(movieId).map { pagingData ->
       pagingData.map { it.toResultItem() }
     }
 
   override fun getPagingTvRecommendation(
-    tvId: Int
+    tvId: Int,
   ): Flow<PagingData<ResultItem>> =
     movieDataSource.getPagingTvRecommendation(tvId).map { pagingData ->
       pagingData.map { it.toResultItem() }
+    }
+
+  override suspend fun getWatchProviders(
+    params: String,
+    id: Int,
+  ): Flow<Outcome<WatchProviders>> =
+    movieDataSource.getWatchProviders(params, id).map { networkResult ->
+      when (networkResult) {
+        is NetworkResult.Success -> Outcome.Success(networkResult.data.toWatchProviders())
+        is NetworkResult.Error -> Outcome.Error(networkResult.message)
+        is NetworkResult.Loading -> Outcome.Loading
+      }
     }
 }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/model/watchproviders/CountryProviderData.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/model/watchproviders/CountryProviderData.kt
@@ -1,0 +1,9 @@
+package com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders
+
+data class CountryProviderData(
+  val link: String?,
+  val flatrate: List<Provider>?,
+  val rent: List<Provider>?,
+  val buy: List<Provider>?,
+  val free: List<Provider>?
+)

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/model/watchproviders/Provider.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/model/watchproviders/Provider.kt
@@ -1,0 +1,8 @@
+package com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders
+
+data class Provider(
+  val logoPath: String?,
+  val providerId: Int?,
+  val providerName: String?,
+  val displayPriority: Int?
+)

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/model/watchproviders/WatchProviders.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/model/watchproviders/WatchProviders.kt
@@ -1,0 +1,6 @@
+package com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders
+
+data class WatchProviders(
+  val id: Int?,
+  val results: Map<String, CountryProviderData>?,
+)

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/repository/IDetailRepository.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/repository/IDetailRepository.kt
@@ -9,6 +9,7 @@ import com.waffiq.bazz_movies.feature.detail.domain.model.movie.DetailMovie
 import com.waffiq.bazz_movies.feature.detail.domain.model.omdb.OMDbDetails
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.DetailTv
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.ExternalTvID
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
 import kotlinx.coroutines.flow.Flow
 
 interface IDetailRepository {
@@ -22,4 +23,5 @@ interface IDetailRepository {
   suspend fun getCreditTv(tvId: Int): Flow<Outcome<MovieTvCredits>>
   fun getPagingMovieRecommendation(movieId: Int): Flow<PagingData<ResultItem>>
   fun getPagingTvRecommendation(tvId: Int): Flow<PagingData<ResultItem>>
+  suspend fun getWatchProviders(params: String, id: Int): Flow<Outcome<WatchProviders>>
 }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailMovie/GetDetailMovieInteractor.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailMovie/GetDetailMovieInteractor.kt
@@ -7,6 +7,7 @@ import com.waffiq.bazz_movies.core.utils.GenreHelper.transformListGenreToJoinStr
 import com.waffiq.bazz_movies.core.utils.GenreHelper.transformToGenreIDs
 import com.waffiq.bazz_movies.feature.detail.domain.model.DetailMovieTvUsed
 import com.waffiq.bazz_movies.feature.detail.domain.model.MovieTvCredits
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
 import com.waffiq.bazz_movies.feature.detail.domain.repository.IDetailRepository
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.AgeRatingHelper.getAgeRating
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.DetailMovieTvHelper.getTransformDuration
@@ -18,12 +19,12 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class GetDetailMovieInteractor @Inject constructor(
-  private val detailRepository: IDetailRepository
+  private val detailRepository: IDetailRepository,
 ) : GetDetailMovieUseCase {
 
   override suspend fun getDetailMovie(
     movieId: Int,
-    userRegion: String
+    userRegion: String,
   ): Flow<Outcome<DetailMovieTvUsed>> =
     detailRepository.getDetailMovie(movieId).map { outcome ->
       when (outcome) {
@@ -60,6 +61,9 @@ class GetDetailMovieInteractor @Inject constructor(
 
   override suspend fun getCreditMovies(movieId: Int): Flow<Outcome<MovieTvCredits>> =
     detailRepository.getCreditMovies(movieId)
+
+  override suspend fun getWatchProvidersMovies(movieId: Int): Flow<Outcome<WatchProviders>> =
+    detailRepository.getWatchProviders("movie", movieId)
 
   override fun getPagingMovieRecommendation(movieId: Int): Flow<PagingData<ResultItem>> =
     detailRepository.getPagingMovieRecommendation(movieId)

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailMovie/GetDetailMovieInteractor.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailMovie/GetDetailMovieInteractor.kt
@@ -7,7 +7,7 @@ import com.waffiq.bazz_movies.core.utils.GenreHelper.transformListGenreToJoinStr
 import com.waffiq.bazz_movies.core.utils.GenreHelper.transformToGenreIDs
 import com.waffiq.bazz_movies.feature.detail.domain.model.DetailMovieTvUsed
 import com.waffiq.bazz_movies.feature.detail.domain.model.MovieTvCredits
-import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.CountryProviderData
 import com.waffiq.bazz_movies.feature.detail.domain.repository.IDetailRepository
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.AgeRatingHelper.getAgeRating
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.DetailMovieTvHelper.getTransformDuration
@@ -62,8 +62,25 @@ class GetDetailMovieInteractor @Inject constructor(
   override suspend fun getCreditMovies(movieId: Int): Flow<Outcome<MovieTvCredits>> =
     detailRepository.getCreditMovies(movieId)
 
-  override suspend fun getWatchProvidersMovies(movieId: Int): Flow<Outcome<WatchProviders>> =
-    detailRepository.getWatchProviders("movie", movieId)
+  override suspend fun getWatchProvidersMovies(
+    countryCode: String,
+    movieId: Int,
+  ): Flow<Outcome<CountryProviderData>> =
+    detailRepository.getWatchProviders("movie", movieId).map { outcome ->
+      when (outcome) {
+        is Outcome.Success -> {
+          val countryProvider = outcome.data.results?.get(countryCode)
+          if (countryProvider != null) {
+            Outcome.Success(countryProvider)
+          } else {
+            Outcome.Error("No watch provider found for country code: $countryCode")
+          }
+        }
+
+        is Outcome.Error -> Outcome.Error(outcome.message)
+        is Outcome.Loading -> Outcome.Loading
+      }
+    }
 
   override fun getPagingMovieRecommendation(movieId: Int): Flow<PagingData<ResultItem>> =
     detailRepository.getPagingMovieRecommendation(movieId)

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailMovie/GetDetailMovieUseCase.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailMovie/GetDetailMovieUseCase.kt
@@ -5,7 +5,7 @@ import com.waffiq.bazz_movies.core.domain.Outcome
 import com.waffiq.bazz_movies.core.domain.ResultItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.DetailMovieTvUsed
 import com.waffiq.bazz_movies.feature.detail.domain.model.MovieTvCredits
-import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.CountryProviderData
 import kotlinx.coroutines.flow.Flow
 
 interface GetDetailMovieUseCase {
@@ -16,6 +16,10 @@ interface GetDetailMovieUseCase {
 
   suspend fun getLinkVideoMovies(movieId: Int): Flow<Outcome<String>>
   suspend fun getCreditMovies(movieId: Int): Flow<Outcome<MovieTvCredits>>
-  suspend fun getWatchProvidersMovies(movieId: Int): Flow<Outcome<WatchProviders>>
+  suspend fun getWatchProvidersMovies(
+    countryCode: String,
+    movieId: Int,
+  ): Flow<Outcome<CountryProviderData>>
+
   fun getPagingMovieRecommendation(movieId: Int): Flow<PagingData<ResultItem>>
 }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailMovie/GetDetailMovieUseCase.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailMovie/GetDetailMovieUseCase.kt
@@ -5,15 +5,17 @@ import com.waffiq.bazz_movies.core.domain.Outcome
 import com.waffiq.bazz_movies.core.domain.ResultItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.DetailMovieTvUsed
 import com.waffiq.bazz_movies.feature.detail.domain.model.MovieTvCredits
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
 import kotlinx.coroutines.flow.Flow
 
 interface GetDetailMovieUseCase {
   suspend fun getDetailMovie(
     movieId: Int,
-    userRegion: String
+    userRegion: String,
   ): Flow<Outcome<DetailMovieTvUsed>>
 
   suspend fun getLinkVideoMovies(movieId: Int): Flow<Outcome<String>>
   suspend fun getCreditMovies(movieId: Int): Flow<Outcome<MovieTvCredits>>
+  suspend fun getWatchProvidersMovies(movieId: Int): Flow<Outcome<WatchProviders>>
   fun getPagingMovieRecommendation(movieId: Int): Flow<PagingData<ResultItem>>
 }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailTv/GetDetailTvInteractor.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailTv/GetDetailTvInteractor.kt
@@ -8,6 +8,7 @@ import com.waffiq.bazz_movies.core.utils.GenreHelper.transformToGenreIDs
 import com.waffiq.bazz_movies.feature.detail.domain.model.DetailMovieTvUsed
 import com.waffiq.bazz_movies.feature.detail.domain.model.MovieTvCredits
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.ExternalTvID
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
 import com.waffiq.bazz_movies.feature.detail.domain.repository.IDetailRepository
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.AgeRatingHelper.getAgeRating
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.DetailMovieTvHelper.getTransformTMDBScore
@@ -18,13 +19,13 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class GetDetailTvInteractor @Inject constructor(
-  private val detailRepository: IDetailRepository
+  private val detailRepository: IDetailRepository,
 ) : GetDetailTvUseCase {
 
   /** notes: for tv, imdb will null and get later using [getExternalTvId] **/
   override suspend fun getDetailTv(
     tvId: Int,
-    userRegion: String
+    userRegion: String,
   ): Flow<Outcome<DetailMovieTvUsed>> =
     detailRepository.getDetailTv(tvId).map { outcome ->
       when (outcome) {
@@ -62,6 +63,9 @@ class GetDetailTvInteractor @Inject constructor(
 
   override suspend fun getCreditTv(tvId: Int): Flow<Outcome<MovieTvCredits>> =
     detailRepository.getCreditTv(tvId)
+
+  override suspend fun getWatchProvidersTv(tvId: Int): Flow<Outcome<WatchProviders>> =
+    detailRepository.getWatchProviders("tv", tvId)
 
   override fun getPagingTvRecommendation(tvId: Int): Flow<PagingData<ResultItem>> =
     detailRepository.getPagingTvRecommendation(tvId)

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailTv/GetDetailTvUseCase.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailTv/GetDetailTvUseCase.kt
@@ -6,6 +6,7 @@ import com.waffiq.bazz_movies.core.domain.ResultItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.DetailMovieTvUsed
 import com.waffiq.bazz_movies.feature.detail.domain.model.MovieTvCredits
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.ExternalTvID
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
 import kotlinx.coroutines.flow.Flow
 
 interface GetDetailTvUseCase {
@@ -13,5 +14,6 @@ interface GetDetailTvUseCase {
   suspend fun getExternalTvId(tvId: Int): Flow<Outcome<ExternalTvID>>
   suspend fun getTrailerLinkTv(tvId: Int): Flow<Outcome<String>>
   suspend fun getCreditTv(tvId: Int): Flow<Outcome<MovieTvCredits>>
+  suspend fun getWatchProvidersTv(tvId: Int): Flow<Outcome<WatchProviders>>
   fun getPagingTvRecommendation(tvId: Int): Flow<PagingData<ResultItem>>
 }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailTv/GetDetailTvUseCase.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getDetailTv/GetDetailTvUseCase.kt
@@ -6,7 +6,7 @@ import com.waffiq.bazz_movies.core.domain.ResultItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.DetailMovieTvUsed
 import com.waffiq.bazz_movies.feature.detail.domain.model.MovieTvCredits
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.ExternalTvID
-import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.CountryProviderData
 import kotlinx.coroutines.flow.Flow
 
 interface GetDetailTvUseCase {
@@ -14,6 +14,10 @@ interface GetDetailTvUseCase {
   suspend fun getExternalTvId(tvId: Int): Flow<Outcome<ExternalTvID>>
   suspend fun getTrailerLinkTv(tvId: Int): Flow<Outcome<String>>
   suspend fun getCreditTv(tvId: Int): Flow<Outcome<MovieTvCredits>>
-  suspend fun getWatchProvidersTv(tvId: Int): Flow<Outcome<WatchProviders>>
+  suspend fun getWatchProvidersTv(
+    countryCode: String,
+    tvId: Int,
+  ): Flow<Outcome<CountryProviderData>>
+
   fun getPagingTvRecommendation(tvId: Int): Flow<PagingData<ResultItem>>
 }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/DetailMovieActivity.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/DetailMovieActivity.kt
@@ -26,17 +26,21 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.paging.LoadState
 import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.transition.AutoTransition
+import androidx.transition.TransitionManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.waffiq.bazz_movies.core.common.utils.Constants.DEBOUNCE_LONG
 import com.waffiq.bazz_movies.core.common.utils.Constants.DEBOUNCE_SHORT
+import com.waffiq.bazz_movies.core.common.utils.Constants.JUSTWATCH_LINK_MAIN
 import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.common.utils.Constants.NAN
 import com.waffiq.bazz_movies.core.common.utils.Constants.NOT_AVAILABLE
 import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_BACKDROP_W780
 import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_POSTER_W500
+import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_LINK_MAIN
 import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.common.utils.Constants.YOUTUBE_LINK_VIDEO
 import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_backdrop_error_filled
@@ -58,6 +62,8 @@ import com.waffiq.bazz_movies.core.designsystem.R.string.rating_added_successful
 import com.waffiq.bazz_movies.core.designsystem.R.string.security_error
 import com.waffiq.bazz_movies.core.designsystem.R.string.status_
 import com.waffiq.bazz_movies.core.designsystem.R.string.unknown_error
+import com.waffiq.bazz_movies.core.designsystem.R.string.where_to_watch_down
+import com.waffiq.bazz_movies.core.designsystem.R.string.where_to_watch_up
 import com.waffiq.bazz_movies.core.designsystem.R.string.yt_not_installed
 import com.waffiq.bazz_movies.core.designsystem.R.style.CustomAlertDialogTheme
 import com.waffiq.bazz_movies.core.domain.FavoriteModel
@@ -84,6 +90,7 @@ import com.waffiq.bazz_movies.feature.detail.domain.model.omdb.OMDbDetails
 import com.waffiq.bazz_movies.feature.detail.ui.adapter.CastAdapter
 import com.waffiq.bazz_movies.feature.detail.ui.adapter.RecommendationAdapter
 import com.waffiq.bazz_movies.feature.detail.ui.adapter.WatchProvidersAdapter
+import com.waffiq.bazz_movies.feature.detail.ui.state.WatchProvidersUiState
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.CreateTableViewHelper.createTable
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.DetailMovieTvHelper.detailCrew
 import com.waffiq.bazz_movies.feature.detail.utils.uihelpers.ButtonImageChanger.changeBtnFavoriteBG
@@ -96,7 +103,7 @@ import kotlinx.coroutines.launch
 import java.util.Locale
 import javax.inject.Inject
 
-@Suppress("ForbiddenComment", "TooManyFunctions")
+@Suppress("ForbiddenComment", "TooManyFunctions", "LargeClass")
 @AndroidEntryPoint
 class DetailMovieActivity : AppCompatActivity() {
 
@@ -112,7 +119,11 @@ class DetailMovieActivity : AppCompatActivity() {
 
   private lateinit var adapterCast: CastAdapter
   private lateinit var adapterRecommendation: RecommendationAdapter
-  private lateinit var adapterWatchProviders: WatchProvidersAdapter
+
+  private lateinit var adapterBuy: WatchProvidersAdapter
+  private lateinit var adapterFree: WatchProvidersAdapter
+  private lateinit var adapterRent: WatchProvidersAdapter
+  private lateinit var adapterStreaming: WatchProvidersAdapter
 
   private var favorite = false // is item favorite or not
   private var watchlist = false // is item watchlist or not
@@ -120,6 +131,8 @@ class DetailMovieActivity : AppCompatActivity() {
 
   private var mSnackbar: Snackbar? = null
   private var toast: Toast? = null
+
+  private var isExpanded = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge(
@@ -138,15 +151,16 @@ class DetailMovieActivity : AppCompatActivity() {
 
     justifyTextView(binding.tvOverview as TextView)
 
+    getDataExtra()
     showLoadingDim(true)
     setupRecyclerView()
     stateObserver()
     initTag()
 
     checkUser()
-    getDataExtra()
     showDetailData()
     favWatchlistHandler()
+    btnWatchProviders()
     viewListener()
   }
 
@@ -162,13 +176,42 @@ class DetailMovieActivity : AppCompatActivity() {
 
   private fun setupRecyclerView() {
     setupRecyclerViewsWithSnap(
-      listOf(binding.rvCast, binding.rvRecommendation, binding.rvWatchProviders)
+      listOf(
+        binding.rvBuy,
+        binding.rvFree,
+        binding.rvRent,
+        binding.rvStreaming,
+        binding.rvCast,
+        binding.rvRecommendation,
+      )
     )
 
+    val clickListener = {
+      startActivity(
+        Intent(
+          Intent.ACTION_VIEW,
+          "$TMDB_LINK_MAIN/${dataExtra.mediaType}/${dataExtra.id}/watch".toUri()
+        )
+      )
+    }
+
     // setup adapter
+    adapterBuy = WatchProvidersAdapter(clickListener)
+    adapterFree = WatchProvidersAdapter(clickListener)
+    adapterRent = WatchProvidersAdapter(clickListener)
+    adapterStreaming = WatchProvidersAdapter(clickListener)
     adapterCast = CastAdapter(navigator)
     adapterRecommendation = RecommendationAdapter(navigator)
-    adapterWatchProviders = WatchProvidersAdapter()
+
+    // setup rv watch providers
+    binding.rvBuy.itemAnimator = DefaultItemAnimator()
+    binding.rvFree.itemAnimator = DefaultItemAnimator()
+    binding.rvRent.itemAnimator = DefaultItemAnimator()
+    binding.rvStreaming.itemAnimator = DefaultItemAnimator()
+    binding.rvBuy.adapter = adapterBuy
+    binding.rvFree.adapter = adapterFree
+    binding.rvRent.adapter = adapterRent
+    binding.rvStreaming.adapter = adapterStreaming
 
     // setup rv cast
     binding.rvCast.itemAnimator = DefaultItemAnimator()
@@ -179,10 +222,6 @@ class DetailMovieActivity : AppCompatActivity() {
     binding.rvRecommendation.adapter = adapterRecommendation.withLoadStateFooter(
       footer = LoadingStateAdapter { adapterRecommendation.retry() }
     )
-
-    // setup rv watch providers
-    binding.rvWatchProviders.itemAnimator = DefaultItemAnimator()
-    binding.rvWatchProviders.adapter = adapterWatchProviders
   }
 
   private fun initTag() {
@@ -315,9 +354,10 @@ class DetailMovieActivity : AppCompatActivity() {
     // shows crew and cast
     detailViewModel.getMovieCredits(dataExtra.id)
 
-    // get detail movie
+    // get detail movie, and watch providers
     prefViewModel.getUserRegion().observe(this) { region ->
       detailViewModel.detailMovie(dataExtra.id, region)
+      detailViewModel.getMovieWatchProviders(region.uppercase(), dataExtra.id)
     }
 
     detailViewModel.detailMovieTv.observe(this) { movie ->
@@ -338,9 +378,6 @@ class DetailMovieActivity : AppCompatActivity() {
       detailViewModel.getLinkVideoMovie(movie.id)
       detailViewModel.getRecommendationMovie(movie.id)
     }
-
-    // get watch providers
-    detailViewModel.getMovieWatchProviders(dataExtra.id)
   }
 
   private fun updateMovieDetailsUI(movie: DetailMovieTvUsed) {
@@ -403,12 +440,7 @@ class DetailMovieActivity : AppCompatActivity() {
       adapterRecommendation.submitData(lifecycle, recommendations)
     }
 
-    detailViewModel.watchProviders.observe(this) {
-      // TODO: change with user country and separate between free, rent, buy, etc
-      val providers = it.results?.get("US")?.flatrate.orEmpty()
-
-      adapterWatchProviders.setProviders(providers)
-    }
+    showWatchProviders()
   }
   // endregion MOVIE
 
@@ -425,9 +457,10 @@ class DetailMovieActivity : AppCompatActivity() {
       adapterRecommendation.submitData(lifecycle, it)
     }
 
-    // show genres & age rate
+    // show genres, age rate, watch region
     prefViewModel.getUserRegion().observe(this) { region ->
       detailViewModel.detailTv(dataExtra.id, region)
+      detailViewModel.getTvWatchProviders(region.uppercase(), dataExtra.id)
     }
     detailViewModel.detailMovieTv.observe(this) { tv ->
 
@@ -467,9 +500,6 @@ class DetailMovieActivity : AppCompatActivity() {
         showViewReleaseDate(false)
       }
     }
-
-    // get watch providers
-    detailViewModel.getTvWatchProviders(dataExtra.id)
   }
 
   private fun observeDetailTv() {
@@ -506,12 +536,7 @@ class DetailMovieActivity : AppCompatActivity() {
       }
     }
 
-    detailViewModel.watchProviders.observe(this) {
-      // TODO: change with user country and separate between free, rent, buy, etc
-      val providers = it.results?.get("US")?.flatrate.orEmpty()
-
-      adapterWatchProviders.setProviders(providers)
-    }
+    showWatchProviders()
   }
   // endregion TV
 
@@ -531,6 +556,7 @@ class DetailMovieActivity : AppCompatActivity() {
   }
 
   private fun btnTrailer(link: String) {
+    // button to open trailer
     binding.ibPlay.setOnClickListener {
       try {
         startActivity(
@@ -551,6 +577,26 @@ class DetailMovieActivity : AppCompatActivity() {
         Log.e(TAG, "Unknown error occurred while trying to play video", e)
         snackBarWarning(binding.coordinatorLayout, null, getString(unknown_error))
       }
+    }
+  }
+
+  private fun btnWatchProviders() {
+    // button to expand or collapse watch providers
+    binding.tvToggleWatchProviders.setOnClickListener {
+      isExpanded = !isExpanded
+
+      // animate visibility changes
+      TransitionManager.beginDelayedTransition(binding.watchProviderSection, AutoTransition())
+      binding.groupWatchProviders.visibility = if (isExpanded) View.VISIBLE else View.GONE
+
+      // update toggle icon
+      binding.tvToggleWatchProviders.text =
+        if (isExpanded) getString(where_to_watch_up) else getString(where_to_watch_down)
+    }
+
+    // open justwatch
+    binding.btnJustwatch.setOnClickListener {
+      startActivity(Intent(Intent.ACTION_VIEW, JUSTWATCH_LINK_MAIN.toUri()))
     }
   }
 
@@ -772,6 +818,66 @@ class DetailMovieActivity : AppCompatActivity() {
   private fun showViewReleaseDate(isShow: Boolean) {
     binding.tvYearReleased.isVisible = isShow
     binding.divider1.isVisible = isShow
+  }
+
+  private fun showWatchProviders() {
+    detailViewModel.watchProvidersUiState.observe(this) { state ->
+      when (state) {
+        is WatchProvidersUiState.Loading -> {
+          binding.progressBar.isVisible = true
+          binding.tvWatchProvidersMessage.isVisible = false
+        }
+
+        is WatchProvidersUiState.Success -> {
+          binding.progressBar.isVisible = false
+          binding.tvWatchProvidersMessage.isVisible = false
+          binding.layoutJustwatch.isVisible = true
+
+          adapterBuy.setProviders(state.buy)
+          adapterFree.setProviders(state.free)
+          adapterRent.setProviders(state.rent)
+          adapterStreaming.setProviders(state.flatrate)
+
+          binding.rvBuy.isVisible = state.buy.isNotEmpty()
+          binding.rvFree.isVisible = state.free.isNotEmpty()
+          binding.rvRent.isVisible = state.rent.isNotEmpty()
+          binding.rvStreaming.isVisible = state.flatrate.isNotEmpty()
+
+          binding.labelBuy.isVisible = state.buy.isNotEmpty()
+          binding.labelFree.isVisible = state.free.isNotEmpty()
+          binding.labelRent.isVisible = state.rent.isNotEmpty()
+          binding.labelStreaming.isVisible = state.flatrate.isNotEmpty()
+
+          binding.layoutFree.isVisible = state.free.isNotEmpty()
+          binding.layoutBuy.isVisible = state.buy.isNotEmpty()
+          binding.layoutRent.isVisible = state.rent.isNotEmpty()
+          binding.layoutStreaming.isVisible = state.flatrate.isNotEmpty()
+        }
+
+        is WatchProvidersUiState.Error -> {
+          binding.progressBar.isVisible = false
+          binding.tvWatchProvidersMessage.text = state.message
+          binding.tvWatchProvidersMessage.isVisible = true
+          binding.layoutJustwatch.isVisible = false
+
+          binding.rvBuy.isVisible = false
+          binding.rvFree.isVisible = false
+          binding.rvRent.isVisible = false
+          binding.rvStreaming.isVisible = false
+
+
+          binding.labelBuy.isVisible = false
+          binding.labelFree.isVisible = false
+          binding.labelRent.isVisible = false
+          binding.labelStreaming.isVisible = false
+
+          binding.layoutFree.isVisible = false
+          binding.layoutBuy.isVisible = false
+          binding.layoutRent.isVisible = false
+          binding.layoutStreaming.isVisible = false
+        }
+      }
+    }
   }
   // endregion VIEW HANDLER
 

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/DetailMovieActivity.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/DetailMovieActivity.kt
@@ -83,6 +83,7 @@ import com.waffiq.bazz_movies.feature.detail.domain.model.DetailMovieTvUsed
 import com.waffiq.bazz_movies.feature.detail.domain.model.omdb.OMDbDetails
 import com.waffiq.bazz_movies.feature.detail.ui.adapter.CastAdapter
 import com.waffiq.bazz_movies.feature.detail.ui.adapter.RecommendationAdapter
+import com.waffiq.bazz_movies.feature.detail.ui.adapter.WatchProvidersAdapter
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.CreateTableViewHelper.createTable
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.DetailMovieTvHelper.detailCrew
 import com.waffiq.bazz_movies.feature.detail.utils.uihelpers.ButtonImageChanger.changeBtnFavoriteBG
@@ -95,7 +96,7 @@ import kotlinx.coroutines.launch
 import java.util.Locale
 import javax.inject.Inject
 
-@Suppress("TooManyFunctions")
+@Suppress("ForbiddenComment", "TooManyFunctions")
 @AndroidEntryPoint
 class DetailMovieActivity : AppCompatActivity() {
 
@@ -111,6 +112,7 @@ class DetailMovieActivity : AppCompatActivity() {
 
   private lateinit var adapterCast: CastAdapter
   private lateinit var adapterRecommendation: RecommendationAdapter
+  private lateinit var adapterWatchProviders: WatchProvidersAdapter
 
   private var favorite = false // is item favorite or not
   private var watchlist = false // is item watchlist or not
@@ -160,12 +162,13 @@ class DetailMovieActivity : AppCompatActivity() {
 
   private fun setupRecyclerView() {
     setupRecyclerViewsWithSnap(
-      listOf(binding.rvCast, binding.rvRecommendation)
+      listOf(binding.rvCast, binding.rvRecommendation, binding.rvWatchProviders)
     )
 
     // setup adapter
     adapterCast = CastAdapter(navigator)
     adapterRecommendation = RecommendationAdapter(navigator)
+    adapterWatchProviders = WatchProvidersAdapter()
 
     // setup rv cast
     binding.rvCast.itemAnimator = DefaultItemAnimator()
@@ -176,6 +179,10 @@ class DetailMovieActivity : AppCompatActivity() {
     binding.rvRecommendation.adapter = adapterRecommendation.withLoadStateFooter(
       footer = LoadingStateAdapter { adapterRecommendation.retry() }
     )
+
+    // setup rv watch providers
+    binding.rvWatchProviders.itemAnimator = DefaultItemAnimator()
+    binding.rvWatchProviders.adapter = adapterWatchProviders
   }
 
   private fun initTag() {
@@ -331,6 +338,9 @@ class DetailMovieActivity : AppCompatActivity() {
       detailViewModel.getLinkVideoMovie(movie.id)
       detailViewModel.getRecommendationMovie(movie.id)
     }
+
+    // get watch providers
+    detailViewModel.getMovieWatchProviders(dataExtra.id)
   }
 
   private fun updateMovieDetailsUI(movie: DetailMovieTvUsed) {
@@ -392,6 +402,13 @@ class DetailMovieActivity : AppCompatActivity() {
     detailViewModel.recommendation.observe(this) { recommendations ->
       adapterRecommendation.submitData(lifecycle, recommendations)
     }
+
+    detailViewModel.watchProviders.observe(this) {
+      // TODO: change with user country and separate between free, rent, buy, etc
+      val providers = it.results?.get("US")?.flatrate.orEmpty()
+
+      adapterWatchProviders.setProviders(providers)
+    }
   }
   // endregion MOVIE
 
@@ -450,6 +467,9 @@ class DetailMovieActivity : AppCompatActivity() {
         showViewReleaseDate(false)
       }
     }
+
+    // get watch providers
+    detailViewModel.getTvWatchProviders(dataExtra.id)
   }
 
   private fun observeDetailTv() {
@@ -484,6 +504,13 @@ class DetailMovieActivity : AppCompatActivity() {
         hideTrailer(false)
         btnTrailer(it)
       }
+    }
+
+    detailViewModel.watchProviders.observe(this) {
+      // TODO: change with user country and separate between free, rent, buy, etc
+      val providers = it.results?.get("US")?.flatrate.orEmpty()
+
+      adapterWatchProviders.setProviders(providers)
     }
   }
   // endregion TV

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/DetailMovieViewModel.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/DetailMovieViewModel.kt
@@ -28,6 +28,7 @@ import com.waffiq.bazz_movies.feature.detail.domain.model.DetailMovieTvUsed
 import com.waffiq.bazz_movies.feature.detail.domain.model.MovieTvCredits
 import com.waffiq.bazz_movies.feature.detail.domain.model.PostModelState
 import com.waffiq.bazz_movies.feature.detail.domain.model.omdb.OMDbDetails
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
 import com.waffiq.bazz_movies.feature.detail.domain.usecase.getDetailMovie.GetDetailMovieUseCase
 import com.waffiq.bazz_movies.feature.detail.domain.usecase.getDetailOmdb.GetDetailOMDbUseCase
 import com.waffiq.bazz_movies.feature.detail.domain.usecase.getDetailTv.GetDetailTvUseCase
@@ -47,7 +48,7 @@ class DetailMovieViewModel @Inject constructor(
   private val postMethodUseCase: PostMethodUseCase,
   private val getDetailOMDbUseCase: GetDetailOMDbUseCase,
   private val getStatedMovieUseCase: GetStatedMovieUseCase,
-  private val getStatedTvUseCase: GetStatedTvUseCase
+  private val getStatedTvUseCase: GetStatedTvUseCase,
 ) : ViewModel() {
 
   // region OBSERVABLES
@@ -89,6 +90,9 @@ class DetailMovieViewModel @Inject constructor(
 
   private val _recommendation = MutableLiveData<PagingData<ResultItem>>()
   val recommendation: LiveData<PagingData<ResultItem>> get() = _recommendation
+
+  private val _watchProviders = MutableLiveData<WatchProviders>()
+  val watchProviders: LiveData<WatchProviders> get() = _watchProviders
   // endregion OBSERVABLES
 
   // region MOVIE
@@ -150,6 +154,21 @@ class DetailMovieViewModel @Inject constructor(
       getStatedMovieUseCase.getStatedMovie(sessionId, id).collect { outcome ->
         when (outcome) {
           is Outcome.Success -> outcome.data.let { _itemState.value = it }
+          is Outcome.Loading -> {}
+          is Outcome.Error -> {
+            _loadingState.value = false
+            _errorState.emit(outcome.message)
+          }
+        }
+      }
+    }
+  }
+
+  fun getMovieWatchProviders(tvId: Int) {
+    viewModelScope.launch {
+      getDetailMovieUseCase.getWatchProvidersMovies(tvId).collect { outcome ->
+        when (outcome) {
+          is Outcome.Success -> outcome.data.let { _watchProviders.value = it }
           is Outcome.Loading -> {}
           is Outcome.Error -> {
             _loadingState.value = false
@@ -238,6 +257,21 @@ class DetailMovieViewModel @Inject constructor(
       getStatedTvUseCase.getStatedTv(sessionId, id).collect { outcome ->
         when (outcome) {
           is Outcome.Success -> outcome.data.let { _itemState.value = it }
+          is Outcome.Loading -> {}
+          is Outcome.Error -> {
+            _loadingState.value = false
+            _errorState.emit(outcome.message)
+          }
+        }
+      }
+    }
+  }
+
+  fun getTvWatchProviders(tvId: Int) {
+    viewModelScope.launch {
+      getDetailTvUseCase.getWatchProvidersTv(tvId).collect { outcome ->
+        when (outcome) {
+          is Outcome.Success -> outcome.data.let { _watchProviders.value = it }
           is Outcome.Loading -> {}
           is Outcome.Error -> {
             _loadingState.value = false

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/WatchProvidersAdapter.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/WatchProvidersAdapter.kt
@@ -1,0 +1,85 @@
+package com.waffiq.bazz_movies.feature.detail.ui.adapter
+
+import android.R.anim.fade_in
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.view.animation.AnimationUtils
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade
+import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_ORIGINAL
+import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_broken_image
+import com.waffiq.bazz_movies.feature.detail.databinding.ItemWatchProviderBinding
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.Provider
+
+@Suppress("ForbiddenComment")
+class WatchProvidersAdapter :
+  RecyclerView.Adapter<WatchProvidersAdapter.ViewHolder>() {
+
+  private val providerList = ArrayList<Provider>()
+
+  fun setProviders(newList: List<Provider>) {
+    val diffCallback = DiffCallback(this.providerList, newList)
+    val diffResult = DiffUtil.calculateDiff(diffCallback)
+
+    this.providerList.clear()
+    this.providerList.addAll(newList)
+    diffResult.dispatchUpdatesTo(this)
+  }
+
+  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+    val binding = ItemWatchProviderBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+    return ViewHolder(binding)
+  }
+
+  override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+    holder.bind(providerList[position])
+    holder.itemView.startAnimation(
+      AnimationUtils.loadAnimation(holder.itemView.context, fade_in)
+    )
+  }
+
+  override fun getItemCount(): Int = providerList.size
+
+  inner class ViewHolder(private val binding: ItemWatchProviderBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(provider: Provider) {
+      binding.ivPictureProvider.contentDescription = provider.providerName
+
+      Glide.with(binding.ivPictureProvider)
+        .load(
+          if (!provider.logoPath.isNullOrEmpty()) {
+            TMDB_IMG_LINK_ORIGINAL + provider.logoPath
+          } else {
+            ic_broken_image
+          }
+        )
+        .placeholder(ic_broken_image)
+        .transition(withCrossFade())
+        .error(ic_broken_image)
+        .into(binding.ivPictureProvider)
+
+      binding.container.setOnClickListener {
+        // TODO: handle click (open link to watch providers)
+      }
+    }
+  }
+
+  inner class DiffCallback(
+    private val oldList: List<Provider>,
+    private val newList: List<Provider>
+  ) : DiffUtil.Callback() {
+    override fun getOldListSize() = oldList.size
+    override fun getNewListSize() = newList.size
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+      return oldList[oldItemPosition].providerId == newList[newItemPosition].providerId
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+      return oldList[oldItemPosition] == newList[newItemPosition]
+    }
+  }
+}

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/WatchProvidersAdapter.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/WatchProvidersAdapter.kt
@@ -13,8 +13,9 @@ import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_broken_image
 import com.waffiq.bazz_movies.feature.detail.databinding.ItemWatchProviderBinding
 import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.Provider
 
-@Suppress("ForbiddenComment")
-class WatchProvidersAdapter :
+class WatchProvidersAdapter(
+  private val onItemClick: () -> Unit,
+) :
   RecyclerView.Adapter<WatchProvidersAdapter.ViewHolder>() {
 
   private val providerList = ArrayList<Provider>()
@@ -29,7 +30,8 @@ class WatchProvidersAdapter :
   }
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-    val binding = ItemWatchProviderBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+    val binding =
+      ItemWatchProviderBinding.inflate(LayoutInflater.from(parent.context), parent, false)
     return ViewHolder(binding)
   }
 
@@ -47,6 +49,7 @@ class WatchProvidersAdapter :
 
     fun bind(provider: Provider) {
       binding.ivPictureProvider.contentDescription = provider.providerName
+      binding.ivPictureProvider.setOnClickListener { onItemClick() }
 
       Glide.with(binding.ivPictureProvider)
         .load(
@@ -60,16 +63,12 @@ class WatchProvidersAdapter :
         .transition(withCrossFade())
         .error(ic_broken_image)
         .into(binding.ivPictureProvider)
-
-      binding.container.setOnClickListener {
-        // TODO: handle click (open link to watch providers)
-      }
     }
   }
 
   inner class DiffCallback(
     private val oldList: List<Provider>,
-    private val newList: List<Provider>
+    private val newList: List<Provider>,
   ) : DiffUtil.Callback() {
     override fun getOldListSize() = oldList.size
     override fun getNewListSize() = newList.size

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/state/WatchProvidersUiState.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/state/WatchProvidersUiState.kt
@@ -1,0 +1,14 @@
+package com.waffiq.bazz_movies.feature.detail.ui.state
+
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.Provider
+
+sealed class WatchProvidersUiState {
+  object Loading : WatchProvidersUiState()
+  data class Success(
+    val flatrate: List<Provider>,
+    val rent: List<Provider>,
+    val buy: List<Provider>,
+    val free: List<Provider>
+  ) : WatchProvidersUiState()
+  data class Error(val message: String) : WatchProvidersUiState()
+}

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/WatchProvidersMapper.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/WatchProvidersMapper.kt
@@ -1,0 +1,33 @@
+package com.waffiq.bazz_movies.feature.detail.utils.mappers
+
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.watchproviders.CountryProviderDataResponse
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.watchproviders.ProviderResponse
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.detailmovietv.watchproviders.WatchProvidersResponse
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.CountryProviderData
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.Provider
+import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.WatchProviders
+
+object WatchProvidersMapper {
+
+  fun WatchProvidersResponse.toWatchProviders(): WatchProviders = WatchProviders(
+    id = id,
+    results = results?.mapValues { (_, countryData) ->
+      countryData.toDomain()
+    }
+  )
+
+  private fun CountryProviderDataResponse.toDomain(): CountryProviderData = CountryProviderData(
+    link = link,
+    flatrate = flatrate?.map { it.toProvider() },
+    rent = rent?.map { it.toProvider() },
+    buy = buy?.map { it.toProvider() },
+    free = free?.map { it.toProvider() },
+  )
+
+  private fun ProviderResponse.toProvider(): Provider = Provider(
+    logoPath = logoPath,
+    providerId = providerId,
+    providerName = providerName,
+    displayPriority = displayPriority
+  )
+}

--- a/feature/detail/src/main/res/layout/activity_detail_movie.xml
+++ b/feature/detail/src/main/res/layout/activity_detail_movie.xml
@@ -431,38 +431,142 @@
         <!-- ========================== -->
         <!--  WATCH PROVIDERS SECTION   -->
         <!-- ========================== -->
-        <androidx.recyclerview.widget.RecyclerView
-          android:id="@+id/rv_watch_providers"
+        <LinearLayout
+          android:id="@+id/watch_provider_section"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginTop="16dp"
-          android:clipToPadding="false"
-          android:orientation="horizontal"
-          android:paddingStart="@dimen/default_margin_parent_20"
-          tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-          tools:listitem="@layout/item_watch_provider" />
+          android:orientation="vertical">
 
-        <LinearLayout
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginHorizontal="@dimen/default_margin_parent_20"
-          android:layout_marginTop="8dp"
-          android:orientation="horizontal">
-
-          <TextView
-            style="@style/TextBody"
+          <com.google.android.material.button.MaterialButton
+            android:id="@+id/tv_toggle_watch_providers"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/data_powered_by" />
-
-          <TextView
-            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
+            android:backgroundTint="@android:color/transparent"
             android:fontFamily="@font/nunito_sans_bold"
-            android:text="@string/justwatch"
-            android:textColor="@color/gray_100" />
+            android:foreground="?attr/selectableItemBackground"
+            android:gravity="start|center"
+            android:text="@string/where_to_watch_down"
+            android:textAllCaps="false"
+            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+            android:textColor="@color/gray_100"
+            app:cornerRadius="@dimen/button_radius"
+            app:rippleColor="@color/gray_800" />
+
+          <LinearLayout
+            android:id="@+id/group_watch_providers"
+            style="@style/GroupWatchProviders"
+            tools:visibility="visible">
+
+            <!-- Streaming (Flatrate) -->
+            <LinearLayout
+              android:id="@+id/layout_streaming"
+              style="@style/LayoutWatchProviders"
+              tools:visibility="visible">
+
+              <TextView
+                android:id="@+id/label_streaming"
+                style="@style/LabelWatchProviders"
+                android:text="@string/streaming" />
+
+              <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_streaming"
+                style="@style/RecyclerViewWatchProviders"
+                tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/item_watch_provider" />
+            </LinearLayout>
+
+            <!-- Rent -->
+            <LinearLayout
+              android:id="@+id/layout_rent"
+              style="@style/LayoutWatchProviders"
+              tools:visibility="visible">
+
+              <TextView
+                android:id="@+id/label_rent"
+                style="@style/LabelWatchProviders"
+                android:text="@string/rent" />
+
+              <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_rent"
+                style="@style/RecyclerViewWatchProviders"
+                tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/item_watch_provider" />
+            </LinearLayout>
+
+            <!-- Buy -->
+            <LinearLayout
+              android:id="@+id/layout_buy"
+              style="@style/LayoutWatchProviders"
+              tools:visibility="visible">
+
+              <TextView
+                android:id="@+id/label_buy"
+                style="@style/LabelWatchProviders"
+                android:text="@string/buy" />
+
+              <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_buy"
+                style="@style/RecyclerViewWatchProviders"
+                tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/item_watch_provider" />
+            </LinearLayout>
+
+            <!-- Free -->
+            <LinearLayout
+              android:id="@+id/layout_free"
+              style="@style/LayoutWatchProviders"
+              tools:visibility="visible">
+
+              <TextView
+                android:id="@+id/label_free"
+                style="@style/LabelWatchProviders"
+                android:text="@string/free" />
+
+              <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_free"
+                style="@style/RecyclerViewWatchProviders"
+                tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/item_watch_provider" />
+            </LinearLayout>
+
+            <!-- JustWatch attribution -->
+            <LinearLayout
+              android:id="@+id/layout_justwatch"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_marginHorizontal="@dimen/default_margin_parent_20"
+              android:orientation="horizontal">
+
+              <TextView
+                style="@style/TextBody"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/data_powered_by" />
+
+              <com.google.android.material.button.MaterialButton
+                android:layout_marginStart="-5dp"
+                android:id="@+id/btn_justwatch"
+                style="@style/MyTransparentButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/nunito_sans_bold"
+                android:text="@string/justwatch"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                android:textColor="@color/gray_100" />
+            </LinearLayout>
+
+            <TextView
+              android:id="@+id/tv_watch_providers_message"
+              style="@style/TextBody"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_marginHorizontal="@dimen/default_margin_parent_20"
+              android:layout_marginBottom="8dp"
+              android:text=""
+              android:visibility="gone"
+              tools:text="Error no watch provider"
+              tools:visibility="visible" />
+          </LinearLayout>
         </LinearLayout>
         <!--   End of WATCH PROVIDERS   -->
 
@@ -471,7 +575,6 @@
           android:layout_width="match_parent"
           android:layout_height="1.5dp"
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
-          android:layout_marginTop="16dp"
           app:dividerColor="@color/yellow_alpha_80" />
 
         <!-- ========================== -->

--- a/feature/detail/src/main/res/layout/activity_detail_movie.xml
+++ b/feature/detail/src/main/res/layout/activity_detail_movie.xml
@@ -106,386 +106,319 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent">
 
-      <androidx.constraintlayout.widget.ConstraintLayout
+      <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/default_margin_parent_20"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:orientation="vertical">
 
         <!-- ========================== -->
-        <!--      BACKDROP SECTION      -->
+        <!--        UPPER SECTION       -->
         <!-- ========================== -->
-
-        <!-- Backdrop image -->
-        <com.google.android.material.imageview.ShapeableImageView
-          android:id="@+id/iv_picture_backdrop"
-          style="@style/roundedCornersPoster"
+        <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_width="match_parent"
-          android:layout_height="270dp"
-          android:adjustViewBounds="true"
-          android:contentDescription="@string/poster"
-          android:fitsSystemWindows="false"
-          android:foreground="@drawable/bg_gradient_shape"
-          android:scaleType="centerCrop"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toTopOf="parent"
-          tools:src="@drawable/ic_bazz_placeholder_backdrops" />
-
-        <!-- No backdrop text -->
-        <TextView
-          android:id="@+id/tv_backdrop_not_found"
-          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="8dp"
-          android:fontFamily="@font/nunito_sans_italic"
-          android:text="@string/backdrop_not_found"
-          android:textAppearance="@style/TextAppearance.Material3.LabelSmall"
-          android:textColor="@color/gray_300"
-          android:visibility="gone"
-          app:layout_constraintBottom_toTopOf="@+id/iv_poster"
+          android:paddingBottom="@dimen/default_margin_parent_20"
+          app:layout_constraintBottom_toBottomOf="parent"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
-          tools:visibility="visible" />
+          app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.cardview.widget.CardView
-          android:id="@+id/cardView"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          app:cardBackgroundColor="@android:color/transparent"
-          app:cardCornerRadius="50dp"
-          app:cardElevation="0dp"
-          app:layout_constraintBottom_toBottomOf="@+id/iv_picture_backdrop"
-          app:layout_constraintEnd_toEndOf="@+id/iv_picture_backdrop"
-          app:layout_constraintStart_toStartOf="@+id/iv_picture_backdrop"
-          app:layout_constraintTop_toTopOf="@+id/iv_picture_backdrop">
+          <!-- ========================== -->
+          <!--      BACKDROP SECTION      -->
+          <!-- ========================== -->
 
-          <!-- Trailer button -->
-          <ImageButton
-            android:id="@+id/ib_play"
+          <!-- Backdrop image -->
+          <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_picture_backdrop"
+            style="@style/roundedCornersPoster"
+            android:layout_width="match_parent"
+            android:layout_height="270dp"
+            android:adjustViewBounds="true"
+            android:contentDescription="@string/poster"
+            android:fitsSystemWindows="false"
+            android:foreground="@drawable/bg_gradient_shape"
+            android:scaleType="centerCrop"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/ic_bazz_placeholder_backdrops" />
+
+          <!-- No backdrop text -->
+          <TextView
+            android:id="@+id/tv_backdrop_not_found"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="@android:color/transparent"
-            android:contentDescription="@string/watch_trailer"
-            android:foreground="?attr/selectableItemBackgroundBorderless"
-            android:padding="12dp"
-            android:src="@drawable/ic_play"
+            android:layout_marginBottom="8dp"
+            android:fontFamily="@font/nunito_sans_italic"
+            android:text="@string/backdrop_not_found"
+            android:textAppearance="@style/TextAppearance.Material3.LabelSmall"
+            android:textColor="@color/gray_300"
             android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@+id/iv_poster"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             tools:visibility="visible" />
-        </androidx.cardview.widget.CardView>
-        <!-- End of BACKDROP SECTION -->
 
-        <!-- ========================== -->
-        <!--    DETAIL UPPER SECTION    -->
-        <!-- ========================== -->
+          <!-- Trailer button -->
+          <androidx.cardview.widget.CardView
+            android:id="@+id/cardView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:cardBackgroundColor="@android:color/transparent"
+            app:cardCornerRadius="50dp"
+            app:cardElevation="0dp"
+            app:layout_constraintBottom_toBottomOf="@+id/iv_picture_backdrop"
+            app:layout_constraintEnd_toEndOf="@+id/iv_picture_backdrop"
+            app:layout_constraintStart_toStartOf="@+id/iv_picture_backdrop"
+            app:layout_constraintTop_toTopOf="@+id/iv_picture_backdrop">
 
-        <!-- Poster -->
-        <com.google.android.material.imageview.ShapeableImageView
-          android:id="@+id/iv_poster"
-          android:layout_width="120dp"
-          android:layout_height="180dp"
-          android:layout_marginStart="@dimen/default_margin_parent_20"
-          android:layout_marginTop="-40dp"
-          android:contentDescription="@string/poster"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@+id/iv_picture_backdrop"
-          app:shapeAppearanceOverlay="@style/roundedCornersPoster"
-          tools:layout_width="120dp"
-          tools:src="@drawable/ic_bazz_placeholder_poster" />
+            <ImageButton
+              android:id="@+id/ib_play"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:background="@android:color/transparent"
+              android:contentDescription="@string/watch_trailer"
+              android:foreground="?attr/selectableItemBackgroundBorderless"
+              android:padding="12dp"
+              android:src="@drawable/ic_play"
+              android:visibility="gone"
+              tools:visibility="visible" />
+          </androidx.cardview.widget.CardView>
+          <!--  End of BACKDROP SECTION  -->
 
-        <!-- Title -->
-        <TextView
-          android:id="@+id/tv_title"
-          style="@style/TextHeader1"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="16dp"
-          android:layout_marginEnd="@dimen/default_margin_parent_20"
-          android:layout_marginBottom="8dp"
-          android:ellipsize="end"
-          android:maxLines="4"
-          app:layout_constrainedWidth="true"
-          app:layout_constraintBottom_toTopOf="@+id/tv_mediaType"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintHorizontal_bias="0"
-          app:layout_constraintStart_toEndOf="@+id/iv_poster"
-          tools:text="The Silence" />
+          <!-- Poster -->
+          <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_poster"
+            android:layout_width="120dp"
+            android:layout_height="180dp"
+            android:layout_marginStart="@dimen/default_margin_parent_20"
+            android:layout_marginTop="-40dp"
+            android:contentDescription="@string/poster"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/iv_picture_backdrop"
+            app:shapeAppearanceOverlay="@style/roundedCornersPoster"
+            tools:layout_width="120dp"
+            tools:src="@drawable/ic_bazz_placeholder_poster" />
 
-        <!-- TV/Movie -->
-        <TextView
-          android:id="@+id/tv_mediaType"
-          style="@style/TextBody"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="@dimen/margin_detail_info"
-          app:layout_constraintBottom_toTopOf="@+id/tv_genre"
-          app:layout_constraintStart_toStartOf="@+id/tv_title"
-          tools:text="MOVIE" />
+          <!-- Title -->
+          <TextView
+            android:id="@+id/tv_title"
+            style="@style/TextHeader1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="@dimen/default_margin_parent_20"
+            android:layout_marginBottom="8dp"
+            android:ellipsize="end"
+            android:maxLines="4"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintBottom_toTopOf="@+id/tv_mediaType"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toEndOf="@+id/iv_poster"
+            tools:text="The Silence" />
 
-        <!-- Release date -->
-        <TextView
-          android:id="@+id/tv_year_released"
-          style="@style/TextBody"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="4dp"
-          app:layout_constraintBottom_toBottomOf="@+id/tv_mediaType"
-          app:layout_constraintStart_toEndOf="@+id/divider1"
-          tools:text="Jul 24, 2020" />
+          <!-- TV/Movie -->
+          <TextView
+            android:id="@+id/tv_mediaType"
+            style="@style/TextBody"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_detail_info"
+            app:layout_constraintBottom_toTopOf="@+id/tv_genre"
+            app:layout_constraintStart_toStartOf="@+id/tv_title"
+            tools:text="MOVIE" />
 
-        <!-- Region -->
-        <TextView
-          android:id="@+id/tv_region_release"
-          style="@style/TextBody"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="@dimen/margin_detail_info"
-          app:layout_constraintBottom_toBottomOf="@+id/tv_mediaType"
-          app:layout_constraintStart_toEndOf="@+id/tv_year_released"
-          tools:text="(US)" />
+          <!-- Release date -->
+          <TextView
+            android:id="@+id/tv_year_released"
+            style="@style/TextBody"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_mediaType"
+            app:layout_constraintStart_toEndOf="@+id/divider1"
+            tools:text="Jul 24, 2020" />
 
-        <TextView
-          android:id="@+id/divider1"
-          style="@style/TextBody"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="@dimen/margin_detail_info"
-          android:importantForAccessibility="no"
-          android:text="@string/_divider"
-          android:textColor="@color/gray_400"
-          app:layout_constraintStart_toEndOf="@+id/tv_mediaType"
-          app:layout_constraintTop_toTopOf="@+id/tv_mediaType" />
+          <!-- Region -->
+          <TextView
+            android:id="@+id/tv_region_release"
+            style="@style/TextBody"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_detail_info"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_mediaType"
+            app:layout_constraintStart_toEndOf="@+id/tv_year_released"
+            tools:text="(US)" />
 
-        <TextView
-          android:id="@+id/divider2"
-          style="@style/TextBody"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="@dimen/margin_detail_info"
-          android:importantForAccessibility="no"
-          android:text="@string/_divider"
-          android:textColor="@color/gray_400"
-          app:layout_constraintBottom_toBottomOf="@+id/tv_mediaType"
-          app:layout_constraintStart_toEndOf="@+id/tv_region_release" />
+          <TextView
+            android:id="@+id/divider1"
+            style="@style/TextBody"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_detail_info"
+            android:importantForAccessibility="no"
+            android:text="@string/_divider"
+            android:textColor="@color/gray_400"
+            app:layout_constraintStart_toEndOf="@+id/tv_mediaType"
+            app:layout_constraintTop_toTopOf="@+id/tv_mediaType" />
 
-        <!-- Age rating -->
-        <TextView
-          android:id="@+id/tv_age_rating"
-          style="@style/TextBody"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginStart="@dimen/margin_detail_info"
-          android:layout_marginEnd="@dimen/default_margin_parent_20"
-          android:ellipsize="end"
-          android:maxLines="1"
-          app:layout_constrainedWidth="true"
-          app:layout_constraintBottom_toBottomOf="@+id/tv_mediaType"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintHorizontal_bias="0"
-          app:layout_constraintStart_toEndOf="@+id/divider2"
-          tools:text="PG-A" />
+          <TextView
+            android:id="@+id/divider2"
+            style="@style/TextBody"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_detail_info"
+            android:importantForAccessibility="no"
+            android:text="@string/_divider"
+            android:textColor="@color/gray_400"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_mediaType"
+            app:layout_constraintStart_toEndOf="@+id/tv_region_release" />
 
-        <!-- Genre -->
-        <TextView
-          android:id="@+id/tv_genre"
-          style="@style/TextBody"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginEnd="@dimen/default_margin_parent_20"
-          android:layout_marginBottom="@dimen/margin_detail_info"
-          android:ellipsize="end"
-          android:maxLines="1"
-          android:text="@string/not_available"
-          app:layout_constrainedWidth="true"
-          app:layout_constraintBottom_toTopOf="@+id/tv_duration"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintHorizontal_bias="0"
-          app:layout_constraintStart_toStartOf="@+id/tv_mediaType"
-          tools:text="Action, Drama, &amp; Family" />
+          <!-- Age rating -->
+          <TextView
+            android:id="@+id/tv_age_rating"
+            style="@style/TextBody"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_detail_info"
+            android:layout_marginEnd="@dimen/default_margin_parent_20"
+            android:ellipsize="end"
+            android:maxLines="1"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_mediaType"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toEndOf="@+id/divider2"
+            tools:text="PG-A" />
 
-        <!-- Duration -->
-        <TextView
-          android:id="@+id/tv_duration"
-          style="@style/TextBody"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginBottom="8dp"
-          android:ellipsize="end"
-          android:maxLines="2"
-          android:text="@string/not_available"
-          app:layout_constraintBottom_toBottomOf="@+id/iv_poster"
-          app:layout_constraintStart_toStartOf="@+id/tv_genre"
-          tools:text="1H 22m" />
-        <!-- End of DETAIL UPPER SECTION -->
+          <!-- Genre -->
+          <TextView
+            android:id="@+id/tv_genre"
+            style="@style/TextBody"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/default_margin_parent_20"
+            android:layout_marginBottom="@dimen/margin_detail_info"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@string/not_available"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintBottom_toTopOf="@+id/tv_duration"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toStartOf="@+id/tv_mediaType"
+            tools:text="Action, Drama, &amp; Family" />
+
+          <!-- Duration -->
+          <TextView
+            android:id="@+id/tv_duration"
+            style="@style/TextBody"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:text="@string/not_available"
+            app:layout_constraintBottom_toBottomOf="@+id/iv_poster"
+            app:layout_constraintStart_toStartOf="@+id/tv_genre"
+            tools:text="1H 22m" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+        <!--     End of UPPER SECTION   -->
 
         <!-- ========================== -->
         <!--        SCORE SECTION       -->
         <!-- ========================== -->
-
         <HorizontalScrollView
           android:id="@+id/score_scrollview"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginTop="14dp"
-          android:scrollbars="none"
-          app:layout_constraintTop_toBottomOf="@+id/iv_poster">
+          android:scrollbars="none">
 
           <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:paddingHorizontal="16dp">
+            android:paddingHorizontal="@dimen/default_margin_parent_20">
 
             <!-- IMDB -->
             <LinearLayout
               android:id="@+id/imdb_viewGroup"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_marginEnd="16dp"
-              android:background="?attr/selectableItemBackgroundBorderless"
-              android:minWidth="48dp"
-              android:minHeight="48dp"
-              android:orientation="vertical"
-              android:paddingBottom="10dp">
+              style="@style/GroupScore">
 
               <TextView
                 android:id="@+id/tv_score_imdb"
                 style="@style/TextScore"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/not_available"
                 tools:text="8.5" />
 
               <TextView
                 style="@style/TextScoreHeader"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
                 android:text="@string/imdb" />
             </LinearLayout>
 
             <!-- METASCORE -->
             <LinearLayout
               android:id="@+id/metascore_viewGroup"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_marginEnd="16dp"
-              android:background="?attr/selectableItemBackgroundBorderless"
-              android:minWidth="60dp"
-              android:minHeight="48dp"
-              android:orientation="vertical"
-              android:paddingBottom="10dp">
+              style="@style/GroupScore">
 
               <TextView
                 android:id="@+id/tv_score_metascore"
                 style="@style/TextScore"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/not_available"
                 tools:text="8.5" />
 
               <TextView
                 style="@style/TextScoreHeader"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
                 android:text="@string/metascore" />
             </LinearLayout>
 
             <!-- ROTTEN TOMATOES -->
             <LinearLayout
               android:id="@+id/rotten_tomatoes_viewGroup"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_marginEnd="16dp"
-              android:background="?attr/selectableItemBackgroundBorderless"
-              android:minWidth="60dp"
-              android:minHeight="48dp"
-              android:orientation="vertical"
-              android:paddingBottom="10dp">
+              style="@style/GroupScore">
 
               <TextView
                 android:id="@+id/tv_score_rotten_tomatoes"
                 style="@style/TextScore"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/not_available"
                 tools:text="85%" />
 
               <TextView
                 style="@style/TextScoreHeader"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
                 android:text="@string/r_tomatoes" />
             </LinearLayout>
 
             <!-- TMDB -->
             <LinearLayout
               android:id="@+id/tmdb_viewGroup"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_marginEnd="16dp"
-              android:background="?attr/selectableItemBackgroundBorderless"
-              android:minWidth="48dp"
-              android:minHeight="48dp"
-              android:orientation="vertical"
-              android:paddingBottom="10dp">
+              style="@style/GroupScore">
 
               <TextView
                 android:id="@+id/tv_score_tmdb"
                 style="@style/TextScore"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/not_available"
                 tools:text="8.5" />
 
               <TextView
                 style="@style/TextScoreHeader"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
                 android:text="@string/tmdb" />
             </LinearLayout>
 
             <!-- USER SCORE -->
             <LinearLayout
               android:id="@+id/your_score_viewGroup"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:background="?attr/selectableItemBackgroundBorderless"
-              android:contentDescription="@string/rating"
-              android:minWidth="60dp"
-              android:minHeight="48dp"
-              android:orientation="vertical"
-              android:paddingBottom="10dp">
+              style="@style/GroupScore">
 
               <TextView
                 android:id="@+id/tv_score_your_score"
-                style="@style/TextBody"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/not_available"
+                style="@style/TextScore"
                 tools:text="8.5" />
 
               <TextView
                 style="@style/TextScoreHeader"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
                 android:text="@string/your_score" />
             </LinearLayout>
 
           </LinearLayout>
         </HorizontalScrollView>
-        <!-- End of SCORE SECTION -->
+        <!--    End of SCORE SECTION    -->
 
         <com.google.android.material.divider.MaterialDivider
           android:id="@+id/divider_score"
@@ -493,10 +426,53 @@
           android:layout_height="1.5dp"
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
           android:layout_marginTop="8dp"
-          app:dividerColor="@color/yellow_alpha_80"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@+id/score_scrollview" />
+          app:dividerColor="@color/yellow_alpha_80" />
+
+        <!-- ========================== -->
+        <!--  WATCH PROVIDERS SECTION   -->
+        <!-- ========================== -->
+        <androidx.recyclerview.widget.RecyclerView
+          android:id="@+id/rv_watch_providers"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="16dp"
+          android:clipToPadding="false"
+          android:orientation="horizontal"
+          android:paddingStart="@dimen/default_margin_parent_20"
+          tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+          tools:listitem="@layout/item_watch_provider" />
+
+        <LinearLayout
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginHorizontal="@dimen/default_margin_parent_20"
+          android:layout_marginTop="8dp"
+          android:orientation="horizontal">
+
+          <TextView
+            style="@style/TextBody"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/data_powered_by" />
+
+          <TextView
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:fontFamily="@font/nunito_sans_bold"
+            android:text="@string/justwatch"
+            android:textColor="@color/gray_100" />
+        </LinearLayout>
+        <!--   End of WATCH PROVIDERS   -->
+
+        <com.google.android.material.divider.MaterialDivider
+          android:id="@+id/divider_watch_provider"
+          android:layout_width="match_parent"
+          android:layout_height="1.5dp"
+          android:layout_marginHorizontal="@dimen/default_margin_parent_20"
+          android:layout_marginTop="16dp"
+          app:dividerColor="@color/yellow_alpha_80" />
 
         <!-- ========================== -->
         <!--    DETAIL LOWER SECTION    -->
@@ -510,9 +486,7 @@
           android:layout_height="wrap_content"
           android:layout_marginStart="@dimen/default_margin_parent_20"
           android:layout_marginTop="16dp"
-          android:text="@string/overview"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@+id/divider_score" />
+          android:text="@string/overview" />
 
         <io.github.glailton.expandabletextview.ExpandableTextView
           android:id="@+id/tv_overview"
@@ -528,9 +502,6 @@
           app:ellipsizeTextColor="@color/yellow"
           app:expandType="layout"
           app:isExpanded="false"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@+id/tv_summary_header"
           app:readLessText="@string/less_more"
           app:readMoreText="@string/read_more"
           app:textMode="line"
@@ -544,8 +515,6 @@
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
           android:layout_marginTop="8dp"
           android:orientation="horizontal"
-          app:layout_constraintStart_toStartOf="@+id/tv_overview"
-          app:layout_constraintTop_toBottomOf="@+id/tv_overview"
           tools:background="@color/yellow"
           tools:layout_height="100dp" />
 
@@ -555,21 +524,17 @@
           style="@style/TextHeader2"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:layout_marginHorizontal="@dimen/default_margin_parent_20"
           android:layout_marginTop="16dp"
-          android:text="@string/cast"
-          app:layout_constraintStart_toStartOf="@+id/tv_overview"
-          app:layout_constraintTop_toBottomOf="@+id/table" />
+          android:text="@string/cast" />
 
         <androidx.recyclerview.widget.RecyclerView
           android:id="@+id/rv_cast"
-          android:layout_width="0dp"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="8dp"
           android:clipToPadding="false"
           android:paddingStart="@dimen/default_margin_parent_20"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@+id/tv_cast_header"
           tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
           tools:listitem="@layout/item_cast"
           tools:orientation="horizontal" />
@@ -580,10 +545,9 @@
           style="@style/TextHeader2"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:layout_marginHorizontal="@dimen/default_margin_parent_20"
           android:layout_marginTop="16dp"
-          android:text="@string/recommendation"
-          app:layout_constraintStart_toStartOf="@+id/tv_cast_header"
-          app:layout_constraintTop_toBottomOf="@+id/rv_cast" />
+          android:text="@string/recommendation" />
         <!-- End of DETAIL LOWER SECTION -->
 
         <androidx.recyclerview.widget.RecyclerView
@@ -593,17 +557,12 @@
           android:layout_marginTop="8dp"
           android:clipToPadding="false"
           android:paddingStart="@dimen/default_margin_parent_20"
-          app:layout_constraintEnd_toEndOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@+id/tv_recommendation_header"
           tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
           tools:listitem="@layout/item_poster"
           tools:orientation="horizontal" />
 
-      </androidx.constraintlayout.widget.ConstraintLayout>
-
+      </LinearLayout>
     </androidx.core.widget.NestedScrollView>
-
   </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
   <!-- End of MAIN SECTION -->
 

--- a/feature/detail/src/main/res/layout/item_watch_provider.xml
+++ b/feature/detail/src/main/res/layout/item_watch_provider.xml
@@ -11,7 +11,10 @@
     android:layout_width="50dp"
     android:layout_height="50dp"
     android:layout_marginRight="12dp"
-    android:background="@android:color/transparent"
+    android:foreground="?attr/selectableItemBackgroundBorderless"
+    android:backgroundTint="@android:color/transparent"
+    android:clickable="true"
+    android:focusable="true"
     app:shapeAppearanceOverlay="@style/roundedCornersPoster"
     tools:src="@color/yellow" />
 

--- a/feature/detail/src/main/res/layout/item_watch_provider.xml
+++ b/feature/detail/src/main/res/layout/item_watch_provider.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/container"
+  android:layout_width="wrap_content"
+  android:layout_height="wrap_content">
+
+  <com.google.android.material.imageview.ShapeableImageView
+    android:id="@+id/iv_picture_provider"
+    android:layout_width="50dp"
+    android:layout_height="50dp"
+    android:layout_marginRight="12dp"
+    android:background="@android:color/transparent"
+    app:shapeAppearanceOverlay="@style/roundedCornersPoster"
+    tools:src="@color/yellow" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
### Changes Made

- Added initial support for displaying watch providers on the detail page
- Created structured layout for showing providers per movie/TV show
- Added placeholders for filtering by country (`US`)and offer type (`flatrate`)

### Todo:

-  [x] Implement logic to filter providers based on user’s country
-  [x] Implement filtering by offer type (free, rent, buy, etc)
>-  ~~[ ] Add unit tests for watch provider logic~~ 
>this will be a separate PR to make it more organized
-  [x] Add fallback UI for unsupported countries or missing data

> [!NOTE]
> Some of the above tasks are marked in the code with `// TODO:` comments for easier tracking.

### Source

We retrieve watch provider data from the following TMDB endpoints:
- [`/movie/{movie_id}/watch/providers`](https://developer.themoviedb.org/reference/movie-watch-providers)  
- [`/tv/{tv_id}/watch/providers`](https://developer.themoviedb.org/reference/tv-series-watch-providers)

> However, due to TMDB API limitations (discussed here:  [Talk 1](https://www.themoviedb.org/talk/6126a7c09a358d0091aa73ea) , [Talk 2](https://www.themoviedb.org/talk/5fc9a18966a7c3003e46f195), [Talk 3](https://www.themoviedb.org/talk/62eb3ba2273648005d9c8845)),  we are unable to get **full deep links** directly from the API to open the watch provider.

As a workaround, we use the `link` field provided in the response, which redirects to TMDB’s `/watch` page for the selected content.

---

Closes #183 