### PR TITLE
feat: enable navigation to recommendation list from detail page

### DIFF
--- a/core/instrumentationtest/src/main/kotlin/com/waffiq/bazz_movies/core/instrumentationtest/ViewMatcher.kt
+++ b/core/instrumentationtest/src/main/kotlin/com/waffiq/bazz_movies/core/instrumentationtest/ViewMatcher.kt
@@ -4,9 +4,17 @@ import android.view.View
 import android.widget.ImageView
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.drawable.toBitmap
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.ViewInteraction
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.BoundedMatcher
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.Description
 import org.hamcrest.Matcher
+import org.hamcrest.Matchers.not
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist as notExist
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed as isViewDisplayed
 
 object ViewMatcher {
   fun withDrawable(resourceId: Int): Matcher<View> {
@@ -29,5 +37,23 @@ object ViewMatcher {
         return expectedBitmap.sameAs(actualBitmap)
       }
     }
+  }
+
+  fun Int.doesNotExist() {
+    onView(withId(this)).check(notExist())
+  }
+
+  fun Int.isNotDisplayed() {
+    onView(withId(this)).check(matches(not(isViewDisplayed())))
+  }
+
+  fun Int.isDisplayed() {
+    onView(withId(this)).check(matches(isViewDisplayed()))
+  }
+
+  fun Int.view(): ViewInteraction = onView(withId(this))
+
+  fun Int.hasText(text: String) {
+    view().check(matches(withText(text))).check(matches(isViewDisplayed()))
   }
 }

--- a/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/testutils/MediaDetailActivityTestHelper.kt
+++ b/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/testutils/MediaDetailActivityTestHelper.kt
@@ -43,7 +43,7 @@ import kotlinx.coroutines.flow.asStateFlow
 class MediaDetailActivityTestHelper : MediaDetailActivityTestSetup {
 
   override val recommendations = MutableStateFlow<PagingData<MediaItem>>(
-    value = PagingData.empty()
+    value = PagingData.from(listOf(testMediaItem))
   )
   override val errorEvent = MutableSharedFlow<String>(extraBufferCapacity = 1)
   override val toastEvent = MutableSharedFlow<Int>(extraBufferCapacity = 1)
@@ -126,6 +126,7 @@ class MediaDetailActivityTestHelper : MediaDetailActivityTestSetup {
   override fun setupNavigatorMocks(mockNavigator: INavigator) {
     every { mockNavigator.openDetails(any(), any()) } just Runs
     every { mockNavigator.openPersonDetails(any(), any()) } just Runs
+    every { mockNavigator.openList(any(), any()) } just Runs
   }
 
   override fun initializeTest(context: Context) {

--- a/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailActivityInteractionTest.kt
+++ b/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailActivityInteractionTest.kt
@@ -5,6 +5,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.action.ViewActions.swipeDown
 import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -15,6 +16,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.waffiq.bazz_movies.core.common.utils.Constants.NAN
 import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
+import com.waffiq.bazz_movies.core.designsystem.R.id.button
 import com.waffiq.bazz_movies.core.designsystem.R.string.cancel
 import com.waffiq.bazz_movies.core.designsystem.R.string.submit
 import com.waffiq.bazz_movies.feature.detail.R.id.btn_back
@@ -23,6 +25,7 @@ import com.waffiq.bazz_movies.feature.detail.R.id.btn_watchlist
 import com.waffiq.bazz_movies.feature.detail.R.id.iv_poster
 import com.waffiq.bazz_movies.feature.detail.R.id.rating_bar_action
 import com.waffiq.bazz_movies.feature.detail.R.id.rv_genre
+import com.waffiq.bazz_movies.feature.detail.R.id.rv_recommendation
 import com.waffiq.bazz_movies.feature.detail.R.id.score_scrollview
 import com.waffiq.bazz_movies.feature.detail.R.id.tv_score_your_score
 import com.waffiq.bazz_movies.feature.detail.R.id.your_score_viewGroup
@@ -218,7 +221,7 @@ class MediaDetailActivityInteractionTest :
           listType = BY_GENRE,
           mediaType = testMediaItem.mediaType,
           title = "",
-          genreId = testMediaItem.listGenreIds?.get(0) ?: 0,
+          id = testMediaItem.listGenreIds?.get(0) ?: 0,
         )
       )
     }
@@ -326,13 +329,13 @@ class MediaDetailActivityInteractionTest :
 
       // post to watchlist when not yet
       updateState {
-        copy(isFavorite=false, isWatchlist = false)
+        copy(isFavorite = false, isWatchlist = false)
       }
       performClickButtonWatchlist()
 
       // remove from watchlist
       updateState {
-        copy(isFavorite=true, isWatchlist = true)
+        copy(isFavorite = true, isWatchlist = true)
       }
       performClickButtonWatchlist()
     }
@@ -365,6 +368,16 @@ class MediaDetailActivityInteractionTest :
       }
       performClickButtonWatchlist()
       performClickButtonFavorite()
+    }
+  }
+
+  @Test
+  fun buttonMoreRecommendation_whenClicked_shouldOpenListPage() {
+    context.launchMediaDetailActivity {
+      onView(withId(rv_recommendation)).perform(scrollTo())
+      onView(withId(button)).check(matches(isDisplayed())).perform(click())
+
+      verify(exactly = 1) { mockNavigator.openList(any(), any()) }
     }
   }
 

--- a/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailActivityInteractionTest.kt
+++ b/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailActivityInteractionTest.kt
@@ -16,11 +16,11 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.waffiq.bazz_movies.core.common.utils.Constants.NAN
 import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
-import com.waffiq.bazz_movies.core.designsystem.R.id.button
 import com.waffiq.bazz_movies.core.designsystem.R.string.cancel
 import com.waffiq.bazz_movies.core.designsystem.R.string.submit
 import com.waffiq.bazz_movies.feature.detail.R.id.btn_back
 import com.waffiq.bazz_movies.feature.detail.R.id.btn_favorite
+import com.waffiq.bazz_movies.feature.detail.R.id.btn_more_recommendation
 import com.waffiq.bazz_movies.feature.detail.R.id.btn_watchlist
 import com.waffiq.bazz_movies.feature.detail.R.id.iv_poster
 import com.waffiq.bazz_movies.feature.detail.R.id.rating_bar_action
