### PR TITLE
refactor: move movie type comparison from Activity to ViewModel

### DIFF
--- a/core/utils/src/main/kotlin/com/waffiq/bazz_movies/core/utils/FlowUtils.kt
+++ b/core/utils/src/main/kotlin/com/waffiq/bazz_movies/core/utils/FlowUtils.kt
@@ -1,5 +1,6 @@
 package com.waffiq.bazz_movies.core.utils
 
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -45,6 +46,17 @@ object FlowUtils {
         cachedFlow.collectLatest { pagingData ->
           adapter.submitData(pagingData)
         }
+      }
+    }
+  }
+
+  fun <T : Any> AppCompatActivity.load(
+    flow: Flow<PagingData<T>>,
+    adapter: PagingDataAdapter<T, *>,
+  ) {
+    lifecycleScope.launch {
+      repeatOnLifecycle(Lifecycle.State.STARTED) {
+        flow.collectLatest(adapter::submitData)
       }
     }
   }

--- a/core/utils/src/test/kotlin/com/waffiq/bazz_movies/core/utils/FlowUtilsTest.kt
+++ b/core/utils/src/test/kotlin/com/waffiq/bazz_movies/core/utils/FlowUtilsTest.kt
@@ -1,13 +1,16 @@
 package com.waffiq.bazz_movies.core.utils
 
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.paging.PagingData
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.waffiq.bazz_movies.core.designsystem.R.style.Base_Theme_BAZZ_movies
 import com.waffiq.bazz_movies.core.test.LifecycleOwnerRule
 import com.waffiq.bazz_movies.core.utils.FlowUtils.collectAndSubmitData
 import com.waffiq.bazz_movies.core.utils.FlowUtils.collectFlow
 import com.waffiq.bazz_movies.core.utils.FlowUtils.collectPagingData
+import com.waffiq.bazz_movies.core.utils.FlowUtils.load
 import com.waffiq.bazz_movies.core.utils.testutils.FakePagingAdapter
 import io.mockk.coVerify
 import io.mockk.every
@@ -28,6 +31,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -116,6 +120,20 @@ class FlowUtilsTest {
     )
 
     pagingDataFlow.value = samplePagingData
