### PR TITLE
fix: prevent crash when opening URL without browser

### DIFF
--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
   <string name="retry">Retry</string>
   <string name="login_as_guest_successful">Login as Guest Successful</string>
   <string name="login_as_user_successful">Login Successful</string>
+  <string name="no_browser_installed">"No browser installed"</string>
 
   <!-- BOTTOM NAVIGATION -->
   <string name="title_home">Home</string>

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
   // testing
   testImplementation(libs.androidx.core.testing)
+  testImplementation(libs.androidx.test.core.ktx)
   testImplementation(libs.kotlinx.coroutines.test)
   testImplementation(libs.mockito.core)
   testImplementation(libs.mockk)

--- a/feature/login/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginActivityTest.kt
+++ b/feature/login/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginActivityTest.kt
@@ -1,22 +1,18 @@
 package com.waffiq.bazz_movies.feature.login.ui
 
-import android.app.Activity
-import android.app.Instrumentation.ActivityResult
 import android.content.Context
-import android.content.Intent
 import android.content.res.Configuration
 import android.view.View
 import android.widget.EditText
+import androidx.core.net.toUri
 import androidx.lifecycle.MutableLiveData
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.Intents.intended
-import androidx.test.espresso.intent.Intents.intending
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.rule.IntentsRule
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -24,6 +20,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.waffiq.bazz_movies.core.designsystem.R.string.guest_user
 import com.waffiq.bazz_movies.core.domain.UserModel
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomAssertions.isPasswordHidden
+import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewActions.performAction
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewActions.performClick
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewActions.performType
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewMatchers.doesHaveText
@@ -45,6 +42,9 @@ import com.waffiq.bazz_movies.feature.login.R.id.layout_bazz_movies
 import com.waffiq.bazz_movies.feature.login.R.id.progress_bar
 import com.waffiq.bazz_movies.feature.login.R.id.tv_guest
 import com.waffiq.bazz_movies.feature.login.R.id.tv_joinTMDB
+import com.waffiq.bazz_movies.feature.login.ui.testutils.FakeUriLauncher
+import com.waffiq.bazz_movies.feature.login.utils.common.Constants.TMDB_LINK_FORGET_PASSWORD
+import com.waffiq.bazz_movies.feature.login.utils.common.Constants.TMDB_LINK_SIGNUP
 import com.waffiq.bazz_movies.navigation.INavigator
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -56,7 +56,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
-import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -75,10 +75,13 @@ class LoginActivityTest {
 
   private lateinit var context: Context
 
-  @get:Rule
+  @get:Rule(order = 0)
   var hiltRule = HiltAndroidRule(this)
 
-  @get:Rule
+  @get:Rule(order = 1)
+  var intentsRule = IntentsRule()
+
+  @get:Rule(order = 2)
   var activityRule = ActivityScenarioRule(LoginActivity::class.java)
 
   @BindValue
@@ -96,7 +99,6 @@ class LoginActivityTest {
   @Before
   fun init() {
     hiltRule.inject()
-    Intents.init()
 
     activityRule.scenario.onActivity { activity ->
       context = activity.applicationContext
@@ -107,11 +109,6 @@ class LoginActivityTest {
     every { mockAuthViewModel.userModel } returns userModelLiveData
     every { mockAuthViewModel.loadingState } returns loadingStateLiveData
     every { mockUserPrefViewModel.saveUserPref(any()) } just Runs
-  }
-
-  @After
-  fun tearDown() {
-    Intents.release()
   }
 
   @Test
@@ -138,41 +135,88 @@ class LoginActivityTest {
   }
 
   @Test
-  fun login_withoutUsernameAndPassword_showsErrorMessage() {
-    // click login button without entering username/password
-    btn_login.performClick()
+  fun clickForgetPassword_successful_launchesCorrectURI() {
+    btn_forget_password.performClick()
 
-    // verify that error messages are shown
-    ed_username.hasErrorText("Please enter a username")
-    ed_pass.hasErrorText("Please enter a password")
+    activityRule.scenario.onActivity { activity ->
+      val fake = activity.uriLauncher as FakeUriLauncher
+      assertEquals(TMDB_LINK_FORGET_PASSWORD.toUri(), fake.launchedUris.first())
+    }
   }
 
   @Test
-  fun login_withOnlyUsername_showsPasswordError() {
+  fun clickJoinTMDB_successful_launchesCorrectURI() {
+    tv_joinTMDB.performClick()
+
+    activityRule.scenario.onActivity { activity ->
+      val fake = activity.uriLauncher as FakeUriLauncher
+      assertEquals(TMDB_LINK_SIGNUP.toUri(), fake.launchedUris.first())
+    }
+  }
+
+  @Test
+  fun clickJoinTMDB_noBrowser_launchesToast() {
+    activityRule.scenario.onActivity { activity ->
+      (activity.uriLauncher as FakeUriLauncher).shouldFail = true
+    }
+
+    tv_joinTMDB.performClick()
+    // Hard to test toast in code, so must check it manually
+  }
+
+  @Test
+  fun login_withCorrectParams_callsAuthenticationViewModel() {
+    performValidLogin()
+    verify { mockAuthViewModel.userLogin(validUsername, validPassword) }
+  }
+
+  @Test
+  fun login_withIncorrectCredential_showsErrorMessage() {
+    // without entering username/password
+    btn_login.performClick()
+    ed_username.hasErrorText("Please enter a username")
+    ed_pass.hasErrorText("Please enter a password")
+
+    clearForm()
+
+    // only username
     typeUserName(validUsername)
     btn_login.performClick()
-
     ed_username.hasNoError()
     ed_pass.hasErrorText("Please enter a password")
-  }
 
-  @Test
-  fun login_withOnlyPassword_showsUsernameError() {
+    clearForm()
+
+    // only password
     typePassword(validPassword)
     btn_login.performClick()
-
     ed_username.hasErrorText("Please enter a username")
     ed_pass.hasNoError()
-  }
 
-  @Test
-  fun login_withBlankSpaces_showsErrorMessages() {
+    clearForm()
+
+    // blank value
     typeUserName("   ")
     typePassword("   ")
     btn_login.performClick()
-
     ed_username.hasErrorText("Please enter a username")
     ed_pass.hasErrorText("Please enter a password")
+
+    clearForm()
+
+    // empty pass
+    typeUserName(validUsername)
+    typePassword("")
+    btn_login.performClick()
+    ed_pass.hasErrorText("Please enter a password")
+
+    clearForm()
+
+    // empty user
+    typeUserName("")
+    typePassword(validPassword)
+    btn_login.performClick()
+    ed_username.hasErrorText("Please enter a username")
   }
 
   @Test
@@ -194,7 +238,7 @@ class LoginActivityTest {
     ed_pass.performType(validPassword)
 
     // move cursor to middle
-    onView(withId(ed_pass)).perform(clickAtPosition(Random.nextInt(1, 6)))
+    ed_pass.performAction(clickAtPosition(Random.nextInt(1, 6)))
 
     // toggle password visibility
     btn_eye.performClick()
@@ -273,36 +317,6 @@ class LoginActivityTest {
   }
 
   @Test
-  fun forgetPasswordButton_whenClicked_opensWebBrowser() {
-    // mock intent to verify URL opening
-    val expectedIntent = hasAction(Intent.ACTION_VIEW)
-    intending(expectedIntent).respondWith(ActivityResult(Activity.RESULT_OK, null))
-
-    btn_forget_password.performClick()
-
-    // verify intent was sent
-    intended(expectedIntent)
-  }
-
-  @Test
-  fun joinTMDBButton_whenClicked_opensWebBrowser() {
-    // mock intent to verify URL opening
-    val expectedIntent = hasAction(Intent.ACTION_VIEW)
-    intending(expectedIntent).respondWith(ActivityResult(Activity.RESULT_OK, null))
-
-    tv_joinTMDB.performClick()
-
-    // verify intent was sent
-    intended(expectedIntent)
-  }
-
-  @Test
-  fun login_withCorrectParams_callsAuthenticationViewModel() {
-    performValidLogin()
-    verify { mockAuthViewModel.userLogin(validUsername, validPassword) }
-  }
-
-  @Test
   fun loginScreen_whenConfigurationChange_maintainsTheState() {
     typeValidCredentials()
 
@@ -318,6 +332,11 @@ class LoginActivityTest {
     // verify data is maintained
     ed_username.doesHaveText(validUsername)
     ed_pass.doesHaveText(validPassword)
+  }
+
+  private fun clearForm() {
+    ed_username.performAction(clearText())
+    ed_pass.performAction(clearText())
   }
 
   private fun typeUserName(userName: String) {

--- a/feature/login/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/login/ui/testutils/FakeUriLauncher.kt
+++ b/feature/login/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/login/ui/testutils/FakeUriLauncher.kt
@@ -1,0 +1,21 @@
+package com.waffiq.bazz_movies.feature.login.ui.testutils
+
+import android.content.ActivityNotFoundException
+import android.net.Uri
+import androidx.core.net.toUri
+import com.waffiq.bazz_movies.feature.login.utils.openurl.UriLauncher
+import javax.inject.Inject
+
+class FakeUriLauncher @Inject constructor() : UriLauncher {
+  val launchedUris = mutableListOf<Uri>()
+  var shouldFail = false
+
+  override fun launch(url: String): Result<Unit> {
+    return if (shouldFail) {
+      Result.failure(ActivityNotFoundException())
+    } else {
+      launchedUris.add(url.toUri())
+      Result.success(Unit)
+    }
+  }
+}

--- a/feature/login/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/login/ui/testutils/FakeUriLauncherModule.kt
+++ b/feature/login/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/login/ui/testutils/FakeUriLauncherModule.kt
@@ -1,0 +1,20 @@
+package com.waffiq.bazz_movies.feature.login.ui.testutils
+
+import com.waffiq.bazz_movies.feature.login.di.UriLauncherModule
+import com.waffiq.bazz_movies.feature.login.utils.openurl.UriLauncher
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+
+@Suppress("unused")
+@TestInstallIn(
+  components = [SingletonComponent::class],
+  replaces = [UriLauncherModule::class]
+)
+@Module
+fun interface FakeUriLauncherModule {
+
+  @Binds
+  fun bindFakeUriLauncher(impl: FakeUriLauncher): UriLauncher
+}

--- a/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/di/AuthTMDbAccountUseCaseModule.kt
+++ b/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/di/AuthTMDbAccountUseCaseModule.kt
@@ -13,7 +13,6 @@ import dagger.hilt.android.scopes.ViewModelScoped
 @InstallIn(ViewModelComponent::class)
 fun interface AuthTMDbAccountUseCaseModule {
 
-  // region USER
   @Binds
   @ViewModelScoped
   fun bindAuthTMDbAccountUseCase(

--- a/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/di/UriLauncherModule.kt
+++ b/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/di/UriLauncherModule.kt
@@ -1,0 +1,17 @@
+package com.waffiq.bazz_movies.feature.login.di
+
+import com.waffiq.bazz_movies.feature.login.utils.openurl.UriLauncherImpl
+import com.waffiq.bazz_movies.feature.login.utils.openurl.UriLauncher
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Suppress("unused")
+@Module
+@InstallIn(SingletonComponent::class)
+fun interface UriLauncherModule {
+
+  @Binds
+  fun bindUriLauncher(impl: UriLauncherImpl): UriLauncher
+}

--- a/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginActivity.kt
+++ b/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginActivity.kt
@@ -1,6 +1,5 @@
 package com.waffiq.bazz_movies.feature.login.ui
 
-import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Bundle
@@ -9,14 +8,13 @@ import android.text.SpannableStringBuilder
 import android.text.method.HideReturnsTransformationMethod
 import android.text.method.PasswordTransformationMethod
 import android.view.View
+import android.widget.Toast
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
-import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.res.ResourcesCompat
-import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import com.waffiq.bazz_movies.core.common.utils.Constants.ANIM_DURATION
@@ -25,6 +23,7 @@ import com.waffiq.bazz_movies.core.designsystem.R.font.nunito_sans_regular
 import com.waffiq.bazz_movies.core.designsystem.R.string.guest_user
 import com.waffiq.bazz_movies.core.designsystem.R.string.login_as_guest_successful
 import com.waffiq.bazz_movies.core.designsystem.R.string.login_as_user_successful
+import com.waffiq.bazz_movies.core.designsystem.R.string.no_browser_installed
 import com.waffiq.bazz_movies.core.designsystem.R.string.please_enter_a_password
 import com.waffiq.bazz_movies.core.designsystem.R.string.please_enter_a_username
 import com.waffiq.bazz_movies.core.domain.UserModel
@@ -40,6 +39,7 @@ import com.waffiq.bazz_movies.feature.login.utils.CustomTypefaceSpan
 import com.waffiq.bazz_movies.feature.login.utils.InsetListener.applyWindowInsets
 import com.waffiq.bazz_movies.feature.login.utils.common.Constants.TMDB_LINK_FORGET_PASSWORD
 import com.waffiq.bazz_movies.feature.login.utils.common.Constants.TMDB_LINK_SIGNUP
+import com.waffiq.bazz_movies.feature.login.utils.openurl.UriLauncher
 import com.waffiq.bazz_movies.navigation.INavigator
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -50,8 +50,10 @@ class LoginActivity : AppCompatActivity() {
   @Inject
   lateinit var navigator: INavigator
 
-  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-  lateinit var binding: ActivityLoginBinding
+  @Inject
+  lateinit var uriLauncher: UriLauncher
+
+  private lateinit var binding: ActivityLoginBinding
 
   private val authenticationViewModel: AuthenticationViewModel by viewModels()
   private val userPreferenceViewModel: UserPreferenceViewModel by viewModels()
@@ -81,13 +83,19 @@ class LoginActivity : AppCompatActivity() {
     btnGuestListener()
   }
 
+  private fun launchUri(url: String) {
+    uriLauncher.launch(url)
+      .onFailure {
+        Toast.makeText(this, getString(no_browser_installed), Toast.LENGTH_SHORT).show()
+      }
+  }
+
   private fun openTMDB() {
     binding.tvJoinTMDB.setOnClickListener {
-      startActivity(Intent(Intent.ACTION_VIEW, TMDB_LINK_SIGNUP.toUri()))
+      launchUri(TMDB_LINK_SIGNUP)
     }
-
     binding.btnForgetPassword.setOnClickListener {
-      startActivity(Intent(Intent.ACTION_VIEW, TMDB_LINK_FORGET_PASSWORD.toUri()))
+      launchUri(TMDB_LINK_FORGET_PASSWORD)
     }
   }
 
@@ -184,9 +192,7 @@ class LoginActivity : AppCompatActivity() {
   }
 
   private fun formNotEmpty(): Boolean =
-    binding.edUsername.text.isNotEmpty() &&
-      binding.edUsername.text.isNotBlank() &&
-      binding.edPass.text.isNotEmpty() &&
+    binding.edUsername.text.isNotBlank() &&
       binding.edPass.text.isNotBlank()
 
   private fun goToMainActivity(isGuest: Boolean) {

--- a/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/utils/openurl/UriLauncher.kt
+++ b/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/utils/openurl/UriLauncher.kt
@@ -1,0 +1,5 @@
+package com.waffiq.bazz_movies.feature.login.utils.openurl
+
+fun interface UriLauncher {
+  fun launch(url: String): Result<Unit>
+}

--- a/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/utils/openurl/UriLauncherImpl.kt
+++ b/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/utils/openurl/UriLauncherImpl.kt
@@ -1,0 +1,31 @@
+package com.waffiq.bazz_movies.feature.login.utils.openurl
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.net.toUri
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class UriLauncherImpl @Inject constructor(@ApplicationContext private val context: Context) :
+  UriLauncher {
+
+  @Suppress("TooGenericExceptionCaught")
+  override fun launch(url: String): Result<Unit> {
+    val intent = Intent(Intent.ACTION_VIEW, url.toUri()).apply {
+      addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    return try {
+      if (intent.resolveActivity(context.packageManager) != null) {
+        context.startActivity(intent)
+        Result.success(Unit)
+      } else {
+        Result.failure(ActivityNotFoundException("No browser found to handle: $url"))
+      }
+    } catch (e: Exception) {
+      Log.e("UriLauncher", e.toString())
+      Result.failure(e)
+    }
+  }
+}

--- a/feature/login/src/test/kotlin/com/waffiq/bazz_movies/feature/login/utils/openurl/UriLauncherImplTest.kt
+++ b/feature/login/src/test/kotlin/com/waffiq/bazz_movies/feature/login/utils/openurl/UriLauncherImplTest.kt
@@ -1,0 +1,103 @@
+package com.waffiq.bazz_movies.feature.login.utils.openurl
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider
+import com.waffiq.bazz_movies.feature.login.utils.common.Constants.TMDB_LINK_SIGNUP
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+
+@RunWith(RobolectricTestRunner::class)
+class UriLauncherImplTest {
+
+  private lateinit var context: Context
+  private lateinit var launcher: UriLauncherImpl
+
+  @Before
+  fun setUp() {
+    context = ApplicationProvider.getApplicationContext()
+    launcher = UriLauncherImpl(context)
+  }
+
+  @Test
+  fun launch_whenBrowserIsAvailable_returnsSuccess() {
+    registerBrowserForUrl()
+
+    val result = launcher.launch("https://example.com")
+
+    assertTrue(result.isSuccess)
+  }
+
+  @Test
+  fun launch_withCorrectIntent_startsActivity() {
+    registerBrowserForUrl()
+
+    launcher.launch("https://example.com")
+
+    val started = Shadows.shadowOf(context as Application).nextStartedActivity
+    assertNotNull(started)
+    assertEquals(Intent.ACTION_VIEW, started.action)
+    assertEquals("https://example.com".toUri(), started.data)
+  }
+
+  @Test
+  fun launch_whenNoBrowserAvailable_returnsFailure() {
+    // No browser registered
+
+    val result = launcher.launch("https://example.com")
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is ActivityNotFoundException)
+  }
+
+  @Test
+  fun launch_whenStartActivityThrows_returnsFailure() {
+    val context = mockk<Context>(relaxed = true)
+    val packageManager = mockk<PackageManager>()
+    val resolveInfo = mockk<ResolveInfo>()
+
+    every { context.packageManager } returns packageManager
+    every { packageManager.resolveActivity(any<Intent>(),any<Int>()) } returns resolveInfo
+    every { context.startActivity(any()) } throws RuntimeException("boom")
+
+    val launcher = UriLauncherImpl(context)
+    val result = launcher.launch(TMDB_LINK_SIGNUP)
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is RuntimeException)
+  }
+
+  private fun registerBrowserForUrl() {
+    val packageManager = Shadows.shadowOf(context.packageManager)
+    val componentName = ComponentName("com.example.browser", "com.example.browser.BrowserActivity")
+
+    // register the activity
+    packageManager.addActivityIfNotPresent(componentName)
+
+    // intent filter
+    packageManager.addIntentFilterForActivity(
+      componentName,
+      IntentFilter(Intent.ACTION_VIEW).apply {
+        addCategory(Intent.CATEGORY_DEFAULT)
+        addCategory(Intent.CATEGORY_BROWSABLE)
+        addDataScheme("https")
+        addDataScheme("http")
+      }
+    )
+  }
+}


### PR DESCRIPTION
### Changes Made

- Fix #566 
- Introduce `UriLauncher` interface with `ActivityUriLauncher` implementation
- Use injected `UriLauncher` in LoginActivity instead of direct intents to make it testable
- Show toast when no browser is available
- Update related tests