### PR TITLE
chore(ci): run follow-up job only on Renovate PR merges to main

### DIFF
--- a/.github/workflows/lint_dependency.yml
+++ b/.github/workflows/lint_dependency.yml
@@ -1,7 +1,9 @@
 name: Auto PR after Renovate Merge
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - main
 
@@ -13,8 +15,7 @@ env:
 jobs:
   create-follow-up-pr:
     runs-on: ubuntu-latest
-    # Check if the push was from a renovate merge
-    if: github.actor == 'renovate[bot]' || github.event.sender.login == 'renovate[bot]'
+    if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'renovate[bot]'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
### **User description**
### Changes Made

- Updated workflow to run follow-up jobs only when Renovate PRs are merged into main
- Restricted trigger to pull_request closed events with renovate[bot] as author


___

### **PR Type**
Other


___

### **Description**
- Changed workflow trigger from push to pull_request closed events

- Restricted execution to merged Renovate PRs only

- Updated condition logic for better PR merge detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["push trigger"] --> B["pull_request closed trigger"]
  C["actor check"] --> D["merged PR + user check"]
  B --> E["Renovate merge detection"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lint_dependency.yml</strong><dd><code>Update workflow trigger and conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/lint_dependency.yml

<ul><li>Changed trigger from <code>push</code> to <code>pull_request</code> with <code>closed</code> type<br> <li> Updated condition to check for merged PRs from <code>renovate[bot]</code><br> <li> Refined workflow execution logic for Renovate merges</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/318/files#diff-7ee98fc0fe5cfc34bc49d9a59d4cc65de4a7b1216a17e66420195af268382f04">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

