### PR TITLE
chore(ci): add commitMessageAction to Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,6 @@
         '*',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update dependency {{{depName}}}'
     },
     {
       // Specific prefix for GitHub Actions
@@ -28,7 +27,6 @@
         'action',
       ],
       commitMessagePrefix: 'chore(ci):',
-      commitMessageTopic: 'update action {{{depName}}}'
     },
     {
       groupName: 'androidX core',
@@ -38,7 +36,6 @@
         'androidx.fragment{/,}**',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'androidX lifecycle',
@@ -46,7 +43,6 @@
         'androidx.lifecycle{/,}**',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'androidX navigation',
@@ -54,7 +50,6 @@
         'androidx.navigation{/,}**',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'androidX room',
@@ -62,7 +57,6 @@
         'androidx.room{/,}**',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'androidX paging',
@@ -70,7 +64,6 @@
         'androidx.paging{/,}**',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'firebase',
@@ -78,7 +71,6 @@
         'com.google.firebase{/,}**',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'google services',
@@ -87,7 +79,6 @@
         '/com.google.android.play/',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'networking libraries',
@@ -97,7 +88,6 @@
         '/com.squareup.okhttp3/',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'testing libraries',
@@ -111,7 +101,6 @@
         '/com.google.truth/',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'hilt dependency injection',
@@ -119,7 +108,6 @@
         'com.google.dagger{/,}**',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'android gradle plugin',
@@ -130,7 +118,6 @@
         '/com.android.library/',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       groupName: 'GitHub Actions',
@@ -150,7 +137,6 @@
         '!/^codacy//',
       ],
       commitMessagePrefix: 'chore(ci):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
     {
       matchUpdateTypes: [
@@ -166,7 +152,6 @@
         '!/androidx.room/',
       ],
       commitMessagePrefix: 'chore(deps):',
-      commitMessageTopic: 'update {{{groupName}}}',
     },
   ],
   ignoreDeps: [],


### PR DESCRIPTION
### **User description**
### Changes Made 

- Add commitMessageAction to Renovate config


___

### **PR Type**
Enhancement


___

### **Description**
- Add `commitMessageAction: 'update'` to Renovate config

- Remove `commitMessageTopic` from all dependency groups

- Simplify commit message generation across all package rules


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Renovate Config"] -->|Add| B["commitMessageAction: update"]
  A -->|Remove| C["commitMessageTopic from all groups"]
  B --> D["Simplified commit messages"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json5</strong><dd><code>Renovate config: add action, remove topics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/renovate.json5

<ul><li>Added global <code>commitMessageAction: 'update'</code> setting<br> <li> Removed <code>commitMessageTopic</code> field from 13 dependency group rules<br> <li> Simplified commit message configuration by using global action instead <br>of per-group topics</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/393/files#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790">+1/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

