### PR TITLE
feat(detail): add missing ad-supported watch providers to detail page

### DIFF
--- a/core/designsystem/src/main/res/values-night/themes.xml
+++ b/core/designsystem/src/main/res/values-night/themes.xml
@@ -268,7 +268,8 @@
   <style name="GroupWatchProviders">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>
-    <item name="android:layout_marginTop">16dp</item>
+    <item name="android:layout_marginStart">4dp</item>
+    <item name="android:layout_marginEnd">4dp</item>
     <item name="android:orientation">vertical</item>
     <item name="android:visibility">gone</item>
   </style>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
   <string name="data_powered_by">*Data powered by</string>
   <string name="where_to_watch_down">Where to watch  ▾</string>
   <string name="where_to_watch_up">Where to watch  ▴</string>
+  <string name="ads">Ads</string>
   <string name="buy">Buy</string>
   <string name="rent">Rent</string>
   <string name="free">Free</string>

--- a/core/designsystem/src/main/res/values/themes.xml
+++ b/core/designsystem/src/main/res/values/themes.xml
@@ -268,6 +268,8 @@
   <style name="GroupWatchProviders">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_marginStart">4dp</item>
+    <item name="android:layout_marginEnd">4dp</item>
     <item name="android:orientation">vertical</item>
     <item name="android:visibility">gone</item>
   </style>

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/watchproviders/CountryProviderDataResponse.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/detailmovietv/watchproviders/CountryProviderDataResponse.kt
@@ -9,15 +9,18 @@ data class CountryProviderDataResponse(
   @Json(name = "link")
   val link: String?,
 
-  @Json(name = "flatrate")
-  val flatrate: List<ProviderResponse>?,
-
-  @Json(name = "rent")
-  val rent: List<ProviderResponse>?,
+  @Json(name = "ads")
+  val ads: List<ProviderResponse>?,
 
   @Json(name = "buy")
   val buy: List<ProviderResponse>?,
 
+  @Json(name = "flatrate")
+  val flatrate: List<ProviderResponse>?,
+
   @Json(name = "free")
   val free: List<ProviderResponse>?,
+
+  @Json(name = "rent")
+  val rent: List<ProviderResponse>?,
 )

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/MovieDataSourceWatchProvidersTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/MovieDataSourceWatchProvidersTest.kt
@@ -12,6 +12,7 @@ import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testSuccessRespo
 import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testUnknownHostExceptionResponse
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import retrofit2.Response
@@ -34,6 +35,7 @@ class MovieDataSourceWatchProvidersTest : BaseMovieDataSourceTest() {
       assertEquals(2, usProviders?.flatrate?.size)
       assertEquals("Netflix", usProviders?.flatrate?.get(0)?.providerName)
       assertEquals("Disney+", usProviders?.flatrate?.get(1)?.providerName)
+      assertEquals("WeTV", usProviders?.ads?.get(0)?.providerName)
       assertNotNull(usProviders?.rent?.get(0))
 
       val idProviders = data.results?.get("ID")
@@ -43,6 +45,7 @@ class MovieDataSourceWatchProvidersTest : BaseMovieDataSourceTest() {
       assertEquals("/logo6.png", idProviders?.free?.get(0)?.logoPath)
       assertEquals("WeTV", idProviders?.free?.get(0)?.providerName)
       assertEquals(6, idProviders?.free?.get(0)?.providerId)
+      assertNull(idProviders?.ads?.get(0))
       assertEquals(12, idProviders?.free?.get(0)?.displayPriority)
     }
   }

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/testutils/DataDumpManager.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/testutils/DataDumpManager.kt
@@ -440,7 +440,6 @@ object DataDumpManager {
         adult = false,
         order = 2
       )
-      // Add the rest of the cast items in a similar way...
     ),
     crew = listOf(
       movieTvCrewItemResponseDump,
@@ -470,7 +469,6 @@ object DataDumpManager {
         department = "Production",
         job = "Producer"
       )
-      // Add the rest of the crew items in a similar way...
     )
   )
 