+    advanceUntilIdle()
+
+    coVerify(atLeast = 1) { adapter.submitData(any()) }
+  }
+
+  @Test
+  fun load_withCorrectActivity_shouldSubmitPagingData() = runTest {
+    val controller = Robolectric.buildActivity(AppCompatActivity::class.java)
+    val activity = controller.get()
+
+    activity.setTheme(Base_Theme_BAZZ_movies)
+    controller.setup()
+    activity.load(pagingDataFlow, adapter)
+
     advanceUntilIdle()
 
     coVerify(atLeast = 1) { adapter.submitData(any()) }

--- a/feature/list/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/list/ListActivityTest.kt
+++ b/feature/list/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/list/ListActivityTest.kt
@@ -153,14 +153,6 @@ class ListActivityTest : BaseListActivityTest() {
   }
 
   @Test
-  fun listActivity_withTrendingType_showsCorrectViews() {
-    context.launchListActivity(movieGenreArgs.copy(listType = ListType.TRENDING)) {
-      onView(withText("title"))
-        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    }
-  }
-
-  @Test
   fun listActivity_toggleButtonPressed_changesTheLayout() {
     context.launchListActivity {
       // should use grid layout on initial 

--- a/feature/list/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/list/ListActivityTest.kt
+++ b/feature/list/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/list/ListActivityTest.kt
@@ -194,8 +194,8 @@ class ListActivityTest : BaseListActivityTest() {
 
   @Test
   fun listActivity_whenAdapterIsEmpty_doesNotLoadBackdrop() {
-    every { mockListViewModel.getMovieByKeywords(any()) } returns flowOf(PagingData.empty())
-    every { mockListViewModel.getTvByKeywords(any()) } returns flowOf(PagingData.empty())
+    every { mockListViewModel.getByKeyword(any(), any()) } returns flowOf(PagingData.empty())
+    every { mockListViewModel.getByKeyword(any(), any()) } returns flowOf(PagingData.empty())
 
     context.launchListActivity(movieKeywordsArgs) { scenario ->
       scenario.onActivity { activity ->
@@ -215,7 +215,7 @@ class ListActivityTest : BaseListActivityTest() {
 
   @Test
   fun onKeywordsLoadState_itemCountZero_skipsShowBackdrop() {
-    every { mockListViewModel.getMovieByKeywords(any()) } returns flowOf(PagingData.empty())
+    every { mockListViewModel.getByKeyword(any(), any()) } returns flowOf(PagingData.empty())
 
     context.launchListActivity(movieKeywordsArgs) { scenario ->
       scenario.onActivity { activity ->

--- a/feature/list/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/list/testutils/BaseListActivityTest.kt
+++ b/feature/list/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/list/testutils/BaseListActivityTest.kt
@@ -70,12 +70,15 @@ open class BaseListActivityTest {
     id = 12344
   )
 
-
   protected fun setupMock(viewModel: ListViewModel, navigator: INavigator) {
-    every { viewModel.getMovieByGenres(any()) } returns listResultsFlow
-    every { viewModel.getTvByGenres(any()) } returns listResultsFlow
-    every { viewModel.getMovieByKeywords(any()) } returns listResultsFlow
-    every { viewModel.getTvByKeywords(any()) } returns listResultsFlow
+    every { viewModel.getAiringThisWeekTv() } returns listResultsFlow
+    every { viewModel.getByGenre(any(), any()) } returns listResultsFlow
+    every { viewModel.getByKeyword(any(), any()) } returns listResultsFlow
+    every { viewModel.getNowPlaying(any()) } returns listResultsFlow
+    every { viewModel.getRecommendation(any(), any()) } returns listResultsFlow
+    every { viewModel.getTopRated(any()) } returns listResultsFlow
+    every { viewModel.getUpcomingMovies() } returns listResultsFlow
+    every { viewModel.getPopular(any()) } returns listResultsFlow
     every { navigator.openDetails(any(), any()) } just Runs
   }
 

--- a/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/ListActivity.kt
+++ b/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/ListActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
@@ -33,13 +34,12 @@ import com.waffiq.bazz_movies.core.designsystem.R.string.upcoming
 import com.waffiq.bazz_movies.core.uihelper.mappers.UIStateMapper.toUiState
 import com.waffiq.bazz_movies.core.uihelper.state.UIState
 import com.waffiq.bazz_movies.core.uihelper.state.isLoading
-import com.waffiq.bazz_movies.core.utils.FlowUtils.collectAndSubmitData
+import com.waffiq.bazz_movies.core.utils.FlowUtils.load
 import com.waffiq.bazz_movies.core.utils.GenreHelper.getGenreName
 import com.waffiq.bazz_movies.feature.list.databinding.ActivityListBinding
 import com.waffiq.bazz_movies.feature.list.ui.adapter.ListAdapter
 import com.waffiq.bazz_movies.feature.list.ui.viewmodel.ListViewModel
-import com.waffiq.bazz_movies.feature.list.utils.BackdropHelper.getBackdropMovieGenre
-import com.waffiq.bazz_movies.feature.list.utils.BackdropHelper.getBackdropTvGenre
+import com.waffiq.bazz_movies.feature.list.utils.BackdropHelper.getBackdrop
 import com.waffiq.bazz_movies.feature.list.utils.Helper.capitaliseEachWord
 import com.waffiq.bazz_movies.feature.list.utils.ParcelableHelper.extractArgsItemFromIntent
 import com.waffiq.bazz_movies.navigation.INavigator
@@ -92,45 +92,21 @@ class ListActivity : AppCompatActivity() {
     adapter.setMediaType(args.mediaType)
     binding.toolbar.subtitle = args.mediaType.uppercase()
 
+    shouldUpdateBackdropFromItems = args.listType.shouldUpdateBackdrop()
+
+    handleListType(args)
+  }
+
+  private fun handleListType(args: ListArgs) {
     when (args.listType) {
       ListType.BY_GENRE -> showListBasedGenre(args)
-
-      // static backdrop, no loadStateChanged
-      ListType.BY_KEYWORD -> {
-        shouldUpdateBackdropFromItems = true
-        showListBasedKeywords(args)
-      }
-
-      ListType.NOW_PLAYING -> {
-        shouldUpdateBackdropFromItems = true
-        showNowPlaying(args)
-      }
-
-      ListType.POPULAR -> {
-        shouldUpdateBackdropFromItems = true
-        showPopular(args)
-      }
-
-      ListType.TOP_RATED -> {
-        shouldUpdateBackdropFromItems = true
-        showTopRated(args)
-      }
-
-      ListType.UPCOMING -> {
-        shouldUpdateBackdropFromItems = true
-        showUpcomingMovies()
-      }
-
-      ListType.AIRING_THIS_WEEK -> {
-        shouldUpdateBackdropFromItems = true
-        showTvAiringThisWeek()
-      }
-
-      ListType.RECOMMENDATION -> {
-        shouldUpdateBackdropFromItems = false
-        showRecommendation(args)
-      }
-
+      ListType.BY_KEYWORD -> showListBasedKeywords(args)
+      ListType.NOW_PLAYING -> showNowPlaying(args)
+      ListType.POPULAR -> showPopular(args)
+      ListType.TOP_RATED -> showTopRated(args)
+      ListType.UPCOMING -> showUpcomingMovies()
+      ListType.AIRING_THIS_WEEK -> showTvAiringThisWeek()
+      ListType.RECOMMENDATION -> showRecommendation(args)
       else -> binding.toolbar.title = args.title
     }
   }
@@ -148,27 +124,6 @@ class ListActivity : AppCompatActivity() {
     }
   }
 
-  private fun showListBasedGenre(args: ListArgs) {
-    val backdrop = if (args.mediaType == MOVIE_MEDIA_TYPE) {
-      getBackdropMovieGenre(args.id)
-    } else {
-      getBackdropTvGenre(args.id)
-    }
-    showBackdrop(backdrop)
-    binding.toolbar.title = getGenreName(args.id)
-    collectAndSubmitData(
-      this,
-      {
-        if (args.mediaType == MOVIE_MEDIA_TYPE) {
-          viewModel.getMovieByGenres(args.id.toString())
-        } else {
-          viewModel.getTvByGenres(args.id.toString())
-        }
-      },
-      adapter,
-    )
-  }
-
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal fun handleRefreshState(state: UIState<Unit>) {
     binding.loadingIndicator.isVisible = state.isLoading
@@ -178,92 +133,57 @@ class ListActivity : AppCompatActivity() {
     binding.illustrationError.btnTryAgain.isVisible = state is UIState.Error
   }
 
+  private fun showListBasedGenre(args: ListArgs) {
+    showBackdrop(getBackdrop(args.mediaType, args.id))
+    binding.toolbar.title = getGenreName(args.id)
+    load(viewModel.getByGenre(args.mediaType, args.id.toString()), adapter)
+  }
+
   private fun showListBasedKeywords(args: ListArgs) {
-    binding.toolbar.title = args.title.capitaliseEachWord()
-    collectAndSubmitData(
-      this,
-      {
-        if (args.mediaType == MOVIE_MEDIA_TYPE) {
-          viewModel.getMovieByKeywords(args.id.toString())
-        } else {
-          viewModel.getTvByKeywords(args.id.toString())
-        }
-      },
-      adapter,
-    )
+    setToolbarTitle(args.title.capitaliseEachWord())
+    load(viewModel.getByKeyword(args.mediaType, args.id.toString()), adapter)
   }
 
   private fun showUpcomingMovies() {
-    binding.toolbar.title = getString(upcoming)
-    collectAndSubmitData(this, { viewModel.getUpcomingMovies() }, adapter)
+    setToolbarTitle(upcoming)
+    load(viewModel.getUpcomingMovies(), adapter)
   }
 
   private fun showTvAiringThisWeek() {
-    binding.toolbar.title = getString(airing_this_week)
-    collectAndSubmitData(this, { viewModel.getAiringThisWeekTv() }, adapter)
+    setToolbarTitle(airing_this_week)
+    load(viewModel.getAiringThisWeekTv(), adapter)
   }
 
   private fun showNowPlaying(args: ListArgs) {
-    collectAndSubmitData(
-      this,
-      {
-        if (args.mediaType == MOVIE_MEDIA_TYPE) {
-          binding.toolbar.title = getString(now_playing)
-          viewModel.getPlayingNowMovies()
-        } else {
-          binding.toolbar.title = getString(airing_today)
-          viewModel.getAiringTodayTv()
-        }
-      },
-      adapter,
+    setToolbarTitle(
+      if (args.mediaType == MOVIE_MEDIA_TYPE) getString(now_playing) else getString(airing_today)
     )
+    load(viewModel.getNowPlaying(args.mediaType), adapter)
   }
 
   private fun showTopRated(args: ListArgs) {
-    binding.toolbar.title = getString(top_rated)
-    collectAndSubmitData(
-      this,
-      {
-        if (args.mediaType == MOVIE_MEDIA_TYPE) {
-          viewModel.getTopRatedMovies()
-        } else {
-          viewModel.getTopRatedTv()
-        }
-      },
-      adapter,
-    )
+    setToolbarTitle(top_rated)
+    load(viewModel.getTopRated(args.mediaType), adapter)
   }
 
   private fun showPopular(args: ListArgs) {
-    binding.toolbar.title = getString(popular)
-    collectAndSubmitData(
-      this,
-      {
-        if (args.mediaType == MOVIE_MEDIA_TYPE) {
-          viewModel.getPopularMovies()
-        } else {
-          viewModel.getPopularTv()
-        }
-      },
-      adapter,
-    )
+    setToolbarTitle(popular)
+    load(viewModel.getPopular(args.mediaType), adapter)
   }
 
   private fun showRecommendation(args: ListArgs) {
-    binding.toolbar.title = args.title
+    setToolbarTitle(args.title)
     binding.toolbar.subtitle = getString(recommendation)
     showBackdrop(args.backdrop)
-    collectAndSubmitData(
-      this,
-      {
-        if (args.mediaType == MOVIE_MEDIA_TYPE) {
-          viewModel.getMovieRecommendation(args.id)
-        } else {
-          viewModel.getTvRecommendation(args.id)
-        }
-      },
-      adapter,
-    )
+    load(viewModel.getRecommendation(args.mediaType, args.id), adapter)
+  }
+
+  private fun setToolbarTitle(@StringRes res: Int) {
+    binding.toolbar.title = getString(res)
+  }
+
+  private fun setToolbarTitle(text: String) {
+    binding.toolbar.title = text
   }
 
   @VisibleForTesting

--- a/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/ListActivity.kt
+++ b/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/ListActivity.kt
@@ -97,18 +97,19 @@ class ListActivity : AppCompatActivity() {
     handleListType(args)
   }
 
+  private val handlers: Map<ListType, (ListArgs) -> Unit> = mapOf(
+    ListType.BY_GENRE to ::showListBasedGenre,
+    ListType.BY_KEYWORD to ::showListBasedKeywords,
+    ListType.NOW_PLAYING to ::showNowPlaying,
+    ListType.POPULAR to ::showPopular,
+    ListType.TOP_RATED to ::showTopRated,
+    ListType.UPCOMING to { showUpcomingMovies() },
+    ListType.AIRING_THIS_WEEK to { showTvAiringThisWeek() },
+    ListType.RECOMMENDATION to ::showRecommendation,
+  )
+
   private fun handleListType(args: ListArgs) {
-    when (args.listType) {
-      ListType.BY_GENRE -> showListBasedGenre(args)
-      ListType.BY_KEYWORD -> showListBasedKeywords(args)
-      ListType.NOW_PLAYING -> showNowPlaying(args)
-      ListType.POPULAR -> showPopular(args)
-      ListType.TOP_RATED -> showTopRated(args)
-      ListType.UPCOMING -> showUpcomingMovies()
-      ListType.AIRING_THIS_WEEK -> showTvAiringThisWeek()
-      ListType.RECOMMENDATION -> showRecommendation(args)
-      else -> binding.toolbar.title = args.title
-    }
+    handlers.getValue(args.listType).invoke(args)
   }
 
   private fun observeLoadState() {

--- a/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModel.kt
+++ b/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
-import com.waffiq.bazz_movies.core.data.domain.usecase.listmovie.GetListMoviesUseCase
-import com.waffiq.bazz_movies.core.data.domain.usecase.listtv.GetListTvUseCase
 import com.waffiq.bazz_movies.core.domain.MediaItem
+import com.waffiq.bazz_movies.core.movie.domain.usecase.listmovie.GetListMoviesUseCase
+import com.waffiq.bazz_movies.core.movie.domain.usecase.listtv.GetListTvUseCase
 import com.waffiq.bazz_movies.feature.list.domain.usecase.GetListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow

--- a/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModel.kt
+++ b/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModel.kt
@@ -4,9 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
+import com.waffiq.bazz_movies.core.data.domain.usecase.listmovie.GetListMoviesUseCase
+import com.waffiq.bazz_movies.core.data.domain.usecase.listtv.GetListTvUseCase
 import com.waffiq.bazz_movies.core.domain.MediaItem
-import com.waffiq.bazz_movies.core.movie.domain.usecase.listmovie.GetListMoviesUseCase
-import com.waffiq.bazz_movies.core.movie.domain.usecase.listtv.GetListTvUseCase
 import com.waffiq.bazz_movies.feature.list.domain.usecase.GetListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
@@ -19,45 +20,33 @@ class ListViewModel @Inject constructor(
   private val getListTvUseCase: GetListTvUseCase,
 ) : ViewModel() {
 
-  fun getMovieByGenres(genres: String): Flow<PagingData<MediaItem>> =
-    getListUseCase.getMovieByGenres(genres).cachedIn(viewModelScope)
+  fun getByGenre(mediaType: String, id: String) =
+    (if (mediaType == MOVIE_MEDIA_TYPE) getListUseCase.getMovieByGenres(id)
+    else getListUseCase.getTvByGenres(id)).cachedIn(viewModelScope)
 
-  fun getTvByGenres(genres: String): Flow<PagingData<MediaItem>> =
-    getListUseCase.getTvByGenres(genres).cachedIn(viewModelScope)
+  fun getByKeyword(mediaType: String, id: String) =
+    (if (mediaType == MOVIE_MEDIA_TYPE) getListUseCase.getMovieByKeywords(id)
+    else getListUseCase.getTvByKeywords(id)).cachedIn(viewModelScope)
 
-  fun getMovieByKeywords(keywords: String): Flow<PagingData<MediaItem>> =
-    getListUseCase.getMovieByKeywords(keywords).cachedIn(viewModelScope)
+  fun getNowPlaying(mediaType: String) =
+    (if (mediaType == MOVIE_MEDIA_TYPE) getListMoviesUseCase.getPlayingNowMovies()
+    else getListTvUseCase.getAiringTodayTv()).cachedIn(viewModelScope)
 
-  fun getTvByKeywords(keywords: String): Flow<PagingData<MediaItem>> =
-    getListUseCase.getTvByKeywords(keywords).cachedIn(viewModelScope)
+  fun getPopular(mediaType: String) =
+    (if (mediaType == MOVIE_MEDIA_TYPE) getListMoviesUseCase.getPopularMovies()
+    else getListTvUseCase.getPopularTv()).cachedIn(viewModelScope)
+
+  fun getTopRated(mediaType: String) =
+    (if (mediaType == MOVIE_MEDIA_TYPE) getListMoviesUseCase.getTopRatedMovies()
+    else getListTvUseCase.getTopRatedTv()).cachedIn(viewModelScope)
+
+  fun getRecommendation(mediaType: String, id: Int) =
+    (if (mediaType == MOVIE_MEDIA_TYPE) getListMoviesUseCase.getMovieRecommendation(id)
+    else getListTvUseCase.getTvRecommendation(id)).cachedIn(viewModelScope)
 
   fun getUpcomingMovies(): Flow<PagingData<MediaItem>> =
     getListMoviesUseCase.getUpcomingMovies().cachedIn(viewModelScope)
 
-  fun getPlayingNowMovies(): Flow<PagingData<MediaItem>> =
-    getListMoviesUseCase.getPlayingNowMovies().cachedIn(viewModelScope)
-
-  fun getPopularMovies(): Flow<PagingData<MediaItem>> =
-    getListMoviesUseCase.getPopularMovies().cachedIn(viewModelScope)
-
-  fun getTopRatedMovies(): Flow<PagingData<MediaItem>> =
-    getListMoviesUseCase.getTopRatedMovies().cachedIn(viewModelScope)
-
-  fun getMovieRecommendation(movieId: Int): Flow<PagingData<MediaItem>> =
-    getListMoviesUseCase.getMovieRecommendation(movieId).cachedIn(viewModelScope)
-
-  fun getPopularTv(): Flow<PagingData<MediaItem>> =
-    getListTvUseCase.getPopularTv().cachedIn(viewModelScope)
-
-  fun getTopRatedTv(): Flow<PagingData<MediaItem>> =
-    getListTvUseCase.getTopRatedTv().cachedIn(viewModelScope)
-
   fun getAiringThisWeekTv(): Flow<PagingData<MediaItem>> =
     getListTvUseCase.getAiringThisWeekTv().cachedIn(viewModelScope)
-
-  fun getAiringTodayTv(): Flow<PagingData<MediaItem>> =
-    getListTvUseCase.getAiringTodayTv().cachedIn(viewModelScope)
-
-  fun getTvRecommendation(tvId: Int): Flow<PagingData<MediaItem>> =
-    getListTvUseCase.getTvRecommendation(tvId).cachedIn(viewModelScope)
 }

--- a/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/utils/BackdropHelper.kt
+++ b/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/utils/BackdropHelper.kt
@@ -1,7 +1,13 @@
 package com.waffiq.bazz_movies.feature.list.utils
 
+import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
+
 @Suppress("MagicNumber", "CyclomaticComplexMethod")
 object BackdropHelper {
+
+  fun getBackdrop(mediaType: String, id: Int) =
+    if (mediaType == MOVIE_MEDIA_TYPE) getBackdropMovieGenre(id) else getBackdropTvGenre(id)
+
   fun getBackdropMovieGenre(genreId: Int): String =
     when (genreId) {
       28 -> "/jDnhdNm7XVwl0GisIV77o64EcDa.jpg"

--- a/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/utils/ParcelableHelper.kt
+++ b/feature/list/src/main/kotlin/com/waffiq/bazz_movies/feature/list/utils/ParcelableHelper.kt
@@ -8,7 +8,8 @@ import com.waffiq.bazz_movies.navigation.ListArgs
 
 object ParcelableHelper {
 
-  fun extractArgsItemFromIntent(intent: Intent): ListArgs? = try {
+  fun extractArgsItemFromIntent(intent: Intent): ListArgs? =
+    try {
       intent.setExtrasClassLoader(ListArgs::class.java.classLoader)
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModelTest.kt
+++ b/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModelTest.kt
@@ -3,9 +3,9 @@ package com.waffiq.bazz_movies.feature.list.ui.viewmodel
 import androidx.paging.PagingData
 import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
-import com.waffiq.bazz_movies.core.data.domain.usecase.listmovie.GetListMoviesUseCase
-import com.waffiq.bazz_movies.core.data.domain.usecase.listtv.GetListTvUseCase
 import com.waffiq.bazz_movies.core.domain.MediaItem
+import com.waffiq.bazz_movies.core.movie.domain.usecase.listmovie.GetListMoviesUseCase
+import com.waffiq.bazz_movies.core.movie.domain.usecase.listtv.GetListTvUseCase
 import com.waffiq.bazz_movies.core.test.PagingFlowHelperTest.testPagingFlowCancelRemaining
 import com.waffiq.bazz_movies.feature.list.domain.usecase.GetListUseCase
 import com.waffiq.bazz_movies.feature.list.testutils.DummyData.fakeMovieMediaItemPagingData

--- a/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModelTest.kt
+++ b/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/ui/viewmodel/ListViewModelTest.kt
@@ -1,9 +1,11 @@
 package com.waffiq.bazz_movies.feature.list.ui.viewmodel
 
 import androidx.paging.PagingData
+import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
+import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
+import com.waffiq.bazz_movies.core.data.domain.usecase.listmovie.GetListMoviesUseCase
+import com.waffiq.bazz_movies.core.data.domain.usecase.listtv.GetListTvUseCase
 import com.waffiq.bazz_movies.core.domain.MediaItem
-import com.waffiq.bazz_movies.core.movie.domain.usecase.listmovie.GetListMoviesUseCase
-import com.waffiq.bazz_movies.core.movie.domain.usecase.listtv.GetListTvUseCase
 import com.waffiq.bazz_movies.core.test.PagingFlowHelperTest.testPagingFlowCancelRemaining
 import com.waffiq.bazz_movies.feature.list.domain.usecase.GetListUseCase
 import com.waffiq.bazz_movies.feature.list.testutils.DummyData.fakeMovieMediaItemPagingData
@@ -23,6 +25,9 @@ import kotlinx.coroutines.test.setMain
 class ListViewModelTest : BehaviorSpec({
 
   val id = 1234512
+
+  val movieMediaType = MOVIE_MEDIA_TYPE
+  val tvMediaType = TV_MEDIA_TYPE
 
   val testDispatcher = UnconfinedTestDispatcher()
 
@@ -74,7 +79,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeMovieMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getMovieByGenres("1") },
+        flowProvider = { viewModel.getByGenre(movieMediaType, "1") },
         expected = expectedMovie,
       )
     }
@@ -84,7 +89,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeTvMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getTvByGenres("1") },
+        flowProvider = { viewModel.getByGenre(tvMediaType, "1") },
       )
     }
   }
@@ -96,7 +101,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeMovieMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getMovieByKeywords("1") },
+        flowProvider = { viewModel.getByKeyword(movieMediaType, "1") },
         expected = expectedMovie,
       )
     }
@@ -106,7 +111,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeTvMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getTvByKeywords("1") },
+        flowProvider = { viewModel.getByKeyword(tvMediaType, "1") },
       )
     }
   }
@@ -128,7 +133,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeMovieMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getPlayingNowMovies() },
+        flowProvider = { viewModel.getNowPlaying(movieMediaType) },
         expected = expectedMovie,
       )
     }
@@ -138,7 +143,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeMovieMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getPopularMovies() },
+        flowProvider = { viewModel.getPopular(movieMediaType) },
         expected = expectedMovie,
       )
     }