@@ -375,7 +375,7 @@ class MediaDetailActivityInteractionTest :
   fun buttonMoreRecommendation_whenClicked_shouldOpenListPage() {
     context.launchMediaDetailActivity {
       onView(withId(rv_recommendation)).perform(scrollTo())
-      onView(withId(button)).check(matches(isDisplayed())).perform(click())
+      onView(withId(btn_more_recommendation)).check(matches(isDisplayed())).perform(click())
 
       verify(exactly = 1) { mockNavigator.openList(any(), any()) }
     }

--- a/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailActivityTest.kt
+++ b/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailActivityTest.kt
@@ -1,19 +1,20 @@
 package com.waffiq.bazz_movies.feature.detail.ui
 
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.designsystem.R.string.not_available
-import com.waffiq.bazz_movies.core.instrumentationtest.Helper.shortDelay
+import com.waffiq.bazz_movies.core.instrumentationtest.ViewMatcher.doesNotExist
+import com.waffiq.bazz_movies.core.instrumentationtest.ViewMatcher.hasText
+import com.waffiq.bazz_movies.core.instrumentationtest.ViewMatcher.isDisplayed
+import com.waffiq.bazz_movies.core.instrumentationtest.ViewMatcher.isNotDisplayed
+import com.waffiq.bazz_movies.core.designsystem.R.string.add_to_favorite
 import com.waffiq.bazz_movies.feature.detail.R.id.btn_back
 import com.waffiq.bazz_movies.feature.detail.R.id.btn_favorite
 import com.waffiq.bazz_movies.feature.detail.R.id.btn_watchlist
+import com.waffiq.bazz_movies.feature.detail.R.id.chip
 import com.waffiq.bazz_movies.feature.detail.R.id.rv_cast
 import com.waffiq.bazz_movies.feature.detail.R.id.tv_age_rating
 import com.waffiq.bazz_movies.feature.detail.R.id.tv_duration
@@ -37,7 +38,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
-import org.hamcrest.Matchers.not
+import kotlinx.coroutines.launch
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -91,9 +92,9 @@ class MediaDetailActivityTest :
   @Test
   fun detailScreen_whenAllDataProvided_showsAllViews() {
     context.launchMediaDetailActivity {
-      onView(withId(btn_back)).check(matches(isDisplayed()))
-      onView(withId(btn_watchlist)).check(matches(isDisplayed()))
-      onView(withId(btn_favorite)).check(matches(isDisplayed()))
+      btn_back.isDisplayed()
+      btn_watchlist.isDisplayed()
+      btn_favorite.isDisplayed()
     }
   }
 
@@ -111,85 +112,67 @@ class MediaDetailActivityTest :
     every { mockMediaDetailViewModel.uiState } returns MutableStateFlow(MediaDetailUiState())
 
     context.launchMediaDetailActivity {
-      verify(exactly = 0){ mockMediaDetailViewModel.getOMDbDetails(any()) }
+      verify(exactly = 0) { mockMediaDetailViewModel.getOMDbDetails(any()) }
     }
   }
 
   @Test
-  fun imdbId_withValidValue_shouldHandleAllPossibility() {
+  fun toastEvent_whenErrorIsOccurs_callsToastCreation() {
     context.launchMediaDetailActivity {
-      uiState.update { s -> s.copy(detail = testMediaDetail.copy(imdbId = "tt1234567")) }
-      shortDelay()
-    }
-  }
-
-  @Test
-  fun imdbId_withNullValue_shouldHandleAllPossibility() {
-    context.launchMediaDetailActivity {
-      uiState.update { s -> s.copy(detail = testMediaDetail.copy(imdbId = null)) }
-      shortDelay()
-    }
-  }
-
-  @Test
-  fun imdbId_withEmptyValue_shouldHandleAllPossibility() {
-    context.launchMediaDetailActivity {
-      uiState.update { s -> s.copy(detail = testMediaDetail.copy(imdbId = "")) }
-      shortDelay()
-    }
-  }
-
-  @Test
-  fun imdbId_withBlankValue_shouldHandleAllPossibility() {
-    context.launchMediaDetailActivity {
-      uiState.update { s -> s.copy(detail = testMediaDetail.copy(imdbId = " ")) }
-      shortDelay()
+      it.onActivity { activity ->
+        activity.lifecycleScope.launch {
+          toastEvent.emit(add_to_favorite)
+        }
+      }
+      // manual verify
     }
   }
 
   @Test
   fun mediaDetailValue_withMixedValue_showsViewsCorrectly() {
-    // genre null
+    // genre empty or null, then chip is not exist at all
     context.launchMediaDetailActivity {
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(genreId = emptyList())) }
+      chip.doesNotExist()
     }
     context.launchMediaDetailActivity {
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(genreId = null)) }
+      chip.doesNotExist()
     }
 
     // status
-    context.launchMediaDetailActivity {
+    context.launchMediaDetailActivity(testMediaItem.copy(mediaType = TV_MEDIA_TYPE)) {
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(status = null)) }
+      tv_duration.hasText(context.getString(not_available))
     }
-    context.launchMediaDetailActivity {
+
+    context.launchMediaDetailActivity(testMediaItem.copy(mediaType = TV_MEDIA_TYPE)) {
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(status = "")) }
+      tv_duration.hasText(context.getString(not_available))
     }
 
     // movie duration null
     context.launchMediaDetailActivity {
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(duration = null)) }
-      onView(withId(tv_duration)).check(matches(withText(context.getString(not_available))))
-        .check(matches(isDisplayed()))
+      tv_duration.hasText(context.getString(not_available))
     }
 
     // tv status null or empty
     context.launchMediaDetailActivity(data = testMediaItem.copy(mediaType = TV_MEDIA_TYPE)) {
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(status = null)) }
-      onView(withId(tv_duration)).check(matches(withText(context.getString(not_available))))
-        .check(matches(isDisplayed()))
+      tv_duration.hasText(context.getString(not_available))
 
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(status = "")) }
-      onView(withId(tv_duration)).check(matches(withText(context.getString(not_available))))
-        .check(matches(isDisplayed()))
+      tv_duration.hasText(context.getString(not_available))
     }
 
     // tmdb score hidden
     context.launchMediaDetailActivity {
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(tmdbScore = null)) }
-      onView(withId(tv_score_tmdb)).check(matches(not(isDisplayed())))
+      tv_score_tmdb.isNotDisplayed()
 
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(tmdbScore = "")) }
-      onView(withId(tv_score_tmdb)).check(matches(not(isDisplayed())))
+      tv_score_tmdb.isNotDisplayed()
     }
   }
 
@@ -198,13 +181,13 @@ class MediaDetailActivityTest :
     // age rating null
     context.launchMediaDetailActivity {
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(ageRating = null)) }
-      onView(withId(tv_age_rating)).check(matches(not(isDisplayed())))
+      tv_age_rating.isNotDisplayed()
     }
 
     // age rating empty
     context.launchMediaDetailActivity {
       uiState.update { s -> s.copy(detail = testMediaDetail.copy(ageRating = "")) }
-      onView(withId(tv_age_rating)).check(matches(not(isDisplayed())))
+      tv_age_rating.isNotDisplayed()
     }
   }
 
@@ -219,7 +202,7 @@ class MediaDetailActivityTest :
           )
         )
       }
-      onView(withId(tv_year_released)).check(matches(not(isDisplayed())))
+      tv_year_released.isNotDisplayed()
     }
   }
 
@@ -229,7 +212,7 @@ class MediaDetailActivityTest :
       uiState.update { s ->
         s.copy(credits = testMediaCredits.copy(crew = emptyList(), cast = emptyList()))
       }
-      onView(withId(rv_cast)).check(matches(not(isDisplayed())))
+      rv_cast.isNotDisplayed()
     }
   }
 }

--- a/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailSideSheetTest.kt
+++ b/feature/detail/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/detail/ui/MediaDetailSideSheetTest.kt
@@ -111,7 +111,7 @@ class MediaDetailSideSheetTest :
             listType = BY_KEYWORD,
             mediaType = testMediaItem.mediaType,
             title = testMediaDetail.keywords?.get(0)?.name.orEmpty(),
-            keywordId = testMediaDetail.keywords?.get(0)?.id ?: 0,
+            id = testMediaDetail.keywords?.get(0)?.id ?: 0,
           )
         )
       }
@@ -133,7 +133,7 @@ class MediaDetailSideSheetTest :
             listType = BY_KEYWORD,
             mediaType = testMediaItem.mediaType,
             title = testMediaDetail.keywords?.get(0)?.name.orEmpty(),
-            keywordId = testMediaDetail.keywords?.get(0)?.id ?: 0,
+            id = testMediaDetail.keywords?.get(0)?.id ?: 0,
           )
         )
       }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/GenreAdapter.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/GenreAdapter.kt
@@ -51,7 +51,7 @@ class GenreAdapter(private val navigator: INavigator) :
             listType = BY_GENRE,
             mediaType = mediaType,
             title = "", // empty for genre
-            genreId = id,
+            id = id,
           ),
         )
       }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/KeywordsAdapter.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/KeywordsAdapter.kt
@@ -50,7 +50,7 @@ class KeywordsAdapter(private val navigator: INavigator) :
             listType = BY_KEYWORD,
             mediaType = mediaType,
             title = keyword.name,
-            keywordId = keyword.id,
+            id = keyword.id,
           ),
         )
       }

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/DetailUIManager.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/DetailUIManager.kt
@@ -46,15 +46,17 @@ import com.waffiq.bazz_movies.feature.detail.ui.adapter.KeywordsAdapter
 import com.waffiq.bazz_movies.feature.detail.ui.adapter.RecommendationAdapter
 import com.waffiq.bazz_movies.feature.detail.ui.launcher.DefaultTrailerLauncher
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.CreateTableViewHelper.createTable
-import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.backdropOriginalSource
+import com.waffiq.bazz_movies.feature.detail.utils.helpers.ImageHelper.backdropOriginalSource
+import com.waffiq.bazz_movies.feature.detail.utils.helpers.ImageHelper.isBackdropNotAvailable
+import com.waffiq.bazz_movies.feature.detail.utils.helpers.ImageHelper.posterDetailSource
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.extractCrewDisplayNames
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.formatRating
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.getOverview
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.getScoreFromOMDB
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.isBackReleased
-import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.isBackdropNotAvailable
-import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.posterDetailSource
 import com.waffiq.bazz_movies.navigation.INavigator
+import com.waffiq.bazz_movies.navigation.ListArgs
+import com.waffiq.bazz_movies.navigation.ListType.RECOMMENDATION
 
 /**
  * Manages the UI presentation logic for the Detail Movie screen.
@@ -366,6 +368,27 @@ class DetailUIManager(
    */
   fun updateRecommendations(recommendations: PagingData<MediaItem>, lifecycle: Lifecycle) {
     adapterRecommendation.submitData(lifecycle, recommendations)
+  }
+
+  /**
+   * Open recommendation on list page
+   */
+  fun openListPage(
+    mediaType: String,
+    title: String,
+    backdrop: String,
+    mediaId: Int,
+  ) {
+    navigator.openList(
+      activity,
+      ListArgs(
+        listType = RECOMMENDATION,
+        mediaType = mediaType,
+        title = title,
+        id = mediaId,
+        backdrop = backdrop,
+      ),
+    )
   }
 
   /**

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/UserInteractionHandler.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/manager/UserInteractionHandler.kt
@@ -19,11 +19,13 @@ import com.waffiq.bazz_movies.core.domain.MediaItem
 import com.waffiq.bazz_movies.core.domain.MediaState
 import com.waffiq.bazz_movies.core.domain.Rated
 import com.waffiq.bazz_movies.core.domain.WatchlistParams
+import com.waffiq.bazz_movies.core.utils.DetailDataUtils.titleHandler
 import com.waffiq.bazz_movies.feature.detail.databinding.ActivityMediaDetailBinding
 import com.waffiq.bazz_movies.feature.detail.ui.dialog.RateDialog
 import com.waffiq.bazz_movies.feature.detail.ui.state.MediaDetailUiState
 import com.waffiq.bazz_movies.feature.detail.ui.state.UserAuthState
 import com.waffiq.bazz_movies.feature.detail.ui.viewmodel.MediaDetailViewModel
+import com.waffiq.bazz_movies.feature.detail.utils.helpers.ImageHelper.backdropPathSource
 import com.waffiq.bazz_movies.feature.detail.utils.uihelpers.ButtonImageChanger.changeBtnAction
 
 /**
@@ -151,6 +153,14 @@ class UserInteractionHandler(
       btnWatchlist.setOnClickListener { handleWatchlistClick() }
       btnSidebar.setOnClickListener { uiManager.showSideSheet() }
       swipeRefresh.setOnRefreshListener { handleSwipeRefresh() }
+      btnMoreRecommendation.button.setOnClickListener {
+        uiManager.openListPage(
+          mediaType = dataExtra.mediaType,
+          title = titleHandler(dataExtra),
+          backdrop = dataExtra.backdropPathSource,
+          mediaId = dataExtra.id,
+        )
+      }
     }
   }
 

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/ImageHelper.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/ImageHelper.kt
@@ -1,0 +1,47 @@
+package com.waffiq.bazz_movies.feature.detail.utils.helpers
+
+import com.waffiq.bazz_movies.core.common.utils.Constants.NOT_AVAILABLE
+import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_BACKDROP_ORIGINAL
+import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_POSTER_W500
+import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_backdrop_error_filled
+import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_poster_error
+import com.waffiq.bazz_movies.core.domain.Imageble
+
+object ImageHelper {
+
+  private fun String?.isValidImagePath(): Boolean = !this.isNullOrBlank() && this != NOT_AVAILABLE
+
+  private val Imageble.backdropOriginalUrl: String?
+    get() = when {
+      backdropPath.isValidImagePath() ->
+        TMDB_IMG_LINK_BACKDROP_ORIGINAL + backdropPath
+
+      posterPath.isValidImagePath() ->
+        TMDB_IMG_LINK_POSTER_W500 + posterPath
+
+      else -> null
+    }
+
+  val Imageble.backdropPathSource: String
+    get() = listOf(backdropPath, posterPath)
+      .firstOrNull { it.isValidImagePath() }
+      .orEmpty()
+
+  val Imageble.backdropOriginalSource: Any
+    get() = backdropOriginalUrl ?: ic_backdrop_error_filled
+
+  val Imageble.isBackdropNotAvailable: Boolean
+    get() = backdropPath.isNullOrBlank() || backdropPath == NOT_AVAILABLE
+
+  private val Imageble.posterUrl: String?
+    get() = posterPath
+      ?.takeIf { it.isNotBlank() && it != NOT_AVAILABLE }
+      ?.let { TMDB_IMG_LINK_POSTER_W500 + it } // higher quality than on the list
+
+  /** Used on detail page, to show poster in higher quality
+   *
+   * @return Poster URL if available, otherwise fallback to drawable
+   */
+  val Imageble.posterDetailSource: Any
+    get() = posterUrl ?: ic_poster_error
+}

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/MediaHelper.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/MediaHelper.kt
@@ -2,13 +2,7 @@ package com.waffiq.bazz_movies.feature.detail.utils.helpers
 
 import android.content.Context
 import android.view.KeyEvent
-import com.waffiq.bazz_movies.core.common.utils.Constants.NOT_AVAILABLE
-import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_BACKDROP_ORIGINAL
-import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_POSTER_W500
-import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_backdrop_error_filled
-import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_poster_error
 import com.waffiq.bazz_movies.core.designsystem.R.string.no_overview
-import com.waffiq.bazz_movies.core.domain.Imageble
 import com.waffiq.bazz_movies.feature.detail.domain.model.MediaCrewItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.keywords.MediaKeywordsItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.video.Video
@@ -81,37 +75,6 @@ object MediaHelper {
 
   fun getListOfKeywords(list: List<MediaKeywordsItem?>?) =
     list?.filter { it?.id != null && !it.name.isNullOrEmpty() }
-
-  private fun String?.isValidImagePath(): Boolean = !this.isNullOrBlank() && this != NOT_AVAILABLE
-
-  private val Imageble.backdropOriginalUrl: String?
-    get() = when {
-      backdropPath.isValidImagePath() ->
-        TMDB_IMG_LINK_BACKDROP_ORIGINAL + backdropPath
-
-      posterPath.isValidImagePath() ->
-        TMDB_IMG_LINK_POSTER_W500 + posterPath
-
-      else -> null
-    }
-
-  val Imageble.backdropOriginalSource: Any
-    get() = backdropOriginalUrl ?: ic_backdrop_error_filled
-
-  val Imageble.isBackdropNotAvailable: Boolean
-    get() = backdropPath.isNullOrBlank() || backdropPath == NOT_AVAILABLE
-
-  private val Imageble.posterUrl: String?
-    get() = posterPath
-      ?.takeIf { it.isNotBlank() && it != NOT_AVAILABLE }
-      ?.let { TMDB_IMG_LINK_POSTER_W500 + it } // higher quality than on the list
-
-  /** Used on detail page, to show poster in higher quality
-   *
-   * @return Poster URL if available, otherwise fallback to drawable
-   */
-  val Imageble.posterDetailSource: Any
-    get() = posterUrl ?: ic_poster_error
 
   fun Context.getOverview(overview: String?): String =
     overview?.takeIf { it.isNotBlank() } ?: getString(no_overview)

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/ReleaseDateHelper.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/ReleaseDateHelper.kt
@@ -22,7 +22,7 @@ object ReleaseDateHelper {
   /**
    * Get release date and its associated region from a movie.
    *
-   * The function employs a multistep search strategy to locate a release date:
+   * The function use this step in order to get proper release date:
    * 1. Checks if there is a release date corresponding to the specified user region.
    * 2. If no matching region is found, falls back to using the production country's release date.
    * 3. If the above options are unavailable, it searches for any valid release date in any region.
@@ -35,7 +35,7 @@ object ReleaseDateHelper {
   fun getReleaseDateRegion(data: MovieDetail?, userRegion: String): ReleaseDateRegion {
     var releaseDateRegion: ReleaseDateRegion? = null
 
-    // Step 1: get release date based user's region.
+    // get release date based user's region.
     val userRegionAndDate =
       getMatchingRegionAndReleaseDateMovie(data?.releaseDates?.listReleaseDatesItem, userRegion)
     if (userRegionAndDate != null) {
@@ -45,7 +45,7 @@ object ReleaseDateHelper {
       )
     }
 
-    // Step 2: fallback - use production country and its release date
+    // fallback, use production country and its release date
     // if no match is found for the user region.
     if (releaseDateRegion == null) {
       // get production country
@@ -62,7 +62,7 @@ object ReleaseDateHelper {
       }
     }
 
-    // Step 3: final Fallback - use any valid region and release date.
+    // final Fallback, use any valid region and release date.
     if (releaseDateRegion == null) {
       val fallback = getAnyValidRegionAndReleaseDateMovie(data?.releaseDates?.listReleaseDatesItem)
       releaseDateRegion = ReleaseDateRegion(
@@ -132,8 +132,7 @@ object ReleaseDateHelper {
   /**
    * For TV-Series
    *
-   * Determines and returns the most relevant release date and its associated region for a given
-   * tv-series.
+   * Get the most relevant release date and its associated region for a given tv-series.
    *
    * @param data A `DetailTv` object containing details about the tv-series, including its release
    *        dates and original country.

--- a/feature/detail/src/main/res/layout/activity_media_detail.xml
+++ b/feature/detail/src/main/res/layout/activity_media_detail.xml
@@ -665,14 +665,29 @@
           tools:orientation="horizontal" />
 
         <!-- Recommendation -->
-        <TextView
-          android:id="@+id/tv_recommendation_header"
-          style="@style/TextHeader2"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+          android:id="@+id/layout_recommendation"
+          style="@style/LayoutHeaderTheme"
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
-          android:layout_marginTop="16dp"
-          android:text="@string/recommendation" />
+          android:layout_marginTop="16dp">
+
+          <TextView
+            android:id="@+id/tv_recommendation_header"
+            style="@style/TextHeader2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left|center_vertical"
+            android:text="@string/recommendation" />
+
+          <include
+            android:id="@+id/btn_more_recommendation"
+            layout="@layout/button_more"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right|end|center"
+            android:layout_marginEnd="-4dp" />
+
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
         <!-- End of DETAIL LOWER SECTION -->
 
         <androidx.recyclerview.widget.RecyclerView

--- a/feature/detail/src/main/res/layout/activity_media_detail.xml
+++ b/feature/detail/src/main/res/layout/activity_media_detail.xml
@@ -676,7 +676,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/recommendation" />
 
           <include
@@ -684,7 +684,7 @@
             layout="@layout/button_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end|center"
+            android:layout_gravity="end|center"
             android:layout_marginEnd="-4dp" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/GenreAdapterTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/ui/adapter/GenreAdapterTest.kt
@@ -78,7 +78,7 @@ class GenreAdapterTest : BaseAdapterTest() {
           listType = ListType.BY_GENRE,
           mediaType = MOVIE_MEDIA_TYPE,
           title = "",
-          genreId = movieGenreIds.first(),
+          id = movieGenreIds.first(),
         )
       )
     }
@@ -95,7 +95,7 @@ class GenreAdapterTest : BaseAdapterTest() {
           listType = ListType.BY_GENRE,
           mediaType = TV_MEDIA_TYPE,
           title = "",
-          genreId = tvGenreIds.first(),
+          id = tvGenreIds.first(),
         )
       )
     }

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/ImageHelperTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/ImageHelperTest.kt
@@ -1,0 +1,133 @@
+package com.waffiq.bazz_movies.feature.detail.utils.helpers
+
+import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_POSTER_W500
+import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_backdrop_error_filled
+import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_poster_error
+import com.waffiq.bazz_movies.core.domain.MediaItem
+import com.waffiq.bazz_movies.feature.detail.utils.helpers.ImageHelper.backdropOriginalSource
+import com.waffiq.bazz_movies.feature.detail.utils.helpers.ImageHelper.backdropPathSource
+import com.waffiq.bazz_movies.feature.detail.utils.helpers.ImageHelper.isBackdropNotAvailable
+import com.waffiq.bazz_movies.feature.detail.utils.helpers.ImageHelper.posterDetailSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImageHelperTest {
+
+  @Test
+  fun backdropPathSource_whenAllPathAvailable_returnsBackdrop() {
+    val data = MediaItem(backdropPath = "backdrop", posterPath = "poster")
+    assertEquals("backdrop", data.backdropPathSource)
+  }
+
+  @Test
+  fun backdropPathSource_whenBackdropPathMissing_returnsBackdrop() {
+    val data = MediaItem(backdropPath = "backdrop", posterPath = "poster")
+    assertEquals("backdrop", data.backdropPathSource)
+  }
+
+  @Test
+  fun backdropOriginalSource_whenAllPathAvailable_returnsCorrectly() {
+    // all null, return empty
+    val data1 = MediaItem()
+    assertEquals("", data1.backdropPathSource)
+
+    // all N/A value, return empty
+    val data2 = MediaItem(backdropPath = "N/A", posterPath = "N/A")
+    assertEquals("", data2.backdropPathSource)
+
+    // all empty value
+    val data3 = MediaItem(backdropPath = "", posterPath = "")
+    assertEquals("", data3.backdropPathSource)
+
+    // all blank
+    val data4 = MediaItem(backdropPath = " ", posterPath = " ")
+    assertEquals("", data4.backdropPathSource)
+
+    // backdrop null
+    val data5 = MediaItem(posterPath = "poster")
+    assertEquals("poster", data5.backdropPathSource)
+
+    // backdrop empty
+    val data6 = MediaItem(backdropPath = "", posterPath = "poster")
+    assertEquals("poster", data6.backdropPathSource)
+
+    // backdrop blank
+    val data7 = MediaItem(backdropPath = " ", posterPath = "poster")
+    assertEquals("poster", data7.backdropPathSource)
+  }
+
+  @Test
+  fun backdropOriginalSource_whenBackdropPathMissing_returnsCorrectValue() {
+    // all null
+    val data1 = MediaItem()
+    assertEquals(ic_backdrop_error_filled, data1.backdropOriginalSource)
+
+    // all N/A value
+    val data2 = MediaItem(backdropPath = "N/A", posterPath = "N/A")
+    assertEquals(ic_backdrop_error_filled, data2.backdropOriginalSource)
+
+    // all empty value
+    val data3 = MediaItem(backdropPath = "", posterPath = "")
+    assertEquals(ic_backdrop_error_filled, data3.backdropOriginalSource)
+
+    // all blank
+    val data4 = MediaItem(backdropPath = " ", posterPath = " ")
+    assertEquals(ic_backdrop_error_filled, data4.backdropOriginalSource)
+
+    // backdrop null
+    val data5 = MediaItem(posterPath = "poster")
+    assertEquals(TMDB_IMG_LINK_POSTER_W500 + "poster", data5.backdropOriginalSource)
+
+    // backdrop empty
+    val data6 = MediaItem(backdropPath = "", posterPath = "poster")
+    assertEquals(TMDB_IMG_LINK_POSTER_W500 + "poster", data6.backdropOriginalSource)
+
+    // backdrop blank
+    val data7 = MediaItem(backdropPath = " ", posterPath = "poster")
+    assertEquals(TMDB_IMG_LINK_POSTER_W500 + "poster", data7.backdropOriginalSource)
+  }
+
+  @Test
+  fun isBackdropNotAvailable_whenPathIsAvailable_returnsFalse() {
+    val data = MediaItem(backdropPath = "backdrop")
+    assertFalse(data.isBackdropNotAvailable)
+  }
+
+  @Test
+  fun isBackdropNotAvailable_whenPathIsNotAvailable_returnsTrue() {
+    // backdrop null
+    assertTrue(MediaItem(backdropPath = null).isBackdropNotAvailable)
+
+    // backdrop blank
+    assertTrue(MediaItem(backdropPath = " ").isBackdropNotAvailable)
+
+    // backdrop empty
+    assertTrue(MediaItem(backdropPath = "").isBackdropNotAvailable)
+
+    // backdrop N/A
+    assertTrue(MediaItem(backdropPath = "N/A").isBackdropNotAvailable)
+  }
+
+  @Test
+  fun posterDetailSource_whenPosterPathIsAvailable_returnsPoster() {
+    val data = MediaItem(posterPath = "poster")
+    assertEquals(TMDB_IMG_LINK_POSTER_W500 + "poster", data.posterDetailSource)
+  }
+
+  @Test
+  fun posterDetailSource_whenPosterPathIsMissing_returnsDrawable() {
+    // null
+    assertEquals(ic_poster_error, MediaItem(posterPath = null).posterDetailSource)
+
+    // empty
+    assertEquals(ic_poster_error, MediaItem(posterPath = "").posterDetailSource)
+
+    // blank
+    assertEquals(ic_poster_error, MediaItem(posterPath = " ").posterDetailSource)
+
+    // N/A
+    assertEquals(ic_poster_error, MediaItem(posterPath = "N/A").posterDetailSource)
+  }
+}

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/MediaHelperTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/helpers/MediaHelperTest.kt
@@ -6,17 +6,11 @@ import android.view.KeyEvent.ACTION_UP
 import android.view.KeyEvent.KEYCODE_0
 import android.view.KeyEvent.KEYCODE_8
 import android.view.KeyEvent.KEYCODE_BACK
-import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_BACKDROP_ORIGINAL
-import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_POSTER_W500
-import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_backdrop_error_filled
-import com.waffiq.bazz_movies.core.designsystem.R.drawable.ic_poster_error
 import com.waffiq.bazz_movies.core.designsystem.R.string.no_overview
-import com.waffiq.bazz_movies.core.domain.MediaItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.MediaCrewItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.keywords.MediaKeywordsItem
 import com.waffiq.bazz_movies.feature.detail.domain.model.video.Video
 import com.waffiq.bazz_movies.feature.detail.domain.model.video.VideoItem
-import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.backdropOriginalSource
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.extractCrewDisplayNames
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.formatRating
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.getListOfKeywords
@@ -25,8 +19,6 @@ import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.getScoreF
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.getTransformDuration
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.getTransformTMDBScore
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.isBackReleased
-import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.isBackdropNotAvailable
-import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.posterDetailSource
 import com.waffiq.bazz_movies.feature.detail.utils.helpers.MediaHelper.toLink
 import io.mockk.every
 import io.mockk.mockk
@@ -281,85 +273,6 @@ class MediaHelperTest {
   }
 
   @Test
-  fun backdropOriginalUrl_whenAllPathAvailable_returnsBackdrop() {
-    val data = MediaItem(backdropPath = "backdrop", posterPath = "poster")
-    assertEquals(TMDB_IMG_LINK_BACKDROP_ORIGINAL + "backdrop", data.backdropOriginalSource)
-  }
-
-  @Test
-  fun backdropOriginalUrl_whenBackdropPathMissing_returnsCorrectValue() {
-    // all null
-    val data1 = MediaItem()
-    assertEquals(ic_backdrop_error_filled, data1.backdropOriginalSource)
-
-    // all N/A value
-    val data2 = MediaItem(backdropPath = "N/A", posterPath = "N/A")
-    assertEquals(ic_backdrop_error_filled, data2.backdropOriginalSource)
-
-    // all empty value
-    val data3 = MediaItem(backdropPath = "", posterPath = "")
-    assertEquals(ic_backdrop_error_filled, data3.backdropOriginalSource)
-
-    // all blank
-    val data4 = MediaItem(backdropPath = " ", posterPath = " ")
-    assertEquals(ic_backdrop_error_filled, data4.backdropOriginalSource)
-
-    // backdrop null
-    val data5 = MediaItem(posterPath = "poster")
-    assertEquals(TMDB_IMG_LINK_POSTER_W500 + "poster", data5.backdropOriginalSource)
-
-    // backdrop empty
-    val data6 = MediaItem(backdropPath = "", posterPath = "poster")
-    assertEquals(TMDB_IMG_LINK_POSTER_W500 + "poster", data6.backdropOriginalSource)
-
-    // backdrop blank
-    val data7 = MediaItem(backdropPath = " ", posterPath = "poster")
-    assertEquals(TMDB_IMG_LINK_POSTER_W500 + "poster", data7.backdropOriginalSource)
-  }
-
-  @Test
-  fun isBackdropNotAvailable_whenPathIsAvailable_returnsFalse() {
-    val data = MediaItem(backdropPath = "backdrop")
-    assertFalse(data.isBackdropNotAvailable)
-  }
-
-  @Test
-  fun isBackdropNotAvailable_whenPathIsNotAvailable_returnsTrue() {
-    // backdrop null
-    assertTrue(MediaItem(backdropPath = null).isBackdropNotAvailable)
-
-    // backdrop blank
-    assertTrue(MediaItem(backdropPath = " ").isBackdropNotAvailable)
-
-    // backdrop empty
-    assertTrue(MediaItem(backdropPath = "").isBackdropNotAvailable)
-
-    // backdrop N/A
-    assertTrue(MediaItem(backdropPath = "N/A").isBackdropNotAvailable)
-  }
-
-  @Test
-  fun posterDetailSource_whenPosterPathIsAvailable_returnsPoster() {
-    val data = MediaItem(posterPath = "poster")
-    assertEquals(TMDB_IMG_LINK_POSTER_W500 + "poster", data.posterDetailSource)
-  }
-
-  @Test
-  fun posterDetailSource_whenPosterPathIsMissing_returnsDrawable() {
-    // null
-    assertEquals(ic_poster_error, MediaItem(posterPath = null).posterDetailSource)
-
-    // empty
-    assertEquals(ic_poster_error, MediaItem(posterPath = "").posterDetailSource)
-
-    // blank
-    assertEquals(ic_poster_error, MediaItem(posterPath = " ").posterDetailSource)
-
-    // N/A
-    assertEquals(ic_poster_error, MediaItem(posterPath = "N/A").posterDetailSource)
-  }
-
-  @Test
   fun getOverview_whenOverviewIsAvailable_returnsOverview() {
     assertEquals("data overview", context.getOverview("data overview"))
   }
@@ -372,7 +285,7 @@ class MediaHelperTest {
   }
 
   @Test
-  fun formatRating_withValue_returnsCorrectly(){
+  fun formatRating_withValue_returnsCorrectly() {
     assertEquals("10.0", formatRating(10.0))
     assertEquals("10.0", formatRating(10.0f))
     assertEquals("10.0", formatRating(10))

--- a/feature/home/src/main/res/layout/fragment_featured.xml
+++ b/feature/home/src/main/res/layout/fragment_featured.xml
@@ -105,7 +105,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/upcoming_movies" />
 
           <include
@@ -113,7 +113,7 @@
             layout="@layout/button_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end|center"
+            android:layout_gravity="end|center"
             android:layout_marginEnd="-4dp" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
@@ -143,7 +143,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/playing_now_on_theater" />
 
           <include

--- a/feature/home/src/main/res/layout/fragment_movie.xml
+++ b/feature/home/src/main/res/layout/fragment_movie.xml
@@ -39,7 +39,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/popular" />
 
           <include
@@ -47,7 +47,7 @@
             layout="@layout/button_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end|center"
+            android:layout_gravity="end|center"
             android:layout_marginEnd="-4dp" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
@@ -70,7 +70,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/now_playing" />
 
           <include
@@ -78,7 +78,7 @@
             layout="@layout/button_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end|center"
+            android:layout_gravity="end|center"
             android:layout_marginEnd="-4dp" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
@@ -108,7 +108,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/upcoming" />
 
           <include
@@ -116,7 +116,7 @@
             layout="@layout/button_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end|center"
+            android:layout_gravity="end|center"
             android:layout_marginEnd="-4dp" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
@@ -145,7 +145,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/top_rated" />
 
           <include
@@ -153,7 +153,7 @@
             layout="@layout/button_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end|center"
+            android:layout_gravity="end|center"
             android:layout_marginEnd="-4dp" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/feature/home/src/main/res/layout/fragment_tv_series.xml
+++ b/feature/home/src/main/res/layout/fragment_tv_series.xml
@@ -39,7 +39,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/popular" />
 
           <include
@@ -47,7 +47,7 @@
             layout="@layout/button_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end|center"
+            android:layout_gravity="end|center"
             android:layout_marginEnd="-4dp" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
@@ -76,7 +76,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/airing_today" />
 
           <include
@@ -84,7 +84,7 @@
             layout="@layout/button_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end|center"
+            android:layout_gravity="end|center"
             android:layout_marginEnd="-4dp" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
@@ -113,7 +113,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/airing_this_week" />
 
           <include
@@ -121,7 +121,7 @@
             layout="@layout/button_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end|center"
+            android:layout_gravity="end|center"
             android:layout_marginEnd="-4dp" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
@@ -151,7 +151,7 @@
             style="@style/TextHeader2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left|center_vertical"
+            android:layout_gravity="start|center_vertical"
             android:text="@string/top_rated" />
 
           <include
@@ -159,7 +159,7 @@
             layout="@layout/button_more"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right|end|center"
+            android:layout_gravity="end|center"
             android:layout_marginEnd="-4dp" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/feature/list/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/list/ListActivityTest.kt
+++ b/feature/list/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/list/ListActivityTest.kt
@@ -117,6 +117,18 @@ class ListActivityTest : BaseListActivityTest() {
   }
 
   @Test
+  fun listActivity_withRecommendationType_showsCorrectViews() {
+    context.launchListActivity(movieRecommendationArgs) {
+      shouldShowText(movieRecommendationArgs.title)
+      shouldShowText("Recommendation")
+    }
+    context.launchListActivity(tvRecommendationArgs) {
+      shouldShowText(tvRecommendationArgs.title)
+      shouldShowText("Recommendation")
+    }
+  }
+
+  @Test
   fun listActivity_withTopRatedType_showsCorrectViews() {
     context.launchListActivity(movieTopRatedArgs) {
       shouldShowMovie()
@@ -272,7 +284,7 @@ class ListActivityTest : BaseListActivityTest() {
     }
   }
 
-  private fun triggerListButton(){
+  private fun triggerListButton() {
     onView(withId(btn_toggle_layout)).check(matches(isDisplayed())).perform(click())
   }
 }

--- a/feature/list/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/list/testutils/BaseListActivityTest.kt
+++ b/feature/list/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/list/testutils/BaseListActivityTest.kt
@@ -32,14 +32,14 @@ open class BaseListActivityTest {
     listType = ListType.BY_GENRE,
     mediaType = MOVIE_MEDIA_TYPE,
     title = "title",
-    genreId = 878,
+    id = 878,
   )
   protected val tvGenreArgs = movieGenreArgs.copy(mediaType = TV_MEDIA_TYPE)
   protected val movieKeywordsArgs = ListArgs(
     listType = ListType.BY_KEYWORD,
     mediaType = MOVIE_MEDIA_TYPE,
     title = "post apocalyptic",
-    genreId = 134,
+    id = 134,
   )
   protected val tvKeywordsArgs = movieKeywordsArgs.copy(mediaType = TV_MEDIA_TYPE)
   protected val movieNowPlayingArgs = ListArgs(
@@ -59,6 +59,15 @@ open class BaseListActivityTest {
   )
   protected val tvAiringThisWeekArgs = movieNowPlayingArgs.copy(
     listType = ListType.AIRING_THIS_WEEK, mediaType = TV_MEDIA_TYPE
+  )
+  protected val movieRecommendationArgs = movieNowPlayingArgs.copy(
+    listType = ListType.RECOMMENDATION, title = "Movie Title", id = 12344
+  )
+  protected val tvRecommendationArgs = movieNowPlayingArgs.copy(
+    listType = ListType.RECOMMENDATION,
+    mediaType = TV_MEDIA_TYPE,
+    title = "Tv Title",
+    id = 12344
   )
 
 
@@ -103,13 +112,16 @@ open class BaseListActivityTest {
     }
   }
 
-  protected fun shouldShowTv(){
-    onView(withText("TV"))
-      .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+  protected fun shouldShowTv() {
+    shouldShowText("TV")
   }
 
-  protected fun shouldShowMovie(){
-    onView(withText("MOVIE"))
+  protected fun shouldShowMovie() {
+    shouldShowText("MOVIE")
+  }
+
+  protected fun shouldShowText(text: String) {
+    onView(withText(text))
       .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
   }
 }

--- a/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/ListActivity.kt
+++ b/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/ListActivity.kt
@@ -25,6 +25,7 @@ import com.waffiq.bazz_movies.core.designsystem.R.string.airing_this_week
 import com.waffiq.bazz_movies.core.designsystem.R.string.airing_today
 import com.waffiq.bazz_movies.core.designsystem.R.string.now_playing
 import com.waffiq.bazz_movies.core.designsystem.R.string.popular
+import com.waffiq.bazz_movies.core.designsystem.R.string.recommendation
 import com.waffiq.bazz_movies.core.designsystem.R.string.toggle_grid_layout
 import com.waffiq.bazz_movies.core.designsystem.R.string.toggle_list_layout
 import com.waffiq.bazz_movies.core.designsystem.R.string.top_rated
@@ -125,6 +126,11 @@ class ListActivity : AppCompatActivity() {
         showTvAiringThisWeek()
       }
 
+      ListType.RECOMMENDATION -> {
+        shouldUpdateBackdropFromItems = false
+        showRecommendation(args)
+      }
+
       else -> binding.toolbar.title = args.title
     }
   }
@@ -144,19 +150,19 @@ class ListActivity : AppCompatActivity() {
 
   private fun showListBasedGenre(args: ListArgs) {
     val backdrop = if (args.mediaType == MOVIE_MEDIA_TYPE) {
-      getBackdropMovieGenre(args.genreId)
+      getBackdropMovieGenre(args.id)
     } else {
-      getBackdropTvGenre(args.genreId)
+      getBackdropTvGenre(args.id)
     }
     showBackdrop(backdrop)
-    binding.toolbar.title = getGenreName(args.genreId)
+    binding.toolbar.title = getGenreName(args.id)
     collectAndSubmitData(
       this,
       {
         if (args.mediaType == MOVIE_MEDIA_TYPE) {
-          viewModel.getMovieByGenres(args.genreId.toString())
+          viewModel.getMovieByGenres(args.id.toString())
         } else {
-          viewModel.getTvByGenres(args.genreId.toString())
+          viewModel.getTvByGenres(args.id.toString())
         }
       },
       adapter,
@@ -178,9 +184,9 @@ class ListActivity : AppCompatActivity() {
       this,
       {
         if (args.mediaType == MOVIE_MEDIA_TYPE) {
-          viewModel.getMovieByKeywords(args.keywordId.toString())
+          viewModel.getMovieByKeywords(args.id.toString())
         } else {
-          viewModel.getTvByKeywords(args.keywordId.toString())
+          viewModel.getTvByKeywords(args.id.toString())
         }
       },
       adapter,
@@ -237,6 +243,23 @@ class ListActivity : AppCompatActivity() {
           viewModel.getPopularMovies()
         } else {
           viewModel.getPopularTv()
+        }
+      },
+      adapter,
+    )
+  }
+
+  private fun showRecommendation(args: ListArgs) {
+    binding.toolbar.title = args.title
+    binding.toolbar.subtitle = getString(recommendation)
+    showBackdrop(args.backdrop)
+    collectAndSubmitData(
+      this,
+      {
+        if (args.mediaType == MOVIE_MEDIA_TYPE) {
+          viewModel.getMovieRecommendation(args.id)
+        } else {
+          viewModel.getTvRecommendation(args.id)
         }
       },
       adapter,

--- a/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModel.kt
+++ b/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModel.kt
@@ -43,6 +43,9 @@ class ListViewModel @Inject constructor(
   fun getTopRatedMovies(): Flow<PagingData<MediaItem>> =
     getListMoviesUseCase.getTopRatedMovies().cachedIn(viewModelScope)
 
+  fun getMovieRecommendation(movieId: Int): Flow<PagingData<MediaItem>> =
+    getListMoviesUseCase.getMovieRecommendation(movieId).cachedIn(viewModelScope)
+
   fun getPopularTv(): Flow<PagingData<MediaItem>> =
     getListTvUseCase.getPopularTv().cachedIn(viewModelScope)
 
@@ -54,4 +57,7 @@ class ListViewModel @Inject constructor(
 
   fun getAiringTodayTv(): Flow<PagingData<MediaItem>> =
     getListTvUseCase.getAiringTodayTv().cachedIn(viewModelScope)
+
+  fun getTvRecommendation(tvId: Int): Flow<PagingData<MediaItem>> =
+    getListTvUseCase.getTvRecommendation(tvId).cachedIn(viewModelScope)
 }

--- a/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/utils/ParcelableHelper.kt
+++ b/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/utils/ParcelableHelper.kt
@@ -1,20 +1,25 @@
 package com.waffiq.bazz_movies.feature.list.utils
 
 import android.content.Intent
+import android.os.BadParcelableException
 import android.os.Build
 import com.waffiq.bazz_movies.feature.list.ui.ListActivity.Companion.EXTRA_LIST
 import com.waffiq.bazz_movies.navigation.ListArgs
 
 object ParcelableHelper {
 
-  fun extractArgsItemFromIntent(intent: Intent): ListArgs? {
-    intent.setExtrasClassLoader(ListArgs::class.java.classLoader)
+  fun extractArgsItemFromIntent(intent: Intent): ListArgs? = try {
+      intent.setExtrasClassLoader(ListArgs::class.java.classLoader)
 
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      intent.getParcelableExtra(EXTRA_LIST, ListArgs::class.java)
-    } else {
-      @Suppress("DEPRECATION")
-      intent.getParcelableExtra(EXTRA_LIST)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        intent.getParcelableExtra(EXTRA_LIST, ListArgs::class.java)
+      } else {
+        @Suppress("DEPRECATION")
+        intent.getParcelableExtra(EXTRA_LIST)
+      }
+    } catch (_: BadParcelableException) {
+      null
+    } catch (_: ClassCastException) {
+      null
     }
-  }
 }

--- a/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/testutils/DummyData.kt
+++ b/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/testutils/DummyData.kt
@@ -13,7 +13,7 @@ object DummyData {
     listType = ListType.BY_KEYWORD,
     mediaType = MOVIE_MEDIA_TYPE,
     title = "name keywords",
-    genreId = 12345,
+    id = 12345,
   )
 
   val mediaMovieResponseItem = MediaResponseItem(

--- a/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModelTest.kt
+++ b/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModelTest.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.test.setMain
 
 class ListViewModelTest : BehaviorSpec({
 
+  val id = 1234512
+
   val testDispatcher = UnconfinedTestDispatcher()
 
   val mockGetListUseCase: GetListUseCase = mockk()
@@ -150,6 +152,16 @@ class ListViewModelTest : BehaviorSpec({
         expected = expectedMovie,
       )
     }
+
+    When("fetching movie recommendation") {
+      coEvery { mockGetListMoviesUseCase.getMovieRecommendation(any()) } returns
+        flowOf(fakeMovieMediaItemPagingData)
+
+      thenEmitsCorrectItem(
+        flowProvider = { viewModel.getMovieRecommendation(id) },
+        expected = expectedMovie,
+      )
+    }
   }
 
   Given("tv shows list is requested") {
@@ -187,6 +199,15 @@ class ListViewModelTest : BehaviorSpec({
 
       thenEmitsCorrectItem(
         flowProvider = { viewModel.getAiringTodayTv() },
+      )
+    }
+
+    When("fetching tv recommendation") {
+      coEvery { mockGetListTvUseCase.getTvRecommendation(any()) } returns
+        flowOf(fakeTvMediaItemPagingData)
+
+      thenEmitsCorrectItem(
+        flowProvider = { viewModel.getTvRecommendation(id) },
       )
     }
   }

--- a/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/utils/ParcelableHelperTest.kt
+++ b/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/utils/ParcelableHelperTest.kt
@@ -1,13 +1,17 @@
 package com.waffiq.bazz_movies.feature.list.utils
 
 import android.content.Intent
+import android.os.BadParcelableException
 import com.waffiq.bazz_movies.feature.list.testutils.DummyData.movieKeywordsArgs
 import com.waffiq.bazz_movies.feature.list.ui.ListActivity.Companion.EXTRA_LIST
 import com.waffiq.bazz_movies.feature.list.utils.ParcelableHelper.extractArgsItemFromIntent
+import com.waffiq.bazz_movies.navigation.ListArgs
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -41,6 +45,69 @@ class ParcelableHelperTest {
     val intent = Intent() // no extras
 
     val result = extractArgsItemFromIntent(intent)
+    assertNull(result)
+  }
+
+  @Test
+  fun extractArgsItemFromIntent_whenBadParcelableThrown_returnsNull() {
+    val intent = mock(Intent::class.java)
+
+    @Suppress("DEPRECATION")
+    whenever(intent.getParcelableExtra<ListArgs>(EXTRA_LIST))
+      .thenThrow(BadParcelableException("error bad parcelable exception"))
+
+    val result = extractArgsItemFromIntent(intent)
+
+    assertNull(result)
+  }
+
+  @Test
+  @Config(sdk = [33])
+  fun extractArgsItemFromIntent_tiramisu_whenBadParcelableThrown_returnsNull() {
+    val intent = mock(Intent::class.java)
+
+    whenever(intent.getParcelableExtra(EXTRA_LIST, ListArgs::class.java))
+      .thenThrow(BadParcelableException("error bad parcelable exception"))
+
+    val result = extractArgsItemFromIntent(intent)
+
+    assertNull(result)
+  }
+
+  @Test
+  fun extractArgsItemFromIntent_whenClassCastThrown_returnsNull() {
+    val intent = mock(Intent::class.java)
+
+    @Suppress("DEPRECATION")
+    whenever(intent.getParcelableExtra<ListArgs>(EXTRA_LIST))
+      .thenThrow(ClassCastException())
+
+    val result = extractArgsItemFromIntent(intent)
+
+    assertNull(result)
+  }
+
+  @Test
+  @Config(sdk = [33])
+  fun extractArgsItemFromIntent_tiramisu_whenClassCastThrown_returnsNull() {
+    val intent = mock(Intent::class.java)
+
+    whenever(intent.getParcelableExtra(EXTRA_LIST, ListArgs::class.java))
+      .thenThrow(ClassCastException("error class cast exception"))
+
+    val result = extractArgsItemFromIntent(intent)
+
+    assertNull(result)
+  }
+
+  @Test
+  fun extractArgsItemFromIntent_wrongType_returnsNull() {
+    val intent = Intent().apply {
+      putExtra(EXTRA_LIST, "not a parcelable")
+    }
+
+    val result = extractArgsItemFromIntent(intent)
+
     assertNull(result)
   }
 }

--- a/navigation/src/main/kotlin/com/waffiq/bazz_movies/navigation/ListArgs.kt
+++ b/navigation/src/main/kotlin/com/waffiq/bazz_movies/navigation/ListArgs.kt
@@ -8,6 +8,6 @@ data class ListArgs(
   val listType: ListType,
   val mediaType: String,
   val title: String,
-  val genreId: Int = -1,
-  val keywordId: Int = -1,
+  val id: Int = -1, // used for genre, keywords, and recommendation id
+  val backdrop: String = "",
 ) : Parcelable

--- a/navigation/src/main/kotlin/com/waffiq/bazz_movies/navigation/ListType.kt
+++ b/navigation/src/main/kotlin/com/waffiq/bazz_movies/navigation/ListType.kt
@@ -1,12 +1,13 @@
 package com.waffiq.bazz_movies.navigation
 
 enum class ListType {
-  TRENDING,
-  NOW_PLAYING,
   AIRING_THIS_WEEK,
-  TOP_RATED,
-  POPULAR,
-  UPCOMING,
   BY_GENRE,
   BY_KEYWORD,
+  NOW_PLAYING,
+  POPULAR,
+  RECOMMENDATION,
+  TOP_RATED,
+  TRENDING,
+  UPCOMING,
 }


### PR DESCRIPTION
## Summary
Add navigation to open the recommendation list page from the detail screen.

## Changes Made
- Add button to navigate to recommendation list
- Pass recommendation context via `ListArgs`
- Refactor image helper into a separate class
- Unify `ListArgs` id for genre, keyword, and recommendation
- Add shared view matchers for instrumentation tests
- Add tests covering new behavior

### Screenshot

<img src="https://i.postimg.cc/NMzRXrcT/559.gif" width="300"/>

## Notes
- `ListArgs.id is` now used for multiple purposes (genre, keyword, recommendation)
- No breaking changes expected