### PR TITLE
fix: resolve release date not showing based on user region for movie media type

### DIFF
--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/movie/DetailMovieResponse.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/movie/DetailMovieResponse.kt
@@ -35,7 +35,7 @@ data class DetailMovieResponse(
   @Json(name = "popularity")
   val popularity: Double? = null,
 
-  @Json(name = "releasedates")
+  @Json(name = "release_dates")
   val releaseDatesResponse: ReleaseDatesResponse? = null,
 
   @Json(name = "production_countries")

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/releasedates/ReleaseDatesResponseItem.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/releasedates/ReleaseDatesResponseItem.kt
@@ -8,6 +8,6 @@ data class ReleaseDatesResponseItem(
   @Json(name = "iso_3166_1")
   val iso31661: String? = null,
 
-  @Json(name = "releasedates")
+  @Json(name = "release_dates")
   val listReleaseDateResponseItemValue: List<ReleaseDatesResponseItemValue>? = null,
 )

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/TMDBApiService.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/TMDBApiService.kt
@@ -189,7 +189,7 @@ interface TMDBApiService {
     @Path("tvId") tvId: Int,
   ): Response<MediaCreditsResponse>
 
-  @GET("3/movie/{movieId}?language=en-US&append_to_response=releasedates")
+  @GET("3/movie/{movieId}?language=en-US&append_to_response=release_dates")
   suspend fun getMovieDetail(
     @Path("movieId") movieId: Int,
   ): Response<DetailMovieResponse>


### PR DESCRIPTION
### **User description**
### Changes Made

- Resolve #291


___

### **PR Type**
Bug fix


___

### **Description**
- Fix JSON field mapping for movie release dates

- Correct API endpoint parameter name

- Resolve region-based release date display issue


___

### Diagram Walkthrough


```mermaid
flowchart LR
  API["TMDB API"] -- "release_dates" --> Response["DetailMovieResponse"]
  Response -- "corrected mapping" --> Field["releaseDatesResponse"]
  Field -- "displays correctly" --> UI["User Interface"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DetailMovieResponse.kt</strong><dd><code>Correct JSON field mapping for release dates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/movie/DetailMovieResponse.kt

<ul><li>Change JSON field name from <code>releasedates</code> to <code>release_dates</code><br> <li> Fix mapping for <code>releaseDatesResponse</code> property</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/292/files#diff-bd88325ca8a9a3169dc43759ca4d4a56828c00dcec06e17226cfe45f067186e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ReleaseDatesResponseItem.kt</strong><dd><code>Fix release dates item JSON mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/releasedates/ReleaseDatesResponseItem.kt

<ul><li>Update JSON field name from <code>releasedates</code> to <code>release_dates</code><br> <li> Fix mapping for <code>listReleaseDateResponseItemValue</code> property</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/292/files#diff-e566e8149f1d51a90f7c547d63044797f126b4c8e4f7e08e68fc0a71afc49ea1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TMDBApiService.kt</strong><dd><code>Correct API endpoint parameter name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/TMDBApiService.kt

<ul><li>Change API endpoint parameter from <code>releasedates</code> to <code>release_dates</code><br> <li> Update <code>getMovieDetail</code> method's append_to_response parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/292/files#diff-8ca0b40d190433ed800c4b6ba56015e1160589d8f26814193ab4517a451e23bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