@@ -148,7 +153,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeMovieMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getTopRatedMovies() },
+        flowProvider = { viewModel.getTopRated(movieMediaType) },
         expected = expectedMovie,
       )
     }
@@ -158,7 +163,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeMovieMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getMovieRecommendation(id) },
+        flowProvider = { viewModel.getRecommendation(movieMediaType, id) },
         expected = expectedMovie,
       )
     }
@@ -171,7 +176,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeTvMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getPopularTv() },
+        flowProvider = { viewModel.getPopular(tvMediaType) },
       )
     }
 
@@ -180,7 +185,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeTvMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getTopRatedTv() },
+        flowProvider = { viewModel.getTopRated(tvMediaType) },
       )
     }
 
@@ -198,7 +203,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeTvMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getAiringTodayTv() },
+        flowProvider = { viewModel.getNowPlaying(tvMediaType) },
       )
     }
 
@@ -207,7 +212,7 @@ class ListViewModelTest : BehaviorSpec({
         flowOf(fakeTvMediaItemPagingData)
 
       thenEmitsCorrectItem(
-        flowProvider = { viewModel.getTvRecommendation(id) },
+        flowProvider = { viewModel.getRecommendation(tvMediaType, id) },
       )
     }
   }

--- a/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/utils/GetBackdropGenreTest.kt
+++ b/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/utils/GetBackdropGenreTest.kt
@@ -1,14 +1,22 @@
 package com.waffiq.bazz_movies.feature.list.utils
 
