### PR TITLE
chore(ci): update Renovate configuration for commit message prefixes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,20 @@
   },
   packageRules: [
     {
+      // Default prefix for all dependencies
+      matchPackageNames: [
+        '*',
+      ],
+      commitMessagePrefix: 'chore(deps):',
+    },
+    {
+      // Specific prefix for GitHub Actions
+      matchDepTypes: [
+        'action',
+      ],
+      commitMessagePrefix: 'chore(ci):',
+    },
+    {
       groupName: 'Kotlin and KSP',
       matchPackageNames: [
         'org.jetbrains.kotlin{/,}**',
@@ -21,6 +35,7 @@
         '/kotlin/',
         '/ksp/',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'AndroidX Core',
@@ -29,6 +44,7 @@
         'androidx.activity{/,}**',
         'androidx.fragment{/,}**',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'AndroidX UI Components',
@@ -40,36 +56,42 @@
         '/androidx.swiperefreshlayout/',
         '/androidx.viewpager2/',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'AndroidX Lifecycle',
       matchPackageNames: [
         'androidx.lifecycle{/,}**',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'AndroidX Navigation',
       matchPackageNames: [
         'androidx.navigation{/,}**',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'AndroidX Room',
       matchPackageNames: [
         'androidx.room{/,}**',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'AndroidX Paging',
       matchPackageNames: [
         'androidx.paging{/,}**',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'Firebase',
       matchPackageNames: [
         'com.google.firebase{/,}**',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'Google Play Services',
@@ -77,6 +99,7 @@
         '/com.google.android.gms/',
         '/com.google.android.play/',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'Networking Libraries',
@@ -85,6 +108,7 @@
         '/com.squareup.moshi/',
         '/com.squareup.okhttp3/',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'Testing Libraries',
@@ -97,12 +121,14 @@
         '/androidx.arch.core:core-testing/',
         '/com.google.truth/',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'Hilt DI',
       matchPackageNames: [
         'com.google.dagger{/,}**',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'Gradle Plugins',
@@ -112,6 +138,7 @@
         '/com.android.application/',
         '/com.android.library/',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'Development Tools',
@@ -120,6 +147,7 @@
         '/io.gitlab.arturbosch.detekt/',
         '/com.dropbox.dependency-guard/',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
     {
       groupName: 'GitHub Actions - Code Coverage',
@@ -131,6 +159,7 @@
         '/^codecov/test-results-action$/',
         '/^codacy/codacy-coverage-reporter-action$/',
       ],
+      commitMessagePrefix: 'chore(ci):',
     },
     {
       groupName: 'GitHub Actions',
@@ -149,6 +178,7 @@
         '!/^codecov//',
         '!/^codacy//',
       ],
+      commitMessagePrefix: 'chore(ci):',
     },
     {
       matchUpdateTypes: [
@@ -163,6 +193,7 @@
         '!/com.google.devtools.ksp/',
         '!/androidx.room/',
       ],
+      commitMessagePrefix: 'chore(deps):',
     },
   ],
   ignoreDeps: [],


### PR DESCRIPTION
### **User description**
### Changes Made

- Update Renovate configuration for commit message prefixes


___

### **PR Type**
Enhancement


___

### **Description**
- Add default commit message prefix for all dependencies

- Add specific prefix for GitHub Actions dependencies

- Apply consistent prefixes across all package rule groups

- Standardize commit message format for dependency updates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Renovate Config"] --> B["Default Rule<br/>chore(deps):"]
  A --> C["GitHub Actions Rule<br/>chore(ci):"]
  B --> D["All Package Groups<br/>Kotlin, AndroidX, Firebase, etc."]
  C --> E["Action Dependencies"]
  D --> F["Consistent Commit Messages"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json5</strong><dd><code>Add commit message prefixes to all package rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/renovate.json5

<ul><li>Added two new default package rules at the beginning with commit <br>message prefixes<br> <li> Added <code>commitMessagePrefix: 'chore(deps):'</code> to all existing dependency <br>package groups<br> <li> Added <code>commitMessagePrefix: 'chore(ci):'</code> to GitHub Actions-specific <br>package groups<br> <li> Ensures consistent and standardized commit message formatting across <br>all dependency updates</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/391/files#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

