### PR TITLE
test: add missing test for media helper

### DIFF
--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/MediaHelper.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/MediaHelper.kt
@@ -35,20 +35,19 @@ object MediaHelper {
 
     // Process each job title and create pairs of (displayName, joinedNames)
     return jobToNamesMap.mapNotNull { (jobTitle, displayName) ->
-      crewByJob[jobTitle] // Get crew members for this job title
-        ?.takeIf { it.isNotEmpty() } // Only proceed if we have crew members
-        ?.let { members ->
-          // Create pair: display name -> comma-separated crew names
-          displayName to members.joinToString { it.name.orEmpty() }
-        }
+      val members = crewByJob[jobTitle].orEmpty().filter { !it.name.isNullOrEmpty() }
+      if (members.isNotEmpty()) displayName to members.joinToString { it.name!! } else null
     }.unzip() // Split pairs into two separate lists: [displayNames], [joinedNames]
   }
 
   fun Video.toLink(): String {
-    return this.results
-      .filter { it.official == true && it.type.equals("Trailer", ignoreCase = true) }
-      .map { it.key }.firstOrNull()?.trim()
-      ?: this.results.map { it.key }.firstOrNull()?.trim().orEmpty()
+    val preferred = results
+      .filter { it.official == true && it.type.equals("Trailer", ignoreCase = true) } // get official and trailer
+      .map { it.key } // get the key value (youtube id video)
+      .firstOrNull()
+      ?.trim()
+
+    return preferred ?: results.map { it.key }.firstOrNull()?.trim().orEmpty() // if null use valid link
   }
 
   fun getTransformTMDBScore(tmdbScore: Double?): String? =

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/MediaDetailHelperTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/MediaDetailHelperTest.kt
@@ -42,6 +42,57 @@ class MediaDetailHelperTest {
   }
 
   @Test
