### PR TITLE
chore(ci): add commitMessageTopic for dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,18 +30,7 @@
       commitMessageTopic: 'update action {{{depName}}}'
     },
     {
-      groupName: 'Kotlin and KSP',
-      matchPackageNames: [
-        'org.jetbrains.kotlin{/,}**',
-        'com.google.devtools.ksp{/,}**',
-        '/kotlin/',
-        '/ksp/',
-      ],
-      commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
-    },
-    {
-      groupName: 'AndroidX Core',
+      groupName: 'androidX core',
       matchPackageNames: [
         'androidx.core{/,}**',
         'androidx.activity{/,}**',
@@ -51,20 +40,7 @@
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {
-      groupName: 'AndroidX UI Components',
-      matchPackageNames: [
-        '/androidx.appcompat/',
-        '/androidx.cardview/',
-        '/androidx.constraintlayout/',
-        '/androidx.recyclerview/',
-        '/androidx.swiperefreshlayout/',
-        '/androidx.viewpager2/',
-      ],
-      commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
-    },
-    {
-      groupName: 'AndroidX Lifecycle',
+      groupName: 'androidX lifecycle',
       matchPackageNames: [
         'androidx.lifecycle{/,}**',
       ],
@@ -72,7 +48,7 @@
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {
-      groupName: 'AndroidX Navigation',
+      groupName: 'androidX navigation',
       matchPackageNames: [
         'androidx.navigation{/,}**',
       ],
@@ -80,7 +56,7 @@
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {
-      groupName: 'AndroidX Room',
+      groupName: 'androidX room',
       matchPackageNames: [
         'androidx.room{/,}**',
       ],
@@ -88,7 +64,7 @@
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {
-      groupName: 'AndroidX Paging',
+      groupName: 'androidX paging',
       matchPackageNames: [
         'androidx.paging{/,}**',
       ],
@@ -96,7 +72,7 @@
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {
-      groupName: 'Firebase',
+      groupName: 'firebase',
       matchPackageNames: [
         'com.google.firebase{/,}**',
       ],
@@ -104,7 +80,7 @@
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {
-      groupName: 'Google Play Services',
+      groupName: 'google services',
       matchPackageNames: [
         '/com.google.android.gms/',
         '/com.google.android.play/',
@@ -113,7 +89,7 @@
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {
-      groupName: 'Networking Libraries',
+      groupName: 'networking libraries',
       matchPackageNames: [
         '/com.squareup.retrofit2/',
         '/com.squareup.moshi/',
@@ -123,7 +99,7 @@
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {
-      groupName: 'Testing Libraries',
+      groupName: 'testing libraries',
       matchPackageNames: [
         '/junit/',
         '/mockito/',
@@ -137,7 +113,7 @@
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {
-      groupName: 'Hilt DI',
+      groupName: 'hilt dependency injection',
       matchPackageNames: [
         'com.google.dagger{/,}**',
       ],
@@ -145,7 +121,7 @@
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {
-      groupName: 'Gradle Plugins',
+      groupName: 'android gradle plugin',
       separateMinorPatch: true,
       matchPackageNames: [
         '/com.android.tools.build/',
@@ -153,29 +129,6 @@
         '/com.android.library/',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
-    },
-    {
-      groupName: 'Development Tools',
-      matchPackageNames: [
-        '/com.squareup.leakcanary/',
-        '/io.gitlab.arturbosch.detekt/',
-        '/com.dropbox.dependency-guard/',
-      ],
-      commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
-    },
-    {
-      groupName: 'GitHub Actions - Code Coverage',
-      digest: {
-        enabled: false,
-      },
-      matchPackageNames: [
-        '/^codecov/codecov-action$/',
-        '/^codecov/test-results-action$/',
-        '/^codacy/codacy-coverage-reporter-action$/',
-      ],
-      commitMessagePrefix: 'chore(ci):',
       commitMessageTopic: 'update {{{groupName}}}',
     },
     {


### PR DESCRIPTION
### **User description**
### Changes Made

- Add commitMessageTopic for dependency updates


___

### **PR Type**
Enhancement


___

### **Description**
- Add `commitMessageTopic` to all dependency update rules

- Standardize group names to lowercase format

- Remove Kotlin/KSP group (no longer tied together)

- Remove Development Tools and GitHub Actions Code Coverage groups


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["renovate.json5"] -->|Add commitMessageTopic| B["Standardized commit messages"]
  A -->|Refactor group names| C["Lowercase naming convention"]
  A -->|Remove groups| D["Simplified configuration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json5</strong><dd><code>Standardize commit messages and refactor dependency groups</code></dd></summary>
<hr>

.github/renovate.json5

<ul><li>Added <code>commitMessageTopic</code> field to all 12 dependency package rules for <br>consistent commit message formatting<br> <li> Refactored group names to lowercase format (e.g., 'Kotlin and KSP' → <br>removed, 'AndroidX Core' → 'androidX core')<br> <li> Removed 'Kotlin and KSP' group as KSP is no longer tied to Kotlin <br>compiler version<br> <li> Removed 'Development Tools' and 'GitHub Actions - Code Coverage' <br>groups for simplified maintenance<br> <li> Consolidated GitHub Actions rules by removing separate code coverage <br>action group</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/392/files#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790">+26/-54</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

