### PR TITLE
fix: resolve profile picture not showing on person page

### DIFF
--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/DetailMovieUIManager.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/DetailMovieUIManager.kt
@@ -194,8 +194,7 @@ class DetailMovieUIManager(
       tvMediaType.text = dataExtra.mediaType.uppercase()
       tvYearReleased.text = dateFormatterStandard(
         dataExtra.releaseDate?.takeIf { it.isNotEmpty() }
-          ?: dataExtra.firstAirDate?.takeIf { it.isNotEmpty() }
-          ?: ""
+          ?: dataExtra.firstAirDate?.takeIf { it.isNotEmpty() }.orEmpty()
       )
       tvOverview.text = dataExtra.overview?.takeIf { it.isNotBlank() }
         ?: activity.getString(no_overview)


### PR DESCRIPTION
### **User description**
### Change Made

- Closes #278


___

### **PR Type**
Bug fix


___

### **Description**
- Replace null-unsafe date handling with safe `orEmpty()` call

- Simplify date fallback logic for release/air dates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Date handling logic"] -- "replace unsafe null handling" --> B["Safe orEmpty() call"]
  B -- "prevents null pointer exceptions" --> C["Stable date display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DetailMovieUIManager.kt</strong><dd><code>Improve null-safe date handling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/DetailMovieUIManager.kt

<ul><li>Replace unsafe null handling with <code>orEmpty()</code> extension<br> <li> Simplify date fallback chain for release/air dates<br> <li> Remove redundant null check and empty string fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/280/files#diff-ebf43278d15a524db0a8b7bc47ee3e7c0d0077b5404a5659b00065918bf8a2d1">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