+  fun detailCrew_withNullCrewName_filtersOut() {
+    val crew = listOf(
+      MediaCrewItem(job = "Director", name = null),
+      MediaCrewItem(job = "Writer", name = "Jane Smith")
+    )
+    val (displayNames, joinedNames) = MediaHelper.extractCrewDisplayNames(crew)
+
+    assertEquals(listOf("Writer"), displayNames) // exclude null job
+    assertEquals(listOf("Jane Smith"), joinedNames) // exclude null name
+  }
+
+  @Test
+  fun detailCrew_withEmptyStringName_filtersOut() {
+    val crew = listOf(
+      MediaCrewItem(job = "Writer", name = "Jane Smith"),
+      MediaCrewItem(job = "Writer", name = ""),
+      MediaCrewItem(job = "Writer", name = "Bob Jones")
+    )
+    val (displayNames, joinedNames) = MediaHelper.extractCrewDisplayNames(crew)
+
+    assertEquals(listOf("Writer"), displayNames)
+    assertEquals(listOf("Jane Smith, Bob Jones"), joinedNames)
+  }
+
+  @Test
+  fun detailCrew_withAllNullOrEmptyNames_filtersOutJob() {
+    val crew = listOf(
+      MediaCrewItem(job = "Director", name = null),
+      MediaCrewItem(job = "Director", name = ""),
+      MediaCrewItem(job = "Writer", name = "Jane Smith")
+    )
+    val (displayNames, joinedNames) = MediaHelper.extractCrewDisplayNames(crew)
+
+    assertEquals(listOf("Writer"), displayNames)
+    assertEquals(listOf("Jane Smith"), joinedNames)
+  }
+
+  @Test
+  fun detailCrew_withMultipleNamesIncludingNull_joinsCorrectly() {
+    val crew = listOf(
+      MediaCrewItem(job = "Writer", name = "Jane Smith"),
+      MediaCrewItem(job = "Writer", name = null),
+      MediaCrewItem(job = "Writer", name = "Bob Jones")
+    )
+    val (displayNames, joinedNames) = MediaHelper.extractCrewDisplayNames(crew)
+
+    assertEquals(listOf("Writer"), displayNames)
+    assertEquals(listOf("Jane Smith, Bob Jones"), joinedNames) //
+  }
+
+  @Test
   fun detailCrew_withEmptyCrewList_returnsEmptyLists() {
     val (displayNames, joinedNames) = MediaHelper.extractCrewDisplayNames(emptyList())
 
@@ -88,11 +139,38 @@ class MediaDetailHelperTest {
   }
 
   @Test
+  fun toLink_withOfficialButNotTrailer_returnsFallbackKey() {
+    val video = Video(
+      results = listOf(
+        VideoItem(official = true, type = "Teaser", name = "Teaser", key = "teaser_key"),
+        VideoItem(official = false, type = "Clip", name = "Clip", key = "clip_key")
+      )
+    )
+    val result = video.toLink()
+
+    assertEquals("teaser_key", result)
+  }
+
+  @Test
   fun toLink_withEmptyResults_returnsEmptyString() {
     val video = Video(results = emptyList())
     val result = video.toLink()
 
     assertEquals("", result)
+  }
+
+  @Test
+  fun toLink_withNoOfficialTrailer_usesFallback() {
+    val video = Video(
+      results = listOf(
+        VideoItem(name = "1", official = false, type = "Trailer", key = "unofficial_trailer"),
+        VideoItem(name = "2", official = true, type = "Teaser", key = "official_teaser"),
+        VideoItem(name = "3", official = false, type = "Clip", key = "clip_key")
+      )
+    )
+    val result = video.toLink()
+
+    assertEquals("unofficial_trailer", result)
   }
 
   @Test


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Refactored crew filtering logic to handle null/empty names explicitly

- Added four new test cases for crew extraction edge cases

- Improved video link selection with clearer fallback logic

- Enhanced code readability with inline comments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MediaHelper.kt<br/>Refactored Logic"] -->|"Cleaner null handling"| B["extractCrewDisplayNames"]
  A -->|"Improved fallback"| C["toLink"]
  D["MediaDetailHelperTest.kt<br/>New Tests"] -->|"4 crew tests"| B
  D -->|"2 video tests"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MediaHelper.kt</strong><dd><code>Refactor crew and video link extraction logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/MediaHelper.kt

<ul><li>Simplified <code>extractCrewDisplayNames</code> to explicitly filter null/empty <br>names using <code>orEmpty()</code> and <code>filter()</code><br> <li> Changed from chained <code>takeIf</code>/<code>let</code> to direct conditional assignment for <br>clarity<br> <li> Refactored <code>toLink()</code> to separate preferred trailer selection from <br>fallback logic<br> <li> Added inline comments explaining filter criteria and fallback behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/422/files#diff-ccf8dd511f7d297a7024706d2557eb4d4f9a80ceb1906bae2dedfff563cb6c1d">+9/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MediaDetailHelperTest.kt</strong><dd><code>Add edge case tests for crew and video helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/MediaDetailHelperTest.kt

<ul><li>Added test for null crew names filtering in <br><code>detailCrew_withNullCrewName_filtersOut()</code><br> <li> Added test for empty string crew names filtering in <br><code>detailCrew_withEmptyStringName_filtersOut()</code><br> <li> Added test for all-null/empty crew members excluding job in <br><code>detailCrew_withAllNullOrEmptyNames_filtersOutJob()</code><br> <li> Added test for mixed null and valid names in <br><code>detailCrew_withMultipleNamesIncludingNull_joinsCorrectly()</code><br> <li> Added test for official non-trailer videos using fallback in <br><code>toLink_withOfficialButNotTrailer_returnsFallbackKey()</code><br> <li> Added test for no official trailer scenario in <br><code>toLink_withNoOfficialTrailer_usesFallback()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/422/files#diff-7e7cbe7de93d65ca2a1f8bc2bcef100018b3067ffbbde4eeb89f5ff36f80b4ef">+78/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

