### PR TITLE
test: create missing test for feature detail module

### DIFF
--- a/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailActivityBackdropTest.kt
+++ b/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailActivityBackdropTest.kt
@@ -1,0 +1,243 @@
+package com.waffiq.bazz_movies.feature.detail.ui
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
+import com.waffiq.bazz_movies.core.common.utils.Constants.NOT_AVAILABLE
+import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
+import com.waffiq.bazz_movies.core.domain.MediaItem
+import com.waffiq.bazz_movies.feature.detail.R.id.iv_picture_backdrop
+import com.waffiq.bazz_movies.feature.detail.testutils.MediaDetailActivityTestHelper
+import com.waffiq.bazz_movies.feature.detail.testutils.MediaDetailActivityTestSetup
+import com.waffiq.bazz_movies.feature.detail.ui.viewmodel.DetailUserPrefViewModel
+import com.waffiq.bazz_movies.feature.detail.ui.viewmodel.MediaDetailViewModel
+import com.waffiq.bazz_movies.navigation.INavigator
+import dagger.hilt.android.testing.BindValue
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Instrumented test for [MediaDetailActivity] that checks the visibility of UI elements
+ * and the correct display of media details based on various conditions.
+ */
+@HiltAndroidTest
+class MediaDetailActivityBackdropTest :
+  MediaDetailActivityTestSetup by MediaDetailActivityTestHelper() {
+
+  @get:Rule
+  var hiltRule = HiltAndroidRule(this)
+
+  @BindValue
+  @JvmField
+  val mockNavigator: INavigator = mockk(relaxed = true)
+
+  @BindValue
+  @JvmField
+  val mockMediaDetailViewModel: MediaDetailViewModel = mockk(relaxed = true)
+
+  @BindValue
+  @JvmField
+  val mockPrefViewModel: DetailUserPrefViewModel = mockk(relaxed = true)
+
+  @Before
+  fun setup() {
+    hiltRule.inject()
+    setupMocks()
+    Intents.init()
+    initializeTest(ApplicationProvider.getApplicationContext())
+  }
+
+  @After
+  fun tearDown() {
+    Intents.release()
+  }
+
+  private fun setupMocks() {
+    setupBaseMocks()
+    setupObservables(mockMediaDetailViewModel)
+    setupPreferencesViewModelMocks(mockPrefViewModel)
+    setupMediaDetailViewModelMocks(mockMediaDetailViewModel)
+    setupNavigatorMocks(mockNavigator)
+  }
+
+  @Test
+  fun mediaItemValue_withNullValue_showsViewsCorrectly() {
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        originalName = "original name",
+        mediaType = MOVIE_MEDIA_TYPE,
+        backdropPath = null,
+        posterPath = null,
+        releaseDate = null,
+        firstAirDate = null,
+        overview = null,
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun mediaItemValue_withEmptyValue_showsViewsCorrectly() {
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        title = "title",
+        mediaType = TV_MEDIA_TYPE,
+        backdropPath = "",
+        posterPath = "",
+        releaseDate = "",
+        firstAirDate = "",
+        overview = "",
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun mediaItemValue_withNotAvailableValue_showsViewsCorrectly() {
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        originalTitle = "original title",
+        mediaType = TV_MEDIA_TYPE,
+        backdropPath = NOT_AVAILABLE,
+        posterPath = NOT_AVAILABLE,
+        releaseDate = null,
+        firstAirDate = "2025-07-09",
+        overview = "overview",
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun mediaItemValue_withOneNotAvailableValue_showsViewsCorrectly() {
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        originalTitle = "original title",
+        mediaType = MOVIE_MEDIA_TYPE,
+        backdropPath = NOT_AVAILABLE,
+        posterPath = null,
+        releaseDate = "2025-07-09",
+        overview = "overview",
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun mediaItemValue_withOneNullAvailableValue_showsViewsCorrectly() {
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        originalTitle = "original title",
+        mediaType = MOVIE_MEDIA_TYPE,
+        backdropPath = null,
+        posterPath = NOT_AVAILABLE,
+        releaseDate = "2025-07-09",
+        overview = "overview",
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun mediaItemValue_withMixedValue_showsViewsCorrectly() {
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        originalTitle = "original title",
+        mediaType = TV_MEDIA_TYPE,
+        backdropPath = null,
+        posterPath = "",
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        originalTitle = "original title",
+        mediaType = TV_MEDIA_TYPE,
+        backdropPath = "",
+        posterPath = null,
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun mediaItemValue_withValidBackdropPath_showsViewsCorrectly() {
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        originalTitle = "original title",
+        mediaType = MOVIE_MEDIA_TYPE,
+        backdropPath = "/valid_backdrop_path.jpg",
+        posterPath = NOT_AVAILABLE,
+        releaseDate = "2025-07-09",
+        overview = "overview",
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun mediaItemValue_withValidPosterPathOnly_showsViewsCorrectly() {
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        originalTitle = "original title",
+        mediaType = MOVIE_MEDIA_TYPE,
+        backdropPath = null,
+        posterPath = "/valid_poster_path.jpg",
+        releaseDate = "2025-07-09",
+        overview = "overview",
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun mediaItemValue_withInvalidPosterPath_showsViewsCorrectly() {
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        originalTitle = "original title",
+        mediaType = MOVIE_MEDIA_TYPE,
+        backdropPath = "",
+        posterPath = null,
+        releaseDate = "2025-07-09",
+        overview = "overview",
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+  }
+
+  @Test
+  fun mediaItemValue_withEmptyPosterPath_showsViewsCorrectly() {
+    context.launchMediaDetailActivity(
+      data = MediaItem(
+        originalTitle = "original title",
+        mediaType = MOVIE_MEDIA_TYPE,
+        backdropPath = null,
+        posterPath = "",
+        releaseDate = "2025-07-09",
+        overview = "overview",
+      )
+    ) {
+      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
+    }
+  }
+}

--- a/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailActivityTest.kt
+++ b/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailActivityTest.kt
@@ -8,16 +8,12 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
-import com.waffiq.bazz_movies.core.common.utils.Constants.NOT_AVAILABLE
 import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.designsystem.R.string.not_available
-import com.waffiq.bazz_movies.core.domain.MediaItem
 import com.waffiq.bazz_movies.core.instrumentationtest.Helper.waitFor
 import com.waffiq.bazz_movies.feature.detail.R.id.btn_back
 import com.waffiq.bazz_movies.feature.detail.R.id.btn_favorite
 import com.waffiq.bazz_movies.feature.detail.R.id.btn_watchlist
-import com.waffiq.bazz_movies.feature.detail.R.id.iv_picture_backdrop
 import com.waffiq.bazz_movies.feature.detail.R.id.rv_cast
 import com.waffiq.bazz_movies.feature.detail.R.id.tv_age_rating
 import com.waffiq.bazz_movies.feature.detail.R.id.tv_duration
@@ -136,82 +132,6 @@ class MediaDetailActivityTest :
     context.launchMediaDetailActivity {
       detailMedia.postValue(testMediaDetail.copy(imdbId = " "))
       waitFor(500)
-    }
-  }
-
-  @Test
-  fun mediaItemValue_withNullValue_showsViewsCorrectly() {
-    context.launchMediaDetailActivity(
-      data = MediaItem(
-        originalName = "original name",
-        mediaType = MOVIE_MEDIA_TYPE,
-        backdropPath = null,
-        posterPath = null,
-        releaseDate = null,
-        firstAirDate = null,
-        overview = null,
-      )
-    ) {
-      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
-    }
-  }
-
-  @Test
-  fun mediaItemValue_withEmptyValue_showsViewsCorrectly() {
-    context.launchMediaDetailActivity(
-      data = MediaItem(
-        title = "title",
-        mediaType = TV_MEDIA_TYPE,
-        backdropPath = "",
-        posterPath = "",
-        releaseDate = "",
-        firstAirDate = "",
-        overview = "",
-      )
-    ) {
-      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
-    }
-  }
-
-  @Test
-  fun mediaItemValue_withNotAvailableValue_showsViewsCorrectly() {
-    context.launchMediaDetailActivity(
-      data = MediaItem(
-        originalTitle = "original title",
-        mediaType = TV_MEDIA_TYPE,
-        backdropPath = NOT_AVAILABLE,
-        posterPath = NOT_AVAILABLE,
-        releaseDate = null,
-        firstAirDate = "2025-07-09",
-        overview = "overview",
-      )
-    ) {
-      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
-    }
-  }
-
-  @Test
-  fun mediaItemValue_withMixedValue_showsViewsCorrectly() {
-    context.launchMediaDetailActivity(
-      data = MediaItem(
-        originalTitle = "original title",
-        mediaType = TV_MEDIA_TYPE,
-        backdropPath = null,
-        posterPath = "",
-      )
-    ) {
-      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
-    }
-
-    context.launchMediaDetailActivity(
-      data = MediaItem(
-        originalTitle = "original title",
-        mediaType = TV_MEDIA_TYPE,
-        backdropPath = "",
-        posterPath = null,
-      )
-    ) {
-      onView(withId(iv_picture_backdrop)).check(matches(isDisplayed()))
     }
   }
 

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/data/repository/DetailRepositoryImpl.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/data/repository/DetailRepositoryImpl.kt
@@ -19,7 +19,7 @@ import com.waffiq.bazz_movies.feature.detail.utils.mappers.MediaDetailMapper.toM
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.MediaDetailMapper.toVideo
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.MovieMapper.toDetailMovie
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.OMDbMapper.toOMDbDetails
-import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toDetailTv
+import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toTvDetail
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toExternalTvID
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.WatchProvidersMapper.toWatchProviders
 import kotlinx.coroutines.flow.Flow
@@ -37,7 +37,7 @@ class DetailRepositoryImpl @Inject constructor(
     movieDataSource.getMovieDetail(movieId).toOutcome { it.toDetailMovie() }
 
   override suspend fun getTvDetail(tvId: Int): Flow<Outcome<TvDetail>> =
-    movieDataSource.getTvDetail(tvId).toOutcome { it.toDetailTv() }
+    movieDataSource.getTvDetail(tvId).toOutcome { it.toTvDetail() }
 
   override suspend fun getTvExternalIds(tvId: Int): Flow<Outcome<TvExternalIds>> =
     movieDataSource.getTvExternalIds(tvId).toOutcome { it.toExternalTvID() }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/model/tv/TvDetail.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/model/tv/TvDetail.kt
@@ -11,7 +11,7 @@ data class TvDetail(
   val listNetworksItem: List<NetworksItem?>? = null,
   val type: String? = null,
   val backdropPath: String? = null,
-  val listGenres: List<GenresItem>? = null,
+  val listGenres: List<GenresItem?>? = null,
   val popularity: Double? = null,
   val listProductionCountriesItem: List<ProductionCountriesItem?>? = null,
   val id: Int? = null,

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/DetailUIManager.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/DetailUIManager.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade
 import com.google.android.material.snackbar.Snackbar
+import com.waffiq.bazz_movies.core.common.utils.Constants.DEBOUNCE_LONG
 import com.waffiq.bazz_movies.core.common.utils.Constants.DEBOUNCE_SHORT
 import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.common.utils.Constants.NOT_AVAILABLE
@@ -48,6 +49,7 @@ import com.waffiq.bazz_movies.feature.detail.utils.helpers.CreateTableViewHelper
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.extractCrewDisplayNames
 import com.waffiq.bazz_movies.navigation.INavigator
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
@@ -348,8 +350,7 @@ class DetailUIManager(
     activity.lifecycleScope.launch {
       activity.repeatOnLifecycle(Lifecycle.State.STARTED) {
         errorState
-//          .debounce(DEBOUNCE_LONG)
-          .distinctUntilChanged()
+          .debounce(DEBOUNCE_LONG)
           .collect { errorMessage ->
             showSnackbarWarning(errorMessage)
           }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/TvMapper.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/TvMapper.kt
@@ -24,13 +24,13 @@ import com.waffiq.bazz_movies.feature.detail.utils.mappers.MediaDetailMapper.toS
 
 object TvMapper {
 
-  fun DetailTvResponse.toDetailTv() = TvDetail(
+  fun DetailTvResponse.toTvDetail() = TvDetail(
     originalLanguage = originalLanguage,
     numberOfEpisodes = numberOfEpisodes,
     listNetworksItem = networksResponse?.map { it?.toNetworksItem() },
     type = type,
     backdropPath = backdropPath,
-    listGenres = genres?.map { it?.toGenresItem() ?: GenresItem() },
+    listGenres = genres?.map { it?.toGenresItem() },
     popularity = popularity,
     listProductionCountriesItem = productionCountriesResponse?.map { it?.toProductionCountriesItem() },
     id = id,

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/data/repository/DetailTvRepositoryImplTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/data/repository/DetailTvRepositoryImplTest.kt
@@ -7,7 +7,7 @@ import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.vide
 import com.waffiq.bazz_movies.feature.detail.testutils.BaseDetailRepositoryImplTest
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.MediaDetailMapper.toMediaCredits
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.MediaDetailMapper.toVideo
-import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toDetailTv
+import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toTvDetail
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toExternalTvID
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -25,7 +25,7 @@ class DetailTvRepositoryImplTest : BaseDetailRepositoryImplTest() {
       mockResponse = mockResponse,
       dataSourceCall = { movieDataSource.getTvDetail(id) },
       repositoryCall = { repository.getTvDetail(id) },
-      expectedData = mockResponse.toDetailTv(),
+      expectedData = mockResponse.toTvDetail(),
       verifyDataSourceCall = { coVerify(atLeast = 1) { movieDataSource.getTvDetail(id) } }
     )
   }

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/WatchProvidersAdapterTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/WatchProvidersAdapterTest.kt
@@ -87,8 +87,11 @@ class WatchProvidersAdapterTest : BaseAdapterTest(){
 
     val testCases = listOf(
       pvd to "provider name1",
-      pvd.copy(providerId = 22, providerName = "provider name2") to "provider name2",
-      pvd.copy(providerId = 4, providerName = "provider name3") to "provider name3"
+      pvd.copy(providerId = 22, providerName = "name2") to "name2",
+      pvd.copy(providerId = 4, providerName = "name3") to "name3",
+      pvd.copy(providerId = 5,providerName = "name5", logoPath = "") to "name5",
+      pvd.copy(providerId = 6,providerName = "name6", logoPath = " ") to "name6",
+      pvd.copy(providerId = 7,providerName = "name7", logoPath = null) to "name7",
     )
 
     testCases.forEach { (provider, castId) ->

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/TvMapperTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/TvMapperTest.kt
@@ -1,29 +1,33 @@
 package com.waffiq.bazz_movies.feature.detail.utils.mappers
 
 import com.waffiq.bazz_movies.core.domain.GenresItem
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.GenresResponseItem
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.ProductionCountriesResponseItem
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv.ContentRatingsResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv.DetailTvResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv.ExternalIdResponse
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv.ProductionCompaniesResponseItem
+import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv.SpokenLanguagesResponseItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.ProductionCompaniesItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.ProductionCountriesItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.SpokenLanguagesItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.ContentRatingsItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.CreatedByItem
-import com.waffiq.bazz_movies.feature.detail.domain.model.tv.TvDetail
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.NetworksItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.SeasonsItem
+import com.waffiq.bazz_movies.feature.detail.domain.model.tv.TvDetail
 import com.waffiq.bazz_movies.feature.detail.domain.model.tv.TvExternalIds
 import com.waffiq.bazz_movies.feature.detail.testutils.HelperTest.detailTvResponse
-import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toDetailTv
 import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toExternalTvID
+import com.waffiq.bazz_movies.feature.detail.utils.mappers.TvMapper.toTvDetail
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class TvMapperTest {
 
   @Test
-  fun toDetailTv_withValidValues_returnsDetailTv() {
-    val detailTv: TvDetail = detailTvResponse.toDetailTv()
+  fun toTvDetail_withValidValues_returnsTvDetail() {
+    val detailTv: TvDetail = detailTvResponse.toTvDetail()
 
     assertEquals("en", detailTv.originalLanguage)
     assertEquals(10, detailTv.numberOfEpisodes)
@@ -63,10 +67,10 @@ class TvMapperTest {
   }
 
   @Test
-  fun toDetailTv_withDefaultValues_returnsDetailTv() {
+  fun toTvDetail_withDefaultValues_returnsTvDetail() {
     val detailTvResponse = DetailTvResponse()
 
-    val detailTv: TvDetail = detailTvResponse.toDetailTv()
+    val detailTv: TvDetail = detailTvResponse.toTvDetail()
     assertEquals(null, detailTv.listNetworksItem)
     assertEquals(null, detailTv.backdropPath)
     assertEquals(null, detailTv.listGenres)
@@ -80,7 +84,7 @@ class TvMapperTest {
   }
 
   @Test
-  fun toDetailTv_withEmptyLists_returnsDetailTv() {
+  fun toTvDetail_withEmptyLists_returnsTvDetail() {
     val detailTvResponse = DetailTvResponse(
       networksResponse = emptyList(),
       genres = emptyList(),
@@ -97,7 +101,7 @@ class TvMapperTest {
       ),
     )
 
-    val detailTv: TvDetail = detailTvResponse.toDetailTv()
+    val detailTv: TvDetail = detailTvResponse.toTvDetail()
 
     assertEquals(emptyList<NetworksItem>(), detailTv.listNetworksItem)
     assertEquals(emptyList<GenresItem>(), detailTv.listGenres)
@@ -113,7 +117,7 @@ class TvMapperTest {
   }
 
   @Test
-  fun toDetailTv_withNullItemsInList_returnsDetailTvWithEmptyGenres() {
+  fun toTvDetail_withNullItemsInList_returnsTvDetailWithEmptyGenres() {
     val detailTvResponse = DetailTvResponse(
       networksResponse = listOf(null, null),
       genres = listOf(null, null),
@@ -131,17 +135,57 @@ class TvMapperTest {
       nextEpisodeToAir = null,
     )
 
-    val detailTv: TvDetail = detailTvResponse.toDetailTv()
+    val detailTv: TvDetail = detailTvResponse.toTvDetail()
     assertEquals(2, detailTv.listNetworksItem?.size)
     assertEquals(2, detailTv.listGenres?.size)
-    assertEquals(GenresItem(), detailTv.listGenres?.get(0))
-    assertEquals(GenresItem(), detailTv.listGenres?.get(1))
+    assertEquals(null, detailTv.listGenres?.get(0))
+    assertEquals(null, detailTv.listGenres?.get(1))
     assertEquals(1, detailTv.listProductionCountriesItem?.size)
     assertEquals(1, detailTv.listSeasonsItem?.size)
     assertEquals(1, detailTv.listCreatedByItem?.size)
     assertEquals(1, detailTv.listSpokenLanguagesItem?.size)
     assertEquals(1, detailTv.listProductionCompaniesItem?.size)
     assertEquals(1, detailTv.contentRatings?.contentRatingsItem?.size)
+  }
+
+  @Test
+  fun toTvDetail_withGenresResponseItemNull_returnsTvDetail() {
+    val detailTvResponse = DetailTvResponse(genres = listOf(null))
+    detailTvResponse.toTvDetail()
+  }
+
+  @Test
+  fun toTvDetail_withProductionCountriesResponseItemNull_returnsTvDetail() {
+    val detailTvResponse = DetailTvResponse(
+      productionCountriesResponse = listOf(ProductionCountriesResponseItem())
+    )
+    detailTvResponse.toTvDetail()
+  }
+
+  @Test
+  fun toTvDetail_withContentRatingsItemResponseNull_returnsTvDetail() {
+    val detailTvResponse = DetailTvResponse(
+      contentRatingsResponse = ContentRatingsResponse(
+        contentRatingsItemResponse = null
+      )
+    )
+    detailTvResponse.toTvDetail()
+  }
+
+  @Test
+  fun toTvDetail_withSpokenLanguagesResponseNull_returnsTvDetail() {
+    val detailTvResponse = DetailTvResponse(
+      spokenLanguagesResponse = listOf(SpokenLanguagesResponseItem())
+    )
+    detailTvResponse.toTvDetail()
+  }
+
+  @Test
+  fun toTvDetail_withProductionCompaniesResponseNull_returnsTvDetail() {
+    val detailTvResponse = DetailTvResponse(
+      productionCompaniesResponse = listOf(ProductionCompaniesResponseItem())
+    )
+    detailTvResponse.toTvDetail()
   }
 
   @Test


### PR DESCRIPTION
### **User description**
### Changes Made

- Create missing test for feature detail module


___

### **PR Type**
Tests


___

### **Description**
- Create comprehensive test for backdrop image display

- Add interaction tests for rating and favorite/watchlist

- Refactor existing tests and improve mapper handling

- Fix null handling in TV detail mapping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MediaDetailActivityTest"] --> B["MediaDetailActivityBackdropTest"]
  A --> C["MediaDetailActivityInteractionTest"]
  B --> D["Backdrop Display Tests"]
  C --> E["Rating & Favorite Tests"]
  F["TvMapper"] --> G["Null Handling Fix"]
  H["DetailUIManager"] --> I["Error Observer Debounce"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>MediaDetailActivityBackdropTest.kt</strong><dd><code>Create comprehensive backdrop image display tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/296/files#diff-5f2b21956803f9048f17eebcb0b874869fb656024158061f2ce6470f8fddbc38">+243/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MediaDetailActivityInteractionTest.kt</strong><dd><code>Add rating and favorite/watchlist interaction tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/296/files#diff-3d2890f7e7e45e0eda432be50701ee7307de8a19ce22fa4e5bbbfc43cb632b1d">+93/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MediaDetailActivityTest.kt</strong><dd><code>Remove backdrop tests moved to separate file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/296/files#diff-b1ee2882c83060d4bba1fe15d157c8a03a7bd0acc298a4d8ed9aa03e6ee74426">+0/-80</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DetailTvRepositoryImplTest.kt</strong><dd><code>Update test to use renamed mapper method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/296/files#diff-90870f87e58dc0a87bd41f8d69f822dba8ec6632754de9873657dda435d90697">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WatchProvidersAdapterTest.kt</strong><dd><code>Add test cases for empty logo paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/296/files#diff-3208c01512f5a34056b965a5aee62e2a3017d41eae5275657c6e33d33600d2cd">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TvMapperTest.kt</strong><dd><code>Update tests for improved null handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/296/files#diff-3c736f4840348a9b5a934a4e59190918576f3defa8687f00bbc6672357c9a529">+56/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>DetailRepositoryImpl.kt</strong><dd><code>Update mapper method name for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/296/files#diff-6021699e657fe139896af400af30e156338211b916a457e7b190559efdd2275a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>TvDetail.kt</strong><dd><code>Allow nullable genres in TV detail model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/296/files#diff-4888109355dbd373dd999fc7838b1236f69d075612f24f5b50c17384bcb6cb15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TvMapper.kt</strong><dd><code>Fix null handling in TV detail mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/296/files#diff-28a0f5776fb49425af19720520603b199354ea7e3f6494a6d9406c020f8f5a60">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>DetailUIManager.kt</strong><dd><code>Add debounce to error observer flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/296/files#diff-1675de97bfb6b59fa7d1fc402e07915271140f8a6443efa1407c24fe7f735b46">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

