### PR TITLE
chore: remove unnecessary when statement

### DIFF
--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getOmdbDetail/GetOMDbDetailInteractor.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/domain/usecase/getOmdbDetail/GetOMDbDetailInteractor.kt
@@ -25,15 +25,11 @@ class GetOMDbDetailInteractor @Inject constructor(
       .filterIsInstance<Outcome.Success<TvExternalIds>>()
       .take(1)
       .flatMapConcat { outcome ->
-        when (outcome) {
-          is Outcome.Success -> {
-            val imdbId = outcome.data.imdbId
-            if (imdbId.isNullOrEmpty()) {
-              flowOf(Outcome.Error(""))
-            } else {
-              detailRepository.getOMDbDetails(imdbId)
-            }
-          }
+        val imdbId = outcome.data.imdbId
+        if (imdbId.isNullOrEmpty()) {
+          flowOf(Outcome.Error(""))
+        } else {
+          detailRepository.getOMDbDetails(imdbId)
         }
       }
 }


### PR DESCRIPTION
### Changes Made

- Remove redundant `when` statement since it always returns `Outcome.Success` (caused compiler warning for always-true condition)