### PR TITLE
refactor: clear search history only after successful logout

### DIFF
--- a/feature/more/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/more/ui/MoreFragmentTest.kt
+++ b/feature/more/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/more/ui/MoreFragmentTest.kt
@@ -232,6 +232,10 @@ class MoreFragmentTest : MoreFragmentTestHelper by DefaultMoreFragmentTestHelper
   @Test
   fun signOutStateLogin_whenSuccess_shouldShowSuccessToastAndNavigateToLogin() {
     performSignOutAction()
+
+    mockUIState.value = UIState.Success(Unit) // success
+
+    verify { mockMoreLocalViewModel.deleteAllSearchHistory() }
   }
 
   @Test
@@ -241,6 +245,8 @@ class MoreFragmentTest : MoreFragmentTestHelper by DefaultMoreFragmentTestHelper
       mockUIState.emit(UIState.Loading)
 
       progress_bar.isDisplayed()
+
+      verify(exactly = 0) { mockMoreLocalViewModel.deleteAllSearchHistory() }
     }
 
   @Test
@@ -250,7 +256,7 @@ class MoreFragmentTest : MoreFragmentTestHelper by DefaultMoreFragmentTestHelper
       performSignOutAction()
       mockUIState.emit(UIState.Success(Unit))
 
-      // manual checking
+      verify { mockMoreLocalViewModel.deleteAllSearchHistory() }
     }
 
   @Test
@@ -268,6 +274,9 @@ class MoreFragmentTest : MoreFragmentTestHelper by DefaultMoreFragmentTestHelper
 
       btn_signout.isEnable()
       onView(withId(progress_bar)).check(waitUntil(not(isDisplayed())))
+
+
+      verify(exactly = 0) { mockMoreLocalViewModel.deleteAllSearchHistory() }
     }
 
   @Test
@@ -394,8 +403,6 @@ class MoreFragmentTest : MoreFragmentTestHelper by DefaultMoreFragmentTestHelper
   private fun performSignOutAction() {
     btn_signout.performClick()
     yes.performTextClick()
-
-    verify { mockMoreLocalViewModel.deleteAllSearchHistory() }
   }
 
   private fun checkAvatarIsVisible(userModel: UserModel, viewMatcher: Matcher<View>) {

--- a/feature/more/src/main/kotlin/com/waffiq/bazz_movies/feature/more/ui/MoreFragment.kt
+++ b/feature/more/src/main/kotlin/com/waffiq/bazz_movies/feature/more/ui/MoreFragment.kt
@@ -101,6 +101,7 @@ class MoreFragment : Fragment() {
 
           when (it) {
             is UIState.Success -> {
+              moreLocalViewModel.deleteAllSearchHistory()
               requireContext().toastShort(getString(sign_out_success))
               openLoginActivity()
             }
@@ -109,7 +110,7 @@ class MoreFragment : Fragment() {
 
             is UIState.Loading -> Unit
 
-            is UIState.Idle -> Unit
+            else -> Unit // idle do nothing
           }
         }
       }
@@ -128,7 +129,7 @@ class MoreFragment : Fragment() {
 
             is UIState.Idle -> Unit
 
-            is UIState.Loading -> Unit
+            else -> Unit // idle do nothing
           }
         }
       }
@@ -177,7 +178,6 @@ class MoreFragment : Fragment() {
       setPositiveButton(resources.getString(yes)) { dialog, _ ->
         fadeInAlpha50(binding.layoutBackground.bgAlpha, ANIM_DURATION)
         btnSignOutIsEnable(false)
-        moreLocalViewModel.deleteAllSearchHistory()
         moreUserViewModel.deleteSession(sessionId) // revoke session for login user
         dialog.dismiss()
       }


### PR DESCRIPTION
### Changes Made

- Clear search history only when logout is successful
- Prevent history removal when logout fails