@@ -697,6 +695,14 @@ object DataDumpManager {
     results = mapOf(
       "US" to CountryProviderDataResponse(
         link = "https://www.link.com/us/movie/example-movie",
+        ads = listOf(
+          ProviderResponse(
+            logoPath = "/logo6.png",
+            providerId = 6,
+            providerName = "WeTV",
+            displayPriority = 3
+          )
+        ),
         flatrate = listOf(
           ProviderResponse(
             logoPath = "/logo1.png",
@@ -731,8 +737,7 @@ object DataDumpManager {
       ),
       "ID" to CountryProviderDataResponse(
         link = "https://www.link.com/id/movie/example-movie",
-        flatrate = null,
-        rent = null,
+        ads = null,
         buy = listOf(
           ProviderResponse(
             logoPath = "/logo5.png",
@@ -741,6 +746,8 @@ object DataDumpManager {
             displayPriority = 8
           )
         ),
+        flatrate = null,
+        rent = null,
         free = listOf(
           ProviderResponse(
             logoPath = "/logo6.png",

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/model/watchproviders/CountryProviderData.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/model/watchproviders/CountryProviderData.kt
@@ -2,8 +2,9 @@ package com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders
 
 data class CountryProviderData(
   val link: String?,
-  val flatrate: List<Provider>?, // a.k.a. streaming
-  val rent: List<Provider>?,
+  val ads: List<Provider>?,
   val buy: List<Provider>?,
-  val free: List<Provider>?
+  val flatrate: List<Provider>?, // a.k.a. streaming
+  val free: List<Provider>?,
+  val rent: List<Provider>?,
 )

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/WatchProvidersManager.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/WatchProvidersManager.kt
@@ -2,6 +2,7 @@ package com.waffiq.bazz_movies.feature.detail.ui.manager
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import android.view.View
 import androidx.core.net.toUri
 import androidx.core.view.isVisible
@@ -40,6 +41,7 @@ class WatchProvidersManager(
   private val context: Context,
   private val dataExtra: ResultItem,
 ) {
+  private lateinit var adapterAds: WatchProvidersAdapter
   private lateinit var adapterBuy: WatchProvidersAdapter
   private lateinit var adapterFree: WatchProvidersAdapter
   private lateinit var adapterRent: WatchProvidersAdapter
@@ -58,6 +60,7 @@ class WatchProvidersManager(
   private fun setupWatchProvidersUI() {
     setupRecyclerViewsWithSnap(
       listOf(
+        binding.rvAds,
         binding.rvBuy,
         binding.rvFree,
         binding.rvRent,
@@ -67,11 +70,13 @@ class WatchProvidersManager(
 
     val clickListener = { openTMDBWatchPage() }
 
+    adapterAds = WatchProvidersAdapter(clickListener)
     adapterBuy = WatchProvidersAdapter(clickListener)
     adapterFree = WatchProvidersAdapter(clickListener)
     adapterRent = WatchProvidersAdapter(clickListener)
     adapterStreaming = WatchProvidersAdapter(clickListener)
 
+    setupRecyclerView(binding.rvAds, adapterAds)
     setupRecyclerView(binding.rvBuy, adapterBuy)
     setupRecyclerView(binding.rvFree, adapterFree)
     setupRecyclerView(binding.rvRent, adapterRent)
@@ -202,7 +207,12 @@ class WatchProvidersManager(
     }
     binding.layoutJustwatch.isVisible = false
 
-    hideAllProviderSections()
+    // hide all provider sections
+    binding.layoutAds.isVisible = false
+    binding.layoutBuy.isVisible = false
+    binding.layoutFree.isVisible = false
+    binding.layoutRent.isVisible = false
+    binding.layoutStreaming.isVisible = false
   }
 
   /**
@@ -211,52 +221,17 @@ class WatchProvidersManager(
    * @param state The successful state containing categorized provider lists.
    */
   private fun showSuccessState(state: WatchProvidersUiState.Success) {
+    adapterAds.setProviders(state.ads)
     adapterBuy.setProviders(state.buy)
     adapterFree.setProviders(state.free)
     adapterRent.setProviders(state.rent)
     adapterStreaming.setProviders(state.flatrate)
 
-    updateProviderVisibility(state.buy, binding.rvBuy, binding.labelBuy, binding.layoutBuy)
-    updateProviderVisibility(state.free, binding.rvFree, binding.labelFree, binding.layoutFree)
-    updateProviderVisibility(state.rent, binding.rvRent, binding.labelRent, binding.layoutRent)
-    updateProviderVisibility(
-      state.flatrate,
-      binding.rvStreaming,
-      binding.labelStreaming,
-      binding.layoutStreaming
-    )
-  }
-
-  /**
-   * Updates the visibility of a specific provider section.
-   *
-   * @param providers The list of providers for this category.
-   * @param recyclerView The RecyclerView showing providers.
-   * @param label The label (e.g., "Buy", "Rent") view.
-   * @param layout The container layout for the section.
-   */
-  private fun updateProviderVisibility(
-    providers: List<Provider>,
-    recyclerView: RecyclerView,
-    label: View,
-    layout: View,
-  ) {
-    val hasProviders = providers.isNotEmpty()
-    recyclerView.isVisible = hasProviders
-    label.isVisible = hasProviders
-    layout.isVisible = hasProviders
-  }
-
-  /**
-   * Hides all provider-related UI sections (used on error or no data).
-   */
-  private fun hideAllProviderSections() {
-    listOf(
-      binding.rvBuy, binding.rvFree, binding.rvRent, binding.rvStreaming,
-      binding.labelBuy, binding.labelFree, binding.labelRent, binding.labelStreaming,
-      binding.layoutBuy, binding.layoutFree, binding.layoutRent, binding.layoutStreaming
-    ).forEach { view ->
-      view.isVisible = false
-    }
+    // update provider visibility
+    binding.layoutAds.isVisible = state.ads.isNotEmpty()
+    binding.layoutBuy.isVisible = state.buy.isNotEmpty()
+    binding.layoutFree.isVisible = state.free.isNotEmpty()
+    binding.layoutRent.isVisible = state.rent.isNotEmpty()
+    binding.layoutStreaming.isVisible = state.flatrate.isNotEmpty()
   }
 }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/state/WatchProvidersUiState.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/state/WatchProvidersUiState.kt
@@ -3,12 +3,16 @@ package com.waffiq.bazz_movies.feature.detail.ui.state
 import com.waffiq.bazz_movies.feature.detail.domain.model.watchproviders.Provider
 
 sealed class WatchProvidersUiState {
+
   object Loading : WatchProvidersUiState()
+
   data class Success(
-    val flatrate: List<Provider>,
-    val rent: List<Provider>,
+    val ads: List<Provider>,
     val buy: List<Provider>,
-    val free: List<Provider>
+    val flatrate: List<Provider>,
+    val free: List<Provider>,
+    val rent: List<Provider>,
   ) : WatchProvidersUiState()
+
   data class Error(val message: String) : WatchProvidersUiState()
 }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/viewmodel/DetailMovieViewModel.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/viewmodel/DetailMovieViewModel.kt
@@ -265,10 +265,11 @@ class DetailMovieViewModel @Inject constructor(
         _watchProvidersUiState.value = when (outcome) {
           is Outcome.Loading -> WatchProvidersUiState.Loading
           is Outcome.Success -> WatchProvidersUiState.Success(
-            flatrate = outcome.data.flatrate.orEmpty(),
-            rent = outcome.data.rent.orEmpty(),
+            ads = outcome.data.ads.orEmpty(),
             buy = outcome.data.buy.orEmpty(),
+            flatrate = outcome.data.flatrate.orEmpty(),
             free = outcome.data.free.orEmpty(),
+            rent = outcome.data.rent.orEmpty(),
           )
 
           is Outcome.Error -> WatchProvidersUiState.Error(outcome.message)

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/WatchProvidersMapper.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/WatchProvidersMapper.kt
@@ -18,10 +18,11 @@ object WatchProvidersMapper {
 
   private fun CountryProviderDataResponse.toDomain(): CountryProviderData = CountryProviderData(
     link = link,
-    flatrate = flatrate?.map { it.toProvider() },
-    rent = rent?.map { it.toProvider() },
+    ads = ads?.map { it.toProvider() },
     buy = buy?.map { it.toProvider() },
+    flatrate = flatrate?.map { it.toProvider() },
     free = free?.map { it.toProvider() },
+    rent = rent?.map { it.toProvider() },
   )
 
   private fun ProviderResponse.toProvider(): Provider = Provider(

--- a/feature/detail/src/main/res/layout/activity_detail_movie.xml
+++ b/feature/detail/src/main/res/layout/activity_detail_movie.xml
@@ -475,19 +475,19 @@
                 tools:listitem="@layout/item_watch_provider" />
             </LinearLayout>
 
-            <!-- Rent -->
+            <!-- Ads -->
             <LinearLayout
-              android:id="@+id/layout_rent"
+              android:id="@+id/layout_ads"
               style="@style/LayoutWatchProviders"
               tools:visibility="visible">
 
               <TextView
-                android:id="@+id/label_rent"
+                android:id="@+id/label_ads"
                 style="@style/LabelWatchProviders"
-                android:text="@string/rent" />
+                android:text="@string/ads" />
 
               <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rv_rent"
+                android:id="@+id/rv_ads"
                 style="@style/RecyclerViewWatchProviders"
                 tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 tools:listitem="@layout/item_watch_provider" />
@@ -506,6 +506,24 @@
 
               <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_buy"
+                style="@style/RecyclerViewWatchProviders"
+                tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/item_watch_provider" />
+            </LinearLayout>
+
+            <!-- Rent -->
+            <LinearLayout
+              android:id="@+id/layout_rent"
+              style="@style/LayoutWatchProviders"
+              tools:visibility="visible">
+
+              <TextView
+                android:id="@+id/label_rent"
+                style="@style/LabelWatchProviders"
+                android:text="@string/rent" />
+
+              <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_rent"
                 style="@style/RecyclerViewWatchProviders"
                 tools:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 tools:listitem="@layout/item_watch_provider" />
@@ -544,11 +562,11 @@
                 android:text="@string/data_powered_by" />
 
               <com.google.android.material.button.MaterialButton
-                android:layout_marginStart="-5dp"
                 android:id="@+id/btn_justwatch"
                 style="@style/MyTransparentButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="-5dp"
                 android:fontFamily="@font/nunito_sans_bold"
                 android:text="@string/justwatch"
                 android:textAppearance="@style/TextAppearance.Material3.BodyMedium"


### PR DESCRIPTION
### Changes Made

- Added logic to include ad-supported watch providers on the detail page.
- Ensured all available provider types (streaming, rent, buy, free, ads) are properly listed