### PR TITLE
chore: remove enableUnitTestCoverage from release build

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationJacocoConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationJacocoConventionPlugin.kt
@@ -12,15 +12,8 @@ class AndroidApplicationJacocoConventionPlugin : Plugin<Project> {
   override fun apply(target: Project) {
     with(target) {
       apply<JacocoPlugin>()
-      val androidExtension = extensions.getByType<ApplicationExtension>()
-
-      androidExtension.buildTypes.configureEach {
-        enableAndroidTestCoverage = true
-        enableUnitTestCoverage = true
-      }
-
       // Set the JaCoCo version to match the one used by the Android Gradle Plugin
-      androidExtension.testCoverage {
+      extensions.getByType<ApplicationExtension>().testCoverage {
         jacocoVersion = libs.findVersion("jacoco").get().toString()
       }
       configureJacoco(


### PR DESCRIPTION
### **User description**
Set `enableUnitTestCoverage = true` on release build can generate debuggable APK. Only enabled it via `commonExtension.buildTypes.named("debug")` inside configureJacoco.

  Reference:
  https://stackoverflow.com/a/40084149/12159309
  https://stackoverflow.com/a/66562788/12159309


___

### **PR Type**
Bug fix


___

### **Description**
- Remove `enableUnitTestCoverage` from release build configuration

- Prevent generation of debuggable APKs in release builds

- Enable unit test coverage only in debug builds via `configureJacoco`

- Simplify code by removing unnecessary `androidExtension` variable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AndroidApplicationJacocoConventionPlugin"] -->|removes| B["enableUnitTestCoverage from buildTypes.configureEach"]
  B -->|prevents| C["Debuggable APKs in release builds"]
  A -->|keeps| D["testCoverage configuration"]
  A -->|delegates| E["configureJacoco for debug builds"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AndroidApplicationJacocoConventionPlugin.kt</strong><dd><code>Remove test coverage from release build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-logic/convention/src/main/kotlin/AndroidApplicationJacocoConventionPlugin.kt

<ul><li>Removed <code>enableAndroidTestCoverage</code> and <code>enableUnitTestCoverage</code> from <br><code>buildTypes.configureEach</code> block<br> <li> Eliminated unnecessary <code>androidExtension</code> variable assignment<br> <li> Simplified <code>testCoverage</code> configuration to use inline extension access<br> <li> Preserved JaCoCo version configuration and <code>configureJacoco</code> delegation</ul>


</details>


  </td>
  <td><a href="https://github.com/waffiqaziz/BAZZ-Movies/pull/465/files#diff-90ab010052804ea0d56c2c94b30b8098fa9d9b036e6f0de2a6cc2616a4e3cd01">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