+import com.waffiq.bazz_movies.feature.list.utils.BackdropHelper.getBackdrop
 import com.waffiq.bazz_movies.feature.list.utils.BackdropHelper.getBackdropMovieGenre
 import com.waffiq.bazz_movies.feature.list.utils.BackdropHelper.getBackdropTvGenre
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import kotlin.test.assertEquals
 
 class GetBackdropGenreTest : BehaviorSpec({
 
   given("a known movie genre id") {
+    `when`("getBackdrop is called") {
+      then("should return correct backdrop url") {
+        assertEquals("/kPmE7vEwQWSvhQt5P0ZR8NIwNRN.jpg", getBackdrop("movie", 16))
+      }
+    }
+
     `when`("getBackdropMovieGenre is called") {
       withData(
         nameFn = { (genreId, _) -> "genreId=$genreId" },
@@ -48,6 +56,12 @@ class GetBackdropGenreTest : BehaviorSpec({
   }
 
   given("a known tv genre id") {
+    `when`("getBackdrop is called") {
+      then("should return correct backdrop url") {
+        assertEquals("/cvytcYJFiVlp3tVUIfjSRHcSTfS.jpg", getBackdrop("tv", 16))
+      }
+    }
+
     `when`("getBackdropTvGenre is called") {
       withData(
         nameFn = { (genreId, _) -> "genreId=$genreId" },

--- a/navigation/src/main/kotlin/com/waffiq/bazz_movies/navigation/ListType.kt
+++ b/navigation/src/main/kotlin/com/waffiq/bazz_movies/navigation/ListType.kt
@@ -9,5 +9,11 @@ enum class ListType {
   RECOMMENDATION,
   TOP_RATED,
   TRENDING,
-  UPCOMING,
+  UPCOMING;
+
+  fun shouldUpdateBackdrop() = when (this) {
+    BY_GENRE -> false
+    RECOMMENDATION -> false
+    else -> true
+  }
 }


### PR DESCRIPTION
## Summary

Refactor to shift movie type comparison logic from `ListActivity` to `ListViewModel`, improving separation of concerns and simplifying the UI layer.

## Changes Made

- Reduce UI complexity
- Improve architecture (logic in ViewModel)
- Update tests to reflect changes