### PR TITLE
refactor: move login logic from ViewModel to use case

### DIFF
--- a/core/user/src/main/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/authtmdbaccount/AuthTMDbAccountInteractor.kt
+++ b/core/user/src/main/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/authtmdbaccount/AuthTMDbAccountInteractor.kt
@@ -1,32 +1,89 @@
 package com.waffiq.bazz_movies.core.user.domain.usecase.authtmdbaccount
 
+import com.waffiq.bazz_movies.core.common.utils.Constants.NAN
 import com.waffiq.bazz_movies.core.domain.Outcome
 import com.waffiq.bazz_movies.core.domain.PostResult
+import com.waffiq.bazz_movies.core.domain.UserModel
 import com.waffiq.bazz_movies.core.user.domain.model.account.AccountDetails
-import com.waffiq.bazz_movies.core.user.domain.model.account.Authentication
-import com.waffiq.bazz_movies.core.user.domain.model.account.CreateSession
 import com.waffiq.bazz_movies.core.user.domain.repository.IUserRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class AuthTMDbAccountInteractor @Inject constructor(
   private val authTMDbAccountRepository: IUserRepository,
 ) : AuthTMDbAccountUseCase {
-  override fun login(
-    username: String,
-    pass: String,
-    sessionId: String,
-  ): Flow<Outcome<Authentication>> = authTMDbAccountRepository.login(username, pass, sessionId)
 
-  override fun createToken(): Flow<Outcome<Authentication>> =
-    authTMDbAccountRepository.createToken()
+  // used only as helper the flow chain
+  private class StepFailureException(val outcomeError: Outcome.Error) : Exception()
+
+  override fun login(username: String, password: String): Flow<Outcome<Unit>> =
+    flow {
+      emit(Outcome.Loading)
+
+      // Official TMDB authentication can be seen here:
+      // https://developer.themoviedb.org/reference/authentication-how-do-i-generate-a-session-id
+      try {
+        // Step 1: Create token
+        val requestToken = authTMDbAccountRepository.createToken()
+          .unwrapStep()
+          .data.requestToken
+          ?: throw StepFailureException(Outcome.Error("Request token was null"))
+
+        // Step 2: Authorize token
+        val authorizedToken = authTMDbAccountRepository.login(username, password, requestToken)
+          .unwrapStep()
+          .data.requestToken
+          ?: throw StepFailureException(Outcome.Error("Authorized token was null"))
+
+        // Step 3: Create session
+        val session = authTMDbAccountRepository.createSessionLogin(authorizedToken)
+          .unwrapStep()
+          .data
+        if (!session.success) throw StepFailureException(Outcome.Error("Session creation failed"))
+        val sessionId = session.sessionId
+
+        // Step 4: Get account details
+        val accountDetails = authTMDbAccountRepository.getAccountDetails(sessionId)
+          .unwrapStep()
+          .data
+
+        // Step 5: Save user
+        authTMDbAccountRepository.saveUserPref(accountDetails.buildUserModel(sessionId))
+        emit(Outcome.Success(Unit))
+      } catch (e: StepFailureException) {
+        emit(e.outcomeError)
+      }
+    }
+
+  /**
+   * Filters loading states, takes the first resolved outcome, and either returns
+   * [Outcome.Success] or throws [StepFailureException]
+   */
+  private suspend fun <T> Flow<Outcome<T>>.unwrapStep(): Outcome.Success<T> {
+    val outcome = filterNot { it is Outcome.Loading }.firstOrNull()
+    return when (outcome) {
+      is Outcome.Success -> outcome
+      is Outcome.Error -> throw StepFailureException(outcome)
+      else -> throw StepFailureException(Outcome.Error("No outcome emitted from step"))
+    }
+  }
+
+  private fun AccountDetails.buildUserModel(sessionId: String) =
+    UserModel(
+      userId = id ?: 0,
+      name = name.toString(),
+      username = username.toString(),
+      password = NAN,
+      region = NAN,
+      token = sessionId,
+      isLogin = true,
+      gravatarHash = avatarItem?.gravatar?.hash,
+      tmdbAvatar = avatarItem?.avatarTMDb?.avatarPath,
+    )
 
   override fun deleteSession(sessionId: String): Flow<Outcome<PostResult>> =
     authTMDbAccountRepository.deleteSession(sessionId)
-
-  override fun createSessionLogin(requestToken: String): Flow<Outcome<CreateSession>> =
-    authTMDbAccountRepository.createSessionLogin(requestToken)
-
-  override fun getAccountDetails(sessionId: String): Flow<Outcome<AccountDetails>> =
-    authTMDbAccountRepository.getAccountDetails(sessionId)
 }

--- a/core/user/src/main/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/authtmdbaccount/AuthTMDbAccountUseCase.kt
+++ b/core/user/src/main/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/authtmdbaccount/AuthTMDbAccountUseCase.kt
@@ -2,20 +2,9 @@ package com.waffiq.bazz_movies.core.user.domain.usecase.authtmdbaccount
 
 import com.waffiq.bazz_movies.core.domain.Outcome
 import com.waffiq.bazz_movies.core.domain.PostResult
-import com.waffiq.bazz_movies.core.user.domain.model.account.AccountDetails
-import com.waffiq.bazz_movies.core.user.domain.model.account.Authentication
-import com.waffiq.bazz_movies.core.user.domain.model.account.CreateSession
 import kotlinx.coroutines.flow.Flow
 
 interface AuthTMDbAccountUseCase {
-  fun login(
-    username: String,
-    pass: String,
-    sessionId: String,
-  ): Flow<Outcome<Authentication>>
-
-  fun createToken(): Flow<Outcome<Authentication>>
+  fun login(username: String, password: String): Flow<Outcome<Unit>>
   fun deleteSession(sessionId: String): Flow<Outcome<PostResult>>
-  fun createSessionLogin(requestToken: String): Flow<Outcome<CreateSession>>
-  fun getAccountDetails(sessionId: String): Flow<Outcome<AccountDetails>>
 }

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/authtmdbaccount/AuthTMDbAccountInteractorTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/authtmdbaccount/AuthTMDbAccountInteractorTest.kt
@@ -3,6 +3,7 @@ package com.waffiq.bazz_movies.core.user.domain.usecase.authtmdbaccount
 import app.cash.turbine.test
 import com.waffiq.bazz_movies.core.domain.Outcome
 import com.waffiq.bazz_movies.core.domain.PostResult
+import com.waffiq.bazz_movies.core.domain.UserModel
 import com.waffiq.bazz_movies.core.user.domain.model.account.AccountDetails
 import com.waffiq.bazz_movies.core.user.domain.model.account.Authentication
 import com.waffiq.bazz_movies.core.user.domain.model.account.AvatarItem
@@ -10,15 +11,20 @@ import com.waffiq.bazz_movies.core.user.domain.model.account.AvatarTMDb
 import com.waffiq.bazz_movies.core.user.domain.model.account.CreateSession
 import com.waffiq.bazz_movies.core.user.domain.model.account.Gravatar
 import com.waffiq.bazz_movies.core.user.domain.repository.IUserRepository
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -26,104 +32,364 @@ import org.mockito.kotlin.whenever
  * Test AuthTMDbAccountInteractor using mockito
  */
 class AuthTMDbAccountInteractorTest {
-  private val sessionId = "session_id"
-  private val errorMessage = "Network error"
-  private val requestToken = "request_token"
 
   private val mockRepository: IUserRepository = mock()
-  private lateinit var authTMDbAccountInteractor: AuthTMDbAccountInteractor
+  private lateinit var interactor: AuthTMDbAccountInteractor
 
   @Before
   fun setup() {
-    authTMDbAccountInteractor = AuthTMDbAccountInteractor(mockRepository)
+    interactor = AuthTMDbAccountInteractor(mockRepository)
   }
 
-  @Test
-  fun login_whenSuccessful_returnsSuccessResult() = runTest {
-    val response = Authentication(
-      success = true,
-      expireAt = "date_expire",
-      requestToken = "request_token_verified"
+  companion object {
+    private const val TEST_USER = "username"
+    private const val TEST_PASS = "password"
+    private const val TEST_TOKEN = "request_token"
+    private const val TEST_SESSION = "session_id"
+    private const val ERROR_MESSAGE = "Network error"
+  }
+
+  // region Helper
+  private fun stubTokenSuccess() {
+    whenever(mockRepository.createToken()).thenReturn(
+      flowOf(Outcome.Success(Authentication(success = true, requestToken = TEST_TOKEN)))
     )
-    val username = "username"
-    val pass = "password"
+  }
 
-    val flow = flowOf(Outcome.Success(response))
-    whenever(mockRepository.login(username, pass, requestToken)).thenReturn(flow)
+  private fun stubLoginSuccess() {
+    whenever(mockRepository.login(TEST_USER, TEST_PASS, TEST_TOKEN)).thenReturn(
+      flowOf(Outcome.Success(Authentication(success = true, requestToken = TEST_TOKEN)))
+    )
+  }
 
-    authTMDbAccountInteractor.login(username, pass, requestToken).test {
-      val emission = awaitItem()
-      assertTrue(emission is Outcome.Success)
-      emission as Outcome.Success
-      assertTrue(emission.data.success)
-      assertEquals("date_expire", emission.data.expireAt)
-      assertEquals("request_token_verified", emission.data.requestToken)
+  private fun stubSessionSuccess() {
+    whenever(mockRepository.createSessionLogin(TEST_TOKEN)).thenReturn(
+      flowOf(Outcome.Success(CreateSession(success = true, sessionId = TEST_SESSION)))
+    )
+  }
+
+  private fun stubAccountDetailsSuccess() {
+    whenever(mockRepository.getAccountDetails(TEST_SESSION)).thenReturn(
+      flowOf(
+        Outcome.Success(
+          AccountDetails(
+            id = 1,
+            name = "Waffiq",
+            username = TEST_USER,
+            avatarItem = AvatarItem(
+              gravatar = Gravatar(hash = "hash123"),
+              avatarTMDb = AvatarTMDb(avatarPath = "/path.jpg")
+            )
+          )
+        )
+      )
+    )
+  }
+  // endregion Helper
+
+  private fun stubFullSuccess() {
+    stubTokenSuccess()
+    stubLoginSuccess()
+    stubSessionSuccess()
+    stubAccountDetailsSuccess()
+  }
+
+  // Success path
+
+  @Test
+  fun login_whenAllStepsSucceed_emitsLoadingThenSuccess() = runTest {
+    stubFullSuccess()
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertTrue(awaitItem() is Outcome.Success)
       awaitComplete()
     }
-    verify(mockRepository, times(1)).login(username, pass, requestToken)
   }
 
   @Test
-  fun login_whenFailedOccur_returnsErrorMessage() = runTest {
-    val username = "username"
-    val pass = "password"
-    val sessionId = "session_id"
+  fun login_whenAllStepsSucceed_callsRepositoryInOrder() = runTest {
+    stubFullSuccess()
 
-    val flow = flowOf(Outcome.Error(message = errorMessage))
-    whenever(mockRepository.login(username, pass, sessionId)).thenReturn(flow)
+    interactor.login(TEST_USER, TEST_PASS).collect()
 
-    authTMDbAccountInteractor.login(username, pass, sessionId).test {
-      val emission = awaitItem()
-      assertTrue(emission is Outcome.Error)
-      emission as Outcome.Error
-      assertEquals(errorMessage, emission.message)
-      awaitComplete()
+    inOrder(mockRepository) {
+      verify(mockRepository).createToken()
+      verify(mockRepository).login(TEST_USER, TEST_PASS, TEST_TOKEN)
+      verify(mockRepository).createSessionLogin(TEST_TOKEN)
+      verify(mockRepository).getAccountDetails(TEST_SESSION)
+      verify(mockRepository).saveUserPref(any())
     }
-    verify(mockRepository, times(1)).login(username, pass, sessionId)
   }
 
   @Test
-  fun createToken_whenSuccessful_returnsSuccessResult() = runTest {
+  fun login_whenAllStepsSucceed_savesCorrectUserModel() = runTest {
+    stubFullSuccess()
+
+    interactor.login(TEST_USER, TEST_PASS).collect()
+
+    val captor = argumentCaptor<UserModel>()
+    verify(mockRepository).saveUserPref(captor.capture())
+    captor.firstValue.also { user ->
+      assertEquals(1, user.userId)
+      assertEquals("Waffiq", user.name)
+      assertEquals(TEST_USER, user.username)
+      assertEquals(TEST_SESSION, user.token)
+      assertTrue(user.isLogin)
+      assertEquals("hash123", user.gravatarHash)
+      assertEquals("/path.jpg", user.tmdbAvatar)
+    }
+  }
+
+  // Step 1: createToken
+
+  @Test
+  fun createToken_errorOutcome_emitErrorAndStopsChain() = runTest {
+    whenever(mockRepository.createToken()).thenReturn(
+      flowOf(Outcome.Error("Token creation failed"))
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Token creation failed", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository).createToken()
+    verify(mockRepository, never()).login(any(), any(), any())
+    verify(mockRepository, never()).createSessionLogin(any())
+    verify(mockRepository, never()).getAccountDetails(any())
+    verify(mockRepository, never()).saveUserPref(any())
+  }
+
+  @Test
+  fun createToken_nullRequestTokenInSuccess_emitsErrorAndStopsChain() = runTest {
+    whenever(mockRepository.createToken()).thenReturn(
+      flowOf(Outcome.Success(Authentication(success = true, requestToken = null)))
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Request token was null", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository).createToken()
+    verify(mockRepository, never()).login(any(), any(), any())
+  }
+
+  @Test
+  fun createToken_unexpectedState_emitsUnexpectedStateError() = runTest {
+    whenever(mockRepository.createToken()).thenReturn(flowOf(Outcome.Loading))
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Unexpected state", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository, never()).login(any(), any(), any())
+  }
+
+  // Step 2: login (authorize token)
+
+  @Test
+  fun authorize_errorOutcome_emitsErrorAndStopsChain() = runTest {
+    stubTokenSuccess()
+    whenever(mockRepository.login(TEST_USER, TEST_PASS, TEST_TOKEN)).thenReturn(
+      flowOf(Outcome.Error("Authorize token failed"))
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Authorize token failed", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository).login(TEST_USER, TEST_PASS, TEST_TOKEN)
+    verify(mockRepository, never()).createSessionLogin(any())
+    verify(mockRepository, never()).saveUserPref(any())
+  }
+
+  @Test
+  fun authorize_nullRequestTokenInSuccess_emitsErrorAndStopsChain() = runTest {
+    stubTokenSuccess()
+    whenever(mockRepository.login(TEST_USER, TEST_PASS, TEST_TOKEN)).thenReturn(
+      flowOf(Outcome.Success(Authentication(success = true, requestToken = null)))
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Authorized token was null", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository).login(TEST_USER, TEST_PASS, TEST_TOKEN)
+    verify(mockRepository, never()).createSessionLogin(any())
+  }
+
+  @Test
+  fun authorize_unexpectedState_emitsUnexpectedStateError() = runTest {
+    stubTokenSuccess()
+    whenever(mockRepository.login(TEST_USER, TEST_PASS, TEST_TOKEN)).thenReturn(
+      flowOf(Outcome.Loading)
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Unexpected state", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository, never()).createSessionLogin(any())
+  }
+
+  // Step 3: createSession
+
+  @Test
+  fun createSession_errorOutcome_emitsErrorAndStopsChain() = runTest {
+    stubTokenSuccess()
+    stubLoginSuccess()
+    whenever(mockRepository.createSessionLogin(TEST_TOKEN)).thenReturn(
+      flowOf(Outcome.Error("Session creation failed"))
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Session creation failed", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository).createSessionLogin(TEST_TOKEN)
+    verify(mockRepository, never()).getAccountDetails(any())
+    verify(mockRepository, never()).saveUserPref(any())
+  }
+
+  @Test
+  fun createSession_unsuccessful_emitsSessionCreationFailedAndStopsChain() = runTest {
+    stubTokenSuccess()
+    stubLoginSuccess()
+    whenever(mockRepository.createSessionLogin(TEST_TOKEN)).thenReturn(
+      flowOf(Outcome.Success(CreateSession(success = false, sessionId = TEST_SESSION)))
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Session creation failed", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository, never()).getAccountDetails(any())
+    verify(mockRepository, never()).saveUserPref(any())
+  }
+
+  @Test
+  fun createSession_unexpectedState_emitsUnexpectedStateError() = runTest {
+    stubTokenSuccess()
+    stubLoginSuccess()
+    whenever(mockRepository.createSessionLogin(TEST_TOKEN)).thenReturn(
+      flowOf(Outcome.Loading)
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Unexpected state", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository, never()).getAccountDetails(any())
+  }
+
+  // Step 4: getAccountDetails
+
+  @Test
+  fun getAccountDetails_errorOutcome_emitsErrorAndNotSaveUser() = runTest {
+    stubTokenSuccess()
+    stubLoginSuccess()
+    stubSessionSuccess()
+    whenever(mockRepository.getAccountDetails(TEST_SESSION)).thenReturn(
+      flowOf(Outcome.Error("Can't get user details"))
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Can't get user details", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository).getAccountDetails(TEST_SESSION)
+    verify(mockRepository, never()).saveUserPref(any())
+  }
+
+  @Test
+  fun getAccountDetails_unexpectedState_emitsUnexpectedStateError() = runTest {
+    stubTokenSuccess()
+    stubLoginSuccess()
+    stubSessionSuccess()
+    whenever(mockRepository.getAccountDetails(TEST_SESSION)).thenReturn(
+      flowOf(Outcome.Loading)
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Unexpected state", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+
+    verify(mockRepository, never()).saveUserPref(any())
+  }
+
+  // Step 5: saveUserPref edge cases
+
+  @Test
+  fun saveUserPref_nullAccountId_savesUserIdAsZero() = runTest {
+    stubTokenSuccess()
+    stubLoginSuccess()
+    stubSessionSuccess()
+    whenever(mockRepository.getAccountDetails(TEST_SESSION)).thenReturn(
+      flowOf(Outcome.Success(AccountDetails(id = null, username = TEST_USER)))
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).collect()
+
+    val captor = argumentCaptor<UserModel>()
+    verify(mockRepository).saveUserPref(captor.capture())
+    assertEquals(0, captor.firstValue.userId)
+  }
+
+  @Test
+  fun saveUserPref_nullAvatars_savesNullGravatarHashAndTmdbAvatar() = runTest {
+    stubTokenSuccess()
+    stubLoginSuccess()
+    stubSessionSuccess()
+    whenever(mockRepository.getAccountDetails(TEST_SESSION)).thenReturn(
+      flowOf(
+        Outcome.Success(
+          AccountDetails(
+            id = 1,
+            username = TEST_USER,
+            avatarItem = AvatarItem(gravatar = null, avatarTMDb = null)
+          )
+        )
+      )
+    )
+
+    interactor.login(TEST_USER, TEST_PASS).collect()
+
+    val captor = argumentCaptor<UserModel>()
+    verify(mockRepository).saveUserPref(captor.capture())
+    assertNull(captor.firstValue.gravatarHash)
+    assertNull(captor.firstValue.tmdbAvatar)
+  }
+
+  @Test
+  fun deleteSession_whenSuccessful_returnsSuccessResult() = runTest {
     val response =
-      Authentication(success = true, expireAt = "date_expire", requestToken = "request_token")
-
+      PostResult(success = true, statusCode = 200, statusMessage = "Delete session success")
     val flow = flowOf(Outcome.Success(response))
-    whenever(mockRepository.createToken()).thenReturn(flow)
+    whenever(mockRepository.deleteSession(TEST_SESSION)).thenReturn(flow)
 
-    authTMDbAccountInteractor.createToken().test {
-      val emission = awaitItem()
-      assertTrue(emission is Outcome.Success)
-      emission as Outcome.Success
-      assertTrue(emission.data.success)
-      assertEquals("date_expire", emission.data.expireAt)
-      assertEquals("request_token", emission.data.requestToken)
-      awaitComplete()
-    }
-    verify(mockRepository, times(1)).createToken()
-  }
-
-  @Test
-  fun createToken_whenFailedOccur_returnsErrorMessage() = runTest {
-    val flow = flowOf(Outcome.Error(message = errorMessage))
-    whenever(mockRepository.createToken()).thenReturn(flow)
-
-    authTMDbAccountInteractor.createToken().test {
-      val emission = awaitItem()
-      assertTrue(emission is Outcome.Error)
-      emission as Outcome.Error
-      assertEquals(errorMessage, emission.message)
-      awaitComplete()
-    }
-    verify(mockRepository, times(1)).createToken()
-  }
-
-  @Test
-  fun deleteSession_whenSuccessfull_returnsSuccessResult() = runTest {
-    val response = PostResult(success = true, statusCode = 200, statusMessage = "Delete session success")
-    val flow = flowOf(Outcome.Success(response))
-    whenever(mockRepository.deleteSession(sessionId)).thenReturn(flow)
-
-    authTMDbAccountInteractor.deleteSession(sessionId).test {
+    interactor.deleteSession(TEST_SESSION).test {
       val emission = awaitItem()
       assertTrue(emission is Outcome.Success)
       emission as Outcome.Success
@@ -132,102 +398,19 @@ class AuthTMDbAccountInteractorTest {
       assertEquals("Delete session success", emission.data.statusMessage)
       awaitComplete()
     }
-    verify(mockRepository, times(1)).deleteSession(sessionId)
+    verify(mockRepository, times(1)).deleteSession(TEST_SESSION)
   }
 
   @Test
   fun deleteSession_whenFailedOccur_returnsErrorMessage() = runTest {
-    val flow = flowOf(Outcome.Error(message = errorMessage))
-    whenever(mockRepository.deleteSession(sessionId)).thenReturn(flow)
+    val flow = flowOf(Outcome.Error(message = ERROR_MESSAGE))
+    whenever(mockRepository.deleteSession(TEST_SESSION)).thenReturn(flow)
 
-    authTMDbAccountInteractor.deleteSession(sessionId).test {
+    interactor.deleteSession(TEST_SESSION).test {
       val emission = awaitItem()
       assertTrue(emission is Outcome.Error)
       emission as Outcome.Error
-      assertEquals(errorMessage, emission.message)
-      awaitComplete()
-    }
-  }
-
-  @Test
-  fun createSession_whenLoginSuccess_returnsSuccessResult() = runTest {
-    val response = CreateSession(success = true, sessionId = "session_id")
-
-    val flow = flowOf(Outcome.Success(response))
-    whenever(mockRepository.createSessionLogin(requestToken)).thenReturn(flow)
-
-    authTMDbAccountInteractor.createSessionLogin(requestToken).test {
-      val emission = awaitItem()
-      assertTrue(emission is Outcome.Success)
-      emission as Outcome.Success
-      assertTrue(emission.data.success)
-      assertEquals("session_id", emission.data.sessionId)
-      awaitComplete()
-    }
-  }
-
-  @Test
-  fun createSession_whenLoginFailed_returnsErrorMessage() = runTest {
-    val flow = flowOf(Outcome.Error(message = errorMessage))
-    whenever(mockRepository.createSessionLogin(requestToken)).thenReturn(flow)
-
-    authTMDbAccountInteractor.createSessionLogin(requestToken).test {
-      val emission = awaitItem()
-      assertTrue(emission is Outcome.Error)
-      emission as Outcome.Error
-      assertEquals(errorMessage, emission.message)
-      awaitComplete()
-    }
-  }
-
-  @Test
-  fun getAccountDetails_whenSuccessful_returnsUserDataCorrectly() = runTest {
-    val response = AccountDetails(
-      includeAdult = false,
-      iso31661 = "en",
-      name = "Waffiq",
-      avatarItem = AvatarItem(
-        gravatar = Gravatar(
-          hash = "325987423659432"
-        ),
-        avatarTMDb = AvatarTMDb(
-          avatarPath = "347589074283054"
-        )
-      ),
-      id = 12345678,
-      iso6391 = "ID",
-      username = "waffiq12345",
-    )
-
-    val flow = flowOf(Outcome.Success(response))
-    whenever(mockRepository.getAccountDetails(sessionId)).thenReturn(flow)
-
-    authTMDbAccountInteractor.getAccountDetails(sessionId).test {
-      val emission = awaitItem()
-      assertTrue(emission is Outcome.Success)
-      emission as Outcome.Success
-      assertFalse(emission.data.includeAdult == true)
-      assertEquals("en", emission.data.iso31661)
-      assertEquals("Waffiq", emission.data.name)
-      assertEquals("325987423659432", emission.data.avatarItem?.gravatar?.hash)
-      assertEquals("347589074283054", emission.data.avatarItem?.avatarTMDb?.avatarPath)
-      assertEquals(12345678, emission.data.id)
-      assertEquals("ID", emission.data.iso6391)
-      assertEquals("waffiq12345", emission.data.username)
-      awaitComplete()
-    }
-  }
-
-  @Test
-  fun getAccountDetails_whenFailedOccur_returnsErrorMessage() = runTest {
-    val flow = flowOf(Outcome.Error(message = errorMessage))
-    whenever(mockRepository.getAccountDetails(sessionId)).thenReturn(flow)
-
-    authTMDbAccountInteractor.getAccountDetails(sessionId).test {
-      val emission = awaitItem()
-      assertTrue(emission is Outcome.Error)
-      emission as Outcome.Error
-      assertEquals(errorMessage, emission.message)
+      assertEquals(ERROR_MESSAGE, emission.message)
       awaitComplete()
     }
   }

--- a/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/authtmdbaccount/AuthTMDbAccountInteractorTest.kt
+++ b/core/user/src/test/kotlin/com/waffiq/bazz_movies/core/user/domain/usecase/authtmdbaccount/AuthTMDbAccountInteractorTest.kt
@@ -85,6 +85,24 @@ class AuthTMDbAccountInteractorTest {
       )
     )
   }
+
+  private suspend fun assertSessionCreationFailed() {
+    performLogin().test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("Session creation failed", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+  }
+
+  private suspend fun assertNoOutcomeEmitted() {
+    performLogin().test {
+      assertTrue(awaitItem() is Outcome.Loading)
+      assertEquals("No outcome emitted from step", (awaitItem() as Outcome.Error).message)
+      awaitComplete()
+    }
+  }
+
+  private fun performLogin() = interactor.login(TEST_USER, TEST_PASS)
   // endregion Helper
 
   private fun stubFullSuccess() {
@@ -100,7 +118,7 @@ class AuthTMDbAccountInteractorTest {
   fun login_whenAllStepsSucceed_emitsLoadingThenSuccess() = runTest {
     stubFullSuccess()
 
-    interactor.login(TEST_USER, TEST_PASS).test {
+    performLogin().test {
       assertTrue(awaitItem() is Outcome.Loading)
       assertTrue(awaitItem() is Outcome.Success)
       awaitComplete()
@@ -111,7 +129,7 @@ class AuthTMDbAccountInteractorTest {
   fun login_whenAllStepsSucceed_callsRepositoryInOrder() = runTest {
     stubFullSuccess()
 
-    interactor.login(TEST_USER, TEST_PASS).collect()
+    performLogin().collect()
 
     inOrder(mockRepository) {
       verify(mockRepository).createToken()
@@ -126,7 +144,7 @@ class AuthTMDbAccountInteractorTest {
   fun login_whenAllStepsSucceed_savesCorrectUserModel() = runTest {
     stubFullSuccess()
 
-    interactor.login(TEST_USER, TEST_PASS).collect()
+    performLogin().collect()
 
     val captor = argumentCaptor<UserModel>()
     verify(mockRepository).saveUserPref(captor.capture())
@@ -149,7 +167,7 @@ class AuthTMDbAccountInteractorTest {
       flowOf(Outcome.Error("Token creation failed"))
     )
 
-    interactor.login(TEST_USER, TEST_PASS).test {
+    performLogin().test {
       assertTrue(awaitItem() is Outcome.Loading)
       assertEquals("Token creation failed", (awaitItem() as Outcome.Error).message)
       awaitComplete()
@@ -168,7 +186,7 @@ class AuthTMDbAccountInteractorTest {
       flowOf(Outcome.Success(Authentication(success = true, requestToken = null)))
     )
 
-    interactor.login(TEST_USER, TEST_PASS).test {
+    performLogin().test {
       assertTrue(awaitItem() is Outcome.Loading)
       assertEquals("Request token was null", (awaitItem() as Outcome.Error).message)
       awaitComplete()
@@ -182,11 +200,7 @@ class AuthTMDbAccountInteractorTest {
   fun createToken_unexpectedState_emitsUnexpectedStateError() = runTest {
     whenever(mockRepository.createToken()).thenReturn(flowOf(Outcome.Loading))
 
-    interactor.login(TEST_USER, TEST_PASS).test {
-      assertTrue(awaitItem() is Outcome.Loading)
-      assertEquals("Unexpected state", (awaitItem() as Outcome.Error).message)
-      awaitComplete()
-    }
+    assertNoOutcomeEmitted()
 
     verify(mockRepository, never()).login(any(), any(), any())
   }
@@ -200,7 +214,7 @@ class AuthTMDbAccountInteractorTest {
       flowOf(Outcome.Error("Authorize token failed"))
     )
 
-    interactor.login(TEST_USER, TEST_PASS).test {
+    performLogin().test {
       assertTrue(awaitItem() is Outcome.Loading)
       assertEquals("Authorize token failed", (awaitItem() as Outcome.Error).message)
       awaitComplete()
@@ -235,11 +249,7 @@ class AuthTMDbAccountInteractorTest {
       flowOf(Outcome.Loading)
     )
 
-    interactor.login(TEST_USER, TEST_PASS).test {
-      assertTrue(awaitItem() is Outcome.Loading)
-      assertEquals("Unexpected state", (awaitItem() as Outcome.Error).message)
-      awaitComplete()
-    }
+    assertNoOutcomeEmitted()
 
     verify(mockRepository, never()).createSessionLogin(any())
   }
@@ -254,11 +264,7 @@ class AuthTMDbAccountInteractorTest {
       flowOf(Outcome.Error("Session creation failed"))
     )
 
-    interactor.login(TEST_USER, TEST_PASS).test {
-      assertTrue(awaitItem() is Outcome.Loading)
-      assertEquals("Session creation failed", (awaitItem() as Outcome.Error).message)
-      awaitComplete()
-    }
+    assertSessionCreationFailed()
 
     verify(mockRepository).createSessionLogin(TEST_TOKEN)
     verify(mockRepository, never()).getAccountDetails(any())
@@ -273,11 +279,7 @@ class AuthTMDbAccountInteractorTest {
       flowOf(Outcome.Success(CreateSession(success = false, sessionId = TEST_SESSION)))
     )
 
-    interactor.login(TEST_USER, TEST_PASS).test {
-      assertTrue(awaitItem() is Outcome.Loading)
-      assertEquals("Session creation failed", (awaitItem() as Outcome.Error).message)
-      awaitComplete()
-    }
+    assertSessionCreationFailed()
 
     verify(mockRepository, never()).getAccountDetails(any())
     verify(mockRepository, never()).saveUserPref(any())
@@ -291,11 +293,7 @@ class AuthTMDbAccountInteractorTest {
       flowOf(Outcome.Loading)
     )
 
-    interactor.login(TEST_USER, TEST_PASS).test {
-      assertTrue(awaitItem() is Outcome.Loading)
-      assertEquals("Unexpected state", (awaitItem() as Outcome.Error).message)
-      awaitComplete()
-    }
+    assertNoOutcomeEmitted()
 
     verify(mockRepository, never()).getAccountDetails(any())
   }
@@ -311,7 +309,7 @@ class AuthTMDbAccountInteractorTest {
       flowOf(Outcome.Error("Can't get user details"))
     )
 
-    interactor.login(TEST_USER, TEST_PASS).test {
+    performLogin().test {
       assertTrue(awaitItem() is Outcome.Loading)
       assertEquals("Can't get user details", (awaitItem() as Outcome.Error).message)
       awaitComplete()
@@ -330,11 +328,7 @@ class AuthTMDbAccountInteractorTest {
       flowOf(Outcome.Loading)
     )
 
-    interactor.login(TEST_USER, TEST_PASS).test {
-      assertTrue(awaitItem() is Outcome.Loading)
-      assertEquals("Unexpected state", (awaitItem() as Outcome.Error).message)
-      awaitComplete()
-    }
+    assertNoOutcomeEmitted()
 
     verify(mockRepository, never()).saveUserPref(any())
   }
@@ -350,7 +344,7 @@ class AuthTMDbAccountInteractorTest {
       flowOf(Outcome.Success(AccountDetails(id = null, username = TEST_USER)))
     )
 
-    interactor.login(TEST_USER, TEST_PASS).collect()
+    performLogin().collect()
 
     val captor = argumentCaptor<UserModel>()
     verify(mockRepository).saveUserPref(captor.capture())
@@ -374,7 +368,7 @@ class AuthTMDbAccountInteractorTest {
       )
     )
 
-    interactor.login(TEST_USER, TEST_PASS).collect()
+    performLogin().collect()
 
     val captor = argumentCaptor<UserModel>()
     verify(mockRepository).saveUserPref(captor.capture())

--- a/feature/login/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginActivityTest.kt
+++ b/feature/login/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginActivityTest.kt
@@ -6,13 +6,13 @@ import android.view.View
 import android.widget.EditText
 import androidx.core.net.toUri
 import androidx.lifecycle.MutableLiveData
+import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.intent.rule.IntentsRule
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.waffiq.bazz_movies.core.designsystem.R.string.guest_user
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomAssertions.isPasswordHidden
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewActions.performAction
@@ -23,6 +23,7 @@ import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewMatchers.doesHa
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewMatchers.hasErrorText
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewMatchers.hasNoError
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewMatchers.isDisplayed
+import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewMatchers.isEnable
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewMatchers.isNotDisplayed
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewMatchers.isNotEnable
 import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewMatchers.withDrawable
@@ -50,6 +51,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.hamcrest.Matcher
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -74,8 +76,7 @@ class LoginActivityTest {
   @get:Rule(order = 1)
   var intentsRule = IntentsRule()
 
-  @get:Rule(order = 2)
-  var activityRule = ActivityScenarioRule(LoginActivity::class.java)
+  private lateinit var scenario: ActivityScenario<LoginActivity>
 
   @BindValue
   @JvmField
@@ -83,21 +84,29 @@ class LoginActivityTest {
 
   @BindValue
   @JvmField
-  val mockAuthViewModel: LoginViewModel = mockk(relaxed = true)
-
+  val mockLoginViewModel: LoginViewModel = mockk(relaxed = true)
 
   @Before
   fun init() {
     hiltRule.inject()
 
-    activityRule.scenario.onActivity { activity ->
+    every { mockLoginViewModel.errorState } returns errorStateLiveData
+    every { mockLoginViewModel.loginState } returns loginStateLiveData
+    every { mockLoginViewModel.loadingState } returns loadingStateLiveData
+    every { mockLoginViewModel.loadingState } returns loadingStateLiveData
+    every { mockLoginViewModel.userLogin(any(), any()) } just Runs
+    every { mockLoginViewModel.saveGuestUserPref(any(), any()) } just Runs
+
+    scenario = ActivityScenario.launch(LoginActivity::class.java)
+
+    scenario.onActivity { activity ->
       context = activity.applicationContext
     }
+  }
 
-    every { mockAuthViewModel.errorState } returns errorStateLiveData
-    every { mockAuthViewModel.loginState } returns loginStateLiveData
-    every { mockAuthViewModel.loadingState } returns loadingStateLiveData
-    every { mockAuthViewModel.saveGuestUserPref(any(), any()) } just Runs
+  @After
+  fun tearDown() {
+    scenario.close()
   }
 
   @Test
@@ -120,7 +129,7 @@ class LoginActivityTest {
   fun clickForgetPassword_successful_launchesCorrectURI() {
     btn_forget_password.performClick()
 
-    activityRule.scenario.onActivity { activity ->
+    scenario.onActivity { activity ->
       val fake = activity.uriLauncher as FakeUriLauncher
       assertEquals(TMDB_LINK_FORGET_PASSWORD.toUri(), fake.launchedUris.first())
     }
@@ -130,7 +139,7 @@ class LoginActivityTest {
   fun clickJoinTMDB_successful_launchesCorrectURI() {
     tv_joinTMDB.performClick()
 
-    activityRule.scenario.onActivity { activity ->
+    scenario.onActivity { activity ->
       val fake = activity.uriLauncher as FakeUriLauncher
       assertEquals(TMDB_LINK_SIGNUP.toUri(), fake.launchedUris.first())
     }
@@ -138,7 +147,7 @@ class LoginActivityTest {
 
   @Test
   fun clickJoinTMDB_noBrowser_launchesToast() {
-    activityRule.scenario.onActivity { activity ->
+    scenario.onActivity { activity ->
       (activity.uriLauncher as FakeUriLauncher).shouldFail = true
     }
 
@@ -149,7 +158,7 @@ class LoginActivityTest {
   @Test
   fun login_withCorrectParams_callsAuthenticationViewModel() {
     performValidLogin()
-    verify { mockAuthViewModel.userLogin(validUsername, validPassword) }
+    verify { mockLoginViewModel.userLogin(validUsername, validPassword) }
   }
 
   @Test
@@ -260,10 +269,10 @@ class LoginActivityTest {
   }
 
   @Test
-  fun login_withValidCredentials_disablesButtonsAndShowsLoading() {
+  fun login_withWhenLoading_disablesButtonsAndShowsLoading() {
     // mock successful login flow
     val loadingLiveData = MutableLiveData<Boolean>()
-    every { mockAuthViewModel.loadingState } returns loadingLiveData
+    every { mockLoginViewModel.loadingState } returns loadingLiveData
 
     performValidLogin()
 
@@ -272,11 +281,48 @@ class LoginActivityTest {
     tv_guest.isNotEnable()
 
     // simulate loading state
-    activityRule.scenario.onActivity {
+    scenario.onActivity {
       loadingLiveData.postValue(true)
     }
 
     progress_bar.isDisplayed()
+  }
+
+  @Test
+  fun login_withSuccessful_navigatesToMainActivity() {
+    performValidLogin()
+    scenario.onActivity {
+      loginStateLiveData.postValue(true)
+    }
+
+    // verify navigation happened
+    verify { mockNavigator.openMainActivity(any()) }
+  }
+
+  @Test
+  fun login_unSuccessful_doesNotNavigate() {
+    performValidLogin()
+
+    scenario.onActivity {
+      loginStateLiveData.postValue(false)
+    }
+
+    // verify navigation never happened
+    verify(exactly = 0) { mockNavigator.openMainActivity(any()) }
+  }
+
+  @Test
+  fun login_whenErrorStateReceived_showsSnackbarAndEnablesButtons() {
+    every { mockLoginViewModel.userLogin(any(), any()) } answers {
+      scenario.onActivity {
+        errorStateLiveData.value = "Invalid credentials"
+      }
+    }
+
+    performValidLogin()
+
+    btn_login.isEnable()
+    tv_guest.isEnable()
   }
 
   @Test
@@ -285,7 +331,7 @@ class LoginActivityTest {
 
     // verify guest user is saved
     verify {
-      mockAuthViewModel.saveGuestUserPref(
+      mockLoginViewModel.saveGuestUserPref(
         context.getString(guest_user),
         context.getString(guest_user),
       )
@@ -300,7 +346,7 @@ class LoginActivityTest {
     typeValidCredentials()
 
     // simulate configuration change (rotation)
-    activityRule.scenario.onActivity { activity ->
+    scenario.onActivity { activity ->
       activity.onConfigurationChanged(
         Configuration().apply {
           orientation = Configuration.ORIENTATION_LANDSCAPE

--- a/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginActivity.kt
+++ b/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginActivity.kt
@@ -14,7 +14,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
-import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import com.waffiq.bazz_movies.core.common.utils.Constants.ANIM_DURATION
@@ -33,6 +32,7 @@ import com.waffiq.bazz_movies.feature.login.R.drawable.ic_eye
 import com.waffiq.bazz_movies.feature.login.R.drawable.ic_eye_off
 import com.waffiq.bazz_movies.feature.login.databinding.ActivityLoginBinding
 import com.waffiq.bazz_movies.feature.login.utils.CustomTypefaceSpan
+import com.waffiq.bazz_movies.feature.login.utils.Helper.loadTypeface
 import com.waffiq.bazz_movies.feature.login.utils.InsetListener.applyWindowInsets
 import com.waffiq.bazz_movies.feature.login.utils.common.Constants.TMDB_LINK_FORGET_PASSWORD
 import com.waffiq.bazz_movies.feature.login.utils.common.Constants.TMDB_LINK_SIGNUP
@@ -198,12 +198,6 @@ class LoginActivity : AppCompatActivity() {
       binding.progressBar.isVisible = it
     }
 
-    /*
-     * login steps
-     * 1. Create a new request token
-     * 2. Get the user to authorize the request token
-     * 3. Create a new session id with the authorized request token
-     */
     authenticationViewModel.userLogin(
       binding.etUsername.text.toString(),
       binding.etPass.text.toString(),
@@ -212,13 +206,8 @@ class LoginActivity : AppCompatActivity() {
 
   private fun applyFontFamily(text: String): SpannableStringBuilder {
     val spannableStringBuilder = SpannableStringBuilder(text)
-    val typeface = ResourcesCompat.getFont(
-      this,
-      nunito_sans_regular,
-    )
-    val customTypefaceSpan = typeface?.let {
-      CustomTypefaceSpan(it)
-    }
+    val customTypefaceSpan = CustomTypefaceSpan(loadTypeface(nunito_sans_regular))
+
     spannableStringBuilder.setSpan(
       customTypefaceSpan,
       0,

--- a/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginViewModel.kt
+++ b/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginViewModel.kt
@@ -28,115 +28,21 @@ class LoginViewModel @Inject constructor(
   private val _loginState = MutableLiveData<Boolean>()
   val loginState: LiveData<Boolean> get() = _loginState
 
-  // 1. Create a new request token
   fun userLogin(username: String, password: String) {
-    _loginState.value = false
     viewModelScope.launch {
-      authTMDbAccountUseCase.createToken().collect { outcome ->
+      authTMDbAccountUseCase.login(username, password).collect { outcome ->
         when (outcome) {
-          is Outcome.Success -> {
-            if (outcome.data.success) {
-              outcome.data.requestToken?.also {
-                login(username, password, it)
-              } ?: run {
-                _loginState.value = false
-              }
-            } else {
-              _loginState.value = false
-            }
-          }
-
           is Outcome.Loading -> _loadingState.value = true
 
           is Outcome.Error -> {
-            _loginState.value = false
             _loadingState.value = false
+            _loginState.value = false
             _errorState.value = outcome.message
           }
-        }
-      }
-    }
-  }
 
-  // 2. authorize the request token
-  private fun login(
-    username: String,
-    password: String,
-    requestToken: String,
-  ) {
-    viewModelScope.launch {
-      authTMDbAccountUseCase.login(username, password, requestToken).collect { outcome ->
-        when (outcome) {
           is Outcome.Success -> {
-            outcome.data.requestToken.let {
-              if (it != null) createSession(it) else _loginState.value = false
-            }
-          }
-
-          is Outcome.Loading -> _loadingState.postValue(true)
-
-          is Outcome.Error -> {
-            _loginState.value = false
             _loadingState.value = false
-            _errorState.value = outcome.message
-          }
-        }
-      }
-    }
-  }
-
-  // 3. Create a new session id with the authorized request token
-  private fun createSession(requestToken: String) {
-    viewModelScope.launch {
-      authTMDbAccountUseCase.createSessionLogin(requestToken).collect { outcome ->
-        when (outcome) {
-          is Outcome.Success -> {
-            if (outcome.data.success) {
-              getAccountDetails(outcome.data.sessionId)
-            } else {
-              _loginState.value = false
-            }
-          }
-
-          is Outcome.Loading -> _loadingState.value = true
-
-          is Outcome.Error -> {
-            _loginState.value = false
-            _loadingState.value = false
-            _errorState.value = outcome.message
-          }
-        }
-      }
-    }
-  }
-
-  private fun getAccountDetails(sessionId: String) {
-    viewModelScope.launch {
-      authTMDbAccountUseCase.getAccountDetails(sessionId).collect { outcome ->
-        when (outcome) {
-          is Outcome.Success -> {
-            val userModel = UserModel(
-              userId = outcome.data.id ?: 0,
-              name = outcome.data.name.toString(),
-              username = outcome.data.username.toString(),
-              password = NAN,
-              region = NAN,
-              token = sessionId,
-              isLogin = true,
-              gravatarHash = outcome.data.avatarItem?.gravatar?.hash,
-              tmdbAvatar = outcome.data.avatarItem?.avatarTMDb?.avatarPath,
-            )
-            userPrefUseCase.saveUserPref(userModel)
             _loginState.value = true
-            _loadingState.value = false
-          }
-
-          is Outcome.Loading -> _loadingState.value = true
-
-          is Outcome.Error -> {
-            _loginState.value = false
-            _loadingState.value = false
-            _errorState.value = outcome.message
           }
         }
       }

--- a/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/utils/CustomTypefaceSpan.kt
+++ b/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/utils/CustomTypefaceSpan.kt
@@ -7,7 +7,7 @@ import android.text.style.StyleSpan
 /**
  * Used to change  font family of error text in EditText.
  */
-class CustomTypefaceSpan(private val typeface: Typeface) : StyleSpan(Typeface.NORMAL) {
+class CustomTypefaceSpan(val typeface: Typeface) : StyleSpan(Typeface.NORMAL) {
   override fun updateDrawState(ds: TextPaint) {
     super.updateDrawState(ds)
     ds.typeface = typeface

--- a/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/utils/Helper.kt
+++ b/feature/login/src/main/kotlin/com/waffiq/bazz_movies/feature/login/utils/Helper.kt
@@ -1,0 +1,10 @@
+package com.waffiq.bazz_movies.feature.login.utils
+
+import android.content.Context
+import android.graphics.Typeface
+import androidx.core.content.res.ResourcesCompat
+
+object Helper {
+  fun Context.loadTypeface(fontRes: Int): Typeface =
+    ResourcesCompat.getFont(this, fontRes) ?: Typeface.DEFAULT
+}

--- a/feature/login/src/test/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginViewModelTest.kt
+++ b/feature/login/src/test/kotlin/com/waffiq/bazz_movies/feature/login/ui/LoginViewModelTest.kt
@@ -4,25 +4,17 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.domain.Outcome
 import com.waffiq.bazz_movies.core.test.MainDispatcherRule
-import com.waffiq.bazz_movies.core.user.domain.model.account.AccountDetails
-import com.waffiq.bazz_movies.core.user.domain.model.account.Authentication
-import com.waffiq.bazz_movies.core.user.domain.model.account.AvatarItem
-import com.waffiq.bazz_movies.core.user.domain.model.account.AvatarTMDb
-import com.waffiq.bazz_movies.core.user.domain.model.account.CreateSession
-import com.waffiq.bazz_movies.core.user.domain.model.account.Gravatar
 import com.waffiq.bazz_movies.core.user.domain.usecase.authtmdbaccount.AuthTMDbAccountUseCase
 import com.waffiq.bazz_movies.core.user.domain.usecase.userpreference.UserPrefUseCase
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.coVerifySequence
 import io.mockk.just
 import io.mockk.mockk
-import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -48,8 +40,6 @@ class LoginViewModelTest {
   companion object {
     private const val TEST_USER = "test_user"
     private const val TEST_PASS = "test_pass"
-    private const val TEST_TOKEN = "test_token"
-    private const val TEST_SESSION = "test_session"
   }
 
   @Before
@@ -68,290 +58,37 @@ class LoginViewModelTest {
     coEvery { mockUserPrefUseCase.saveUserPref(any()) } just Runs
   }
 
-  // helper methods to reduce duplication
-  private fun mockSuccessfulTokenCreation() {
-    coEvery { mockAuthTMDbAccountUseCase.createToken() } returns flowOf(
-      Outcome.Success(Authentication(success = true, requestToken = TEST_TOKEN))
-    )
-  }
-
-  private fun mockSuccessfulLogin() {
-    coEvery {
-      mockAuthTMDbAccountUseCase.login(TEST_USER, TEST_PASS, TEST_TOKEN)
-    } returns flowOf(
-      Outcome.Success(Authentication(success = true, requestToken = TEST_TOKEN))
-    )
-  }
-
-  private fun mockSuccessfulSessionCreation() {
-    coEvery {
-      mockAuthTMDbAccountUseCase.createSessionLogin(TEST_TOKEN)
-    } returns flowOf(
-      Outcome.Success(CreateSession(success = true, sessionId = TEST_SESSION))
-    )
-  }
-
-  private fun mockSuccessfulUserDetail() {
-    coEvery {
-      mockAuthTMDbAccountUseCase.getAccountDetails(TEST_SESSION)
-    } returns flowOf(
-      Outcome.Success(AccountDetails(id = 1, username = TEST_USER))
-    )
-  }
-
-  // verification helper methods
-  private fun verifyTokenCreation() {
-    coVerify { mockAuthTMDbAccountUseCase.createToken() }
-  }
-
-  private fun verifyFullLoginSequence() {
-    coVerifySequence {
-      mockAuthTMDbAccountUseCase.createToken()
-      mockAuthTMDbAccountUseCase.login(TEST_USER, TEST_PASS, TEST_TOKEN)
-      mockAuthTMDbAccountUseCase.createSessionLogin(TEST_TOKEN)
-      mockAuthTMDbAccountUseCase.getAccountDetails(TEST_SESSION)
-    }
-  }
-
-  private fun verifyUpToLoginSequence() {
-    coVerifySequence {
-      mockAuthTMDbAccountUseCase.createToken()
-      mockAuthTMDbAccountUseCase.login(TEST_USER, TEST_PASS, TEST_TOKEN)
-    }
-  }
-
-  private fun verifyUpToSessionCreationSequence() {
-    coVerifySequence {
-      mockAuthTMDbAccountUseCase.createToken()
-      mockAuthTMDbAccountUseCase.login(TEST_USER, TEST_PASS, TEST_TOKEN)
-      mockAuthTMDbAccountUseCase.createSessionLogin(TEST_TOKEN)
-    }
-  }
-
   @Test
   fun userLogin_whenUnsuccessful_emitsLoadingAndErrorStates() = runTest {
-    // mock the UseCase to emit a failure
-    coEvery { mockAuthTMDbAccountUseCase.createToken() } returns flow {
+    coEvery { mockAuthTMDbAccountUseCase.login(any(), any()) } returns flow {
       emit(Outcome.Loading)
       emit(Outcome.Error("Token creation failed"))
     }
 
-    // trigger the login function
     viewModel.userLogin(TEST_USER, TEST_PASS)
     advanceUntilIdle()
 
-    // Verify the states
     assertThat(loadingStates).containsExactly(true, false) // loading started, then stopped
     assertThat(errorStates).contains("Token creation failed") // error message captured
 
-    // verify interactions with use case
-    verifyTokenCreation()
+    coVerify { mockAuthTMDbAccountUseCase.login(any(), any()) }
   }
 
   @Test
   fun userLogin_whenSuccessful_triggersLoginAndSessionCreation() = runTest {
-    mockSuccessfulTokenCreation()
-    mockSuccessfulLogin()
-    mockSuccessfulSessionCreation()
-    mockSuccessfulUserDetail()
-
-    // trigger
-    viewModel.userLogin(TEST_USER, TEST_PASS)
-    advanceUntilIdle()
-
-    // verify states
-    assertThat(loginStates).containsExactly(false, true)
-
-    // verify call sequence
-    verifyFullLoginSequence()
-  }
-
-  @Test
-  fun userLogin_whenResponseSuccessButAuthFails_setsLoginStateFalse() = runTest {
-    coEvery { mockAuthTMDbAccountUseCase.createToken() } returns flowOf(
-      Outcome.Success(Authentication(success = false, requestToken = null))
-    )
-
-    viewModel.userLogin(TEST_USER, TEST_PASS)
-    advanceUntilIdle()
-
-    assertEquals(listOf(false, false), loginStates) // initial value false + unchanged false
-    verifyTokenCreation()
-  }
-
-  @Test
-  fun userLogin_whenResponseSuccessButNullToken_setsLoginStateFalse() = runTest {
-    coEvery { mockAuthTMDbAccountUseCase.createToken() } returns flowOf(
-      Outcome.Success(Authentication(success = true, requestToken = null))
-    )
-
-    viewModel.userLogin(TEST_USER, TEST_PASS)
-    advanceUntilIdle()
-
-    assertEquals(listOf(false, false), loginStates) // initial value false + unchanged false
-    verifyTokenCreation()
-  }
-
-  @Test
-  fun login_whenSuccessful_requestsTokenNull() = runTest {
-    mockSuccessfulTokenCreation()
-
-    coEvery {
-      mockAuthTMDbAccountUseCase.login(TEST_USER, TEST_PASS, TEST_TOKEN)
-    } returns flowOf(
-      Outcome.Success(Authentication(success = true, requestToken = null))
-    )
-
-    viewModel.userLogin(TEST_USER, TEST_PASS)
-    advanceUntilIdle()
-
-    assertThat(loginStates).containsExactly(false, false)
-
-    // verify calls to the use case
-    verifyUpToLoginSequence()
-  }
-
-  @Test
-  fun login_whenUnsuccessful_emitsLoadingAndErrorStates() = runTest {
-    mockSuccessfulTokenCreation()
-
-    coEvery {
-      mockAuthTMDbAccountUseCase.login(TEST_USER, TEST_PASS, TEST_TOKEN)
-    } returns flow {
+    coEvery { mockAuthTMDbAccountUseCase.login(any(), any()) } returns flow {
       emit(Outcome.Loading)
-      emit(Outcome.Error("Token creation failed"))
+      emit(Outcome.Success(Unit))
     }
 
     viewModel.userLogin(TEST_USER, TEST_PASS)
     advanceUntilIdle()
 
-    assertThat(loadingStates).containsExactly(true, false) // loading started, then stopped
-    assertThat(errorStates).contains("Token creation failed") // error message captured
+    assertEquals(true, loginStates[0])
 
-    verifyUpToLoginSequence()
+    coVerify { mockAuthTMDbAccountUseCase.login(any(), any()) }
   }
 
-  @Test
-  fun createSession_whenResponseSuccessButAuthFails_setsLoginStateFalse() = runTest {
-    mockSuccessfulTokenCreation()
-    mockSuccessfulLogin()
-
-    coEvery {
-      mockAuthTMDbAccountUseCase.createSessionLogin(TEST_TOKEN)
-    } returns flowOf(
-      Outcome.Success(CreateSession(success = false, sessionId = TEST_SESSION)) // success false
-    )
-
-    viewModel.userLogin(TEST_USER, TEST_PASS)
-    advanceUntilIdle()
-
-    assertThat(loginStates).containsExactly(false, false)
-
-    verifyUpToSessionCreationSequence()
-  }
-
-  @Test
-  fun createSession_whenErrorOccurs_setsLoadingAndErrorStates() = runTest {
-    mockSuccessfulTokenCreation()
-    mockSuccessfulLogin()
-
-    coEvery {
-      mockAuthTMDbAccountUseCase.createSessionLogin(TEST_TOKEN)
-    } returns flow {
-      emit(Outcome.Loading)
-      emit(Outcome.Error("Create login token failed"))
-    }
-
-    viewModel.userLogin(TEST_USER, TEST_PASS)
-    advanceUntilIdle()
-
-    assertThat(loadingStates).containsExactly(true, false) // loading started, then stopped
-    assertThat(errorStates).contains("Create login token failed") // error message captured
-
-    verifyUpToSessionCreationSequence()
-  }
-
-  @Test
-  fun getAccountDetails_whenSuccessful_setsLoginStateTrue() = runTest {
-    mockSuccessfulTokenCreation()
-    mockSuccessfulLogin()
-    mockSuccessfulSessionCreation()
-
-    coEvery {
-      mockAuthTMDbAccountUseCase.getAccountDetails(TEST_SESSION)
-    } returns flowOf(
-      Outcome.Success(
-        AccountDetails(
-          id = null,
-          username = TEST_USER,
-          avatarItem = AvatarItem(
-            avatarTMDb = AvatarTMDb(avatarPath = null),
-            gravatar = Gravatar(hash = null)
-          )
-        )
-      )
-    )
-
-    viewModel.userLogin(TEST_USER, TEST_PASS)
-    advanceUntilIdle()
-
-    assertThat(loginStates).containsExactly(false, true)
-    assertThat(loadingStates).containsExactly(false)
-
-    verifyFullLoginSequence()
-  }
-
-  @Test
-  fun getAccountDetails_whenResponseSuccessButAvatarNull_returnsUserData() = runTest {
-    mockSuccessfulTokenCreation()
-    mockSuccessfulLogin()
-    mockSuccessfulSessionCreation()
-
-    coEvery {
-      mockAuthTMDbAccountUseCase.getAccountDetails(TEST_SESSION)
-    } returns flowOf(
-      Outcome.Success(
-        AccountDetails(
-          id = null,
-          username = TEST_USER,
-          avatarItem = AvatarItem(
-            avatarTMDb = null,
-            gravatar = null
-          )
-        )
-      )
-    )
-
-    viewModel.userLogin(TEST_USER, TEST_PASS)
-    advanceUntilIdle()
-
-    assertThat(loginStates).containsExactly(false, true)
-    assertThat(loadingStates).containsExactly(false)
-
-    verifyFullLoginSequence()
-  }
-
-  @Test
-  fun getAccountDetails_whenUnsuccessful_emitsLoadingAndErrorStates() = runTest {
-    mockSuccessfulTokenCreation()
-    mockSuccessfulLogin()
-    mockSuccessfulSessionCreation()
-
-    coEvery {
-      mockAuthTMDbAccountUseCase.getAccountDetails(TEST_SESSION)
-    } returns flow {
-      emit(Outcome.Loading)
-      emit(Outcome.Error("Can't get user details"))
-    }
-
-    viewModel.userLogin(TEST_USER, TEST_PASS)
-    advanceUntilIdle()
-
-    assertThat(loadingStates).containsExactly(true, false) // loading started, then stopped
-    assertThat(errorStates).contains("Can't get user details") // error message captured
-
-    verifyFullLoginSequence()
-  }
 
   @Test
   fun saveGuestUserPref_withCorrectValue_shouldSaveCorrectly() = runTest {

--- a/feature/login/src/test/kotlin/com/waffiq/bazz_movies/feature/login/utils/CustomTypefaceSpanTest.kt
+++ b/feature/login/src/test/kotlin/com/waffiq/bazz_movies/feature/login/utils/CustomTypefaceSpanTest.kt
@@ -2,6 +2,7 @@ package com.waffiq.bazz_movies.feature.login.utils
 
 import android.graphics.Typeface
 import android.text.TextPaint
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
@@ -36,5 +37,11 @@ class CustomTypefaceSpanTest {
   fun updateMeasureState_whenCalled_shouldSetCorrectTypeface() {
     customTypefaceSpan.updateMeasureState(mockTextPaint)
     verify(mockTextPaint).typeface = mockTypeface
+  }
+
+  @Test
+  fun customTypefaceSpan_usingConstructor_setsTypeface() {
+    val span = CustomTypefaceSpan(mockTypeface)
+    assertEquals(mockTypeface, span.typeface)
   }
 }

--- a/feature/login/src/test/kotlin/com/waffiq/bazz_movies/feature/login/utils/HelperTest.kt
+++ b/feature/login/src/test/kotlin/com/waffiq/bazz_movies/feature/login/utils/HelperTest.kt
@@ -1,0 +1,43 @@
+package com.waffiq.bazz_movies.feature.login.utils
+
+import android.content.Context
+import android.graphics.Typeface
+import androidx.core.content.res.ResourcesCompat
+import androidx.test.core.app.ApplicationProvider
+import com.waffiq.bazz_movies.core.designsystem.R.font.nunito_sans_regular
+import com.waffiq.bazz_movies.feature.login.utils.Helper.loadTypeface
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HelperTest {
+
+  private val context = ApplicationProvider.getApplicationContext<Context>()
+
+  @Test
+  fun loadTypeface_whenResourceNull_fallsBackToDefault() {
+    mockkStatic(ResourcesCompat::class)
+    every { ResourcesCompat.getFont(context, any()) } returns null
+
+    val result = context.loadTypeface(nunito_sans_regular)
+
+    assertNotNull(result) // Typeface.DEFAULT is now real
+  }
+
+  @Test
+  fun loadTypeface_whenResourceFound_returnsTypeface() {
+    val mockTypeface = mockk<Typeface>()
+    mockkStatic(ResourcesCompat::class)
+    every { ResourcesCompat.getFont(context, any()) } returns mockTypeface
+
+    val result = context.loadTypeface(nunito_sans_regular)
+
+    assertEquals(mockTypeface, result)
+  }
+}


### PR DESCRIPTION
### Changes Made

- Gradually migrate login logic to use case
- Improve separation of concerns
- Keep ViewModel focused on UI state