### PR TITLE
feat: use original backdrop size for feature and detail pages

### DIFF
--- a/core/common/src/main/kotlin/com/waffiq/bazz_movies/core/common/utils/Constants.kt
+++ b/core/common/src/main/kotlin/com/waffiq/bazz_movies/core/common/utils/Constants.kt
@@ -5,6 +5,7 @@ object Constants {
 
   const val TMDB_IMG_LINK_BACKDROP_W300 = "https://image.tmdb.org/t/p/w300/"
   const val TMDB_IMG_LINK_BACKDROP_W780 = "https://image.tmdb.org/t/p/w780/"
+  const val TMDB_IMG_LINK_BACKDROP_ORIGINAL = "https://image.tmdb.org/t/p/original/"
   const val TMDB_IMG_LINK_POSTER_W185 = "https://image.tmdb.org/t/p/w185/"
   const val TMDB_IMG_LINK_POSTER_W500 = "https://image.tmdb.org/t/p/w500/"
   const val TMDB_IMG_LINK_ORIGINAL = "https://www.themoviedb.org/t/p/original"

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/DetailUIManager.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/DetailUIManager.kt
@@ -21,7 +21,7 @@ import com.waffiq.bazz_movies.core.common.utils.Constants.DEBOUNCE_LONG
 import com.waffiq.bazz_movies.core.common.utils.Constants.DEBOUNCE_SHORT
 import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.common.utils.Constants.NOT_AVAILABLE
-import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_BACKDROP_W780
+import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_BACKDROP_ORIGINAL
 import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_POSTER_W500
 import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_backdrop_error_filled
 import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_bazz_placeholder_backdrops
@@ -151,7 +151,7 @@ class DetailUIManager(
         ic_backdrop_error_filled
 
       !dataExtra.backdropPath.isNullOrEmpty() ->
-        TMDB_IMG_LINK_BACKDROP_W780 + dataExtra.backdropPath
+        TMDB_IMG_LINK_BACKDROP_ORIGINAL + dataExtra.backdropPath
 
       !dataExtra.posterPath.isNullOrEmpty() ->
         TMDB_IMG_LINK_POSTER_W500 + dataExtra.posterPath

--- a/feature/home/src/main/kotlin/com/waffiq/bazz_movies/feature/home/ui/FeaturedFragment.kt
+++ b/feature/home/src/main/kotlin/com/waffiq/bazz_movies/feature/home/ui/FeaturedFragment.kt
@@ -11,7 +11,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade
 import com.google.android.material.snackbar.Snackbar
 import com.waffiq.bazz_movies.core.common.utils.Constants.NAN
-import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_BACKDROP_W780
+import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_BACKDROP_ORIGINAL
 import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_bazz_placeholder_search
 import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_broken_image
 import com.waffiq.bazz_movies.core.designsystem.R.string.binding_error
@@ -78,7 +78,7 @@ class FeaturedFragment : Fragment() {
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,
-    savedInstanceState: Bundle?
+    savedInstanceState: Bundle?,
   ): View {
     _binding = FragmentFeaturedBinding.inflate(inflater, container, false)
     return binding.root
@@ -114,7 +114,7 @@ class FeaturedFragment : Fragment() {
 
   private fun showMainPicture() {
     Glide.with(requireContext())
-      .load(TMDB_IMG_LINK_BACKDROP_W780 + "bQXAqRx2Fgc46uCVWgoPz5L5Dtr.jpg") // URL movie poster
+      .load(TMDB_IMG_LINK_BACKDROP_ORIGINAL + "bQXAqRx2Fgc46uCVWgoPz5L5Dtr.jpg") // URL movie poster
       .placeholder(ic_bazz_placeholder_search)
       .transition(withCrossFade())
       .error(ic_broken_image)


### PR DESCRIPTION
### **User description**
### Changes Made

- To support wide screen device, we use original backdrop to make sure the image quality is not blur


___

### **PR Type**
Enhancement


___

### **Description**
- Replace W780 backdrop URLs with original resolution for better image quality

- Add new constant for TMDB original backdrop image endpoint

- Update detail page and featured page to use original backdrop size

- Improve image quality on wide screen devices


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add TMDB_IMG_LINK_BACKDROP_ORIGINAL constant"] --> B["Update DetailUIManager"]
  A --> C["Update FeaturedFragment"]
  B --> D["Display high-quality backdrops"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Constants.kt</strong><dd><code>Add original backdrop image URL constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/common/src/main/kotlin/com/waffiq/bazz_movies/core/common/utils/Constants.kt

<ul><li>Added new constant <code>TMDB_IMG_LINK_BACKDROP_ORIGINAL</code> for original <br>resolution backdrop images<br> <li> Provides endpoint URL for TMDB original quality image size</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/436/files#diff-554ac328e5971726dd0cb5d62824d492a5f69a016b2267e3aa7f4f9af64733f0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DetailUIManager.kt</strong><dd><code>Use original resolution for detail page backdrops</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/DetailUIManager.kt

<ul><li>Changed import from <code>TMDB_IMG_LINK_BACKDROP_W780</code> to <br><code>TMDB_IMG_LINK_BACKDROP_ORIGINAL</code><br> <li> Updated <code>showBackdropAndPoster()</code> method to use original resolution for <br>backdrop images<br> <li> Maintains fallback to poster image if backdrop is unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/436/files#diff-1675de97bfb6b59fa7d1fc402e07915271140f8a6443efa1407c24fe7f735b46">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FeaturedFragment.kt</strong><dd><code>Use original resolution for featured page backdrop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

feature/home/src/main/kotlin/com/waffiq/bazz_movies/feature/home/ui/FeaturedFragment.kt

<ul><li>Changed import from <code>TMDB_IMG_LINK_BACKDROP_W780</code> to <br><code>TMDB_IMG_LINK_BACKDROP_ORIGINAL</code><br> <li> Updated <code>showMainPicture()</code> method to load featured image with original <br>resolution<br> <li> Minor formatting fix: added trailing comma in <code>onCreateView()</code> parameter <br>list</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/436/files#diff-4d8cecdbf6cea563a95cd72a06b440da100536bc85ce2cca497938eaade68d5f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

