### PR TITLE
refactor(account): consolidate media list API endpoints

### DIFF
--- a/core/network/consumer-rules.pro
+++ b/core/network/consumer-rules.pro
@@ -4,6 +4,8 @@
 -keep class com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.** { *; }
 -keep class com.waffiq.bazz_movies.core.network.data.remote.responses.countryip.** { *; }
 -keep class com.waffiq.bazz_movies.core.network.data.remote.models.** { *; }
+-keep class com.waffiq.bazz_movies.core.network.data.remote.query.** { *; }
+-keep class com.waffiq.bazz_movies.core.network.data.remote.constants.** { *; }
 
 # Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
 -keep,allowobfuscation,allowshrinking interface retrofit2.Call

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/constants/AccountMediaCategory.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/constants/AccountMediaCategory.kt
@@ -1,0 +1,13 @@
+package com.waffiq.bazz_movies.core.network.data.remote.constants
+
+enum class AccountMediaCategory {
+  FAVORITE,
+  WATCHLIST,
+  ;
+
+    fun asApiValue(): String =
+    when (this) {
+      FAVORITE -> "favorite"
+      WATCHLIST -> "watchlist"
+    }
+}

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/constants/MediaType.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/constants/MediaType.kt
@@ -1,0 +1,13 @@
+package com.waffiq.bazz_movies.core.network.data.remote.constants
+
+enum class MediaType {
+  MOVIES,
+  TV,
+  ;
+
+    fun asApiValue(): String =
+    when (this) {
+      MOVIES -> "movies"
+      TV -> "tv"
+    }
+}

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/account/AccountRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/account/AccountRemoteDataSource.kt
@@ -2,6 +2,8 @@ package com.waffiq.bazz_movies.core.network.data.remote.datasource.account
 
 import androidx.paging.PagingData
 import com.waffiq.bazz_movies.core.coroutines.IoDispatcher
+import com.waffiq.bazz_movies.core.network.data.remote.constants.AccountMediaCategory
+import com.waffiq.bazz_movies.core.network.data.remote.constants.MediaType
 import com.waffiq.bazz_movies.core.network.data.remote.models.FavoriteRequest
 import com.waffiq.bazz_movies.core.network.data.remote.models.WatchlistRequest
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.MediaResponseItem
@@ -20,31 +22,37 @@ class AccountRemoteDataSource @Inject constructor(
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : AccountRemoteDataSourceInterface {
 
-  override fun getFavoriteMovies(
-    userId: Int,
-    sessionId: String,
-  ): Flow<PagingData<MediaResponseItem>> =
-    createPager { page ->
-      accountApiService.getFavoriteMovies(userId, sessionId, page).results
-    }.flow.flowOn(ioDispatcher)
+  override fun getFavoriteMovies(userId: Int, sessionId: String) =
+    getAccountMediaPaging(
+      userId = userId,
+      sessionId = sessionId,
+      category = AccountMediaCategory.FAVORITE,
+      mediaType = MediaType.MOVIES,
+    )
 
-  override fun getFavoriteTv(userId: Int, sessionId: String): Flow<PagingData<MediaResponseItem>> =
-    createPager { page ->
-      accountApiService.getFavoriteTv(userId, sessionId, page).results
-    }.flow.flowOn(ioDispatcher)
+  override fun getFavoriteTv(userId: Int, sessionId: String) =
+    getAccountMediaPaging(
+      userId = userId,
+      sessionId = sessionId,
+      category = AccountMediaCategory.FAVORITE,
+      mediaType = MediaType.TV,
+    )
 
-  override fun getWatchlistTv(userId: Int, sessionId: String): Flow<PagingData<MediaResponseItem>> =
-    createPager { page ->
-      accountApiService.getWatchlistTv(userId, sessionId, page).results
-    }.flow.flowOn(ioDispatcher)
+  override fun getWatchlistTv(userId: Int, sessionId: String) =
+    getAccountMediaPaging(
+      userId = userId,
+      sessionId = sessionId,
+      category = AccountMediaCategory.WATCHLIST,
+      mediaType = MediaType.TV,
+    )
 
-  override fun getWatchlistMovies(
-    userId: Int,
-    sessionId: String,
-  ): Flow<PagingData<MediaResponseItem>> =
-    createPager { page ->
-      accountApiService.getWatchlistMovies(userId, sessionId, page).results
-    }.flow.flowOn(ioDispatcher)
+  override fun getWatchlistMovies(userId: Int, sessionId: String) =
+    getAccountMediaPaging(
+      userId = userId,
+      sessionId = sessionId,
+      category = AccountMediaCategory.WATCHLIST,
+      mediaType = MediaType.MOVIES,
+    )
 
   override fun postFavorite(
     sessionId: String,
@@ -65,4 +73,20 @@ class AccountRemoteDataSource @Inject constructor(
       apiCall = { accountApiService.postWatchlistTMDB(userId, sessionId, wtc) },
       ioDispatcher = ioDispatcher,
     )
+
+  private fun getAccountMediaPaging(
+    userId: Int,
+    sessionId: String,
+    category: AccountMediaCategory,
+    mediaType: MediaType,
+  ): Flow<PagingData<MediaResponseItem>> =
+    createPager { page ->
+      accountApiService.getMediaList(
+        accountId = userId,
+        sessionId = sessionId,
+        category = category.asApiValue(),
+        mediaType = mediaType.asApiValue(),
+        page = page,
+      ).results
+    }.flow.flowOn(ioDispatcher)
 }

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/AccountApiService.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/AccountApiService.kt
@@ -13,33 +13,12 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface AccountApiService {
-  @GET("3/account/{account_id}/favorite/movies?sort_by=created_at.asc")
-  suspend fun getFavoriteMovies(
-    @Path("account_id") accountId: Int,
-    @Query("session_id") sessionId: String,
-    @Query("page") page: Int,
-    @Query("language") language: String = "en-US",
-  ): MediaResponse
 
-  @GET("3/account/{account_id}/favorite/tv?sort_by=created_at.asc")
-  suspend fun getFavoriteTv(
+  @GET("3/account/{account_id}/{category}/{media_type}?sort_by=created_at.asc")
+  suspend fun getMediaList(
     @Path("account_id") accountId: Int,
-    @Query("session_id") sessionId: String,
-    @Query("page") page: Int,
-    @Query("language") language: String = "en-US",
-  ): MediaResponse
-
-  @GET("3/account/{account_id}/watchlist/movies?sort_by=created_at.asc")
-  suspend fun getWatchlistMovies(
-    @Path("account_id") accountId: Int,
-    @Query("session_id") sessionId: String,
-    @Query("page") page: Int,
-    @Query("language") language: String = "en-US",
-  ): MediaResponse
-
-  @GET("3/account/{account_id}/watchlist/tv?sort_by=created_at.asc")
-  suspend fun getWatchlistTv(
-    @Path("account_id") accountId: Int,
+    @Path("category") category: String,
+    @Path("media_type") mediaType: String,
     @Query("session_id") sessionId: String,
     @Query("page") page: Int,
     @Query("language") language: String = "en-US",

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/account/AccountRemoteDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/account/AccountRemoteDataSourceTest.kt
@@ -1,5 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.datasource.account
 
+import com.waffiq.bazz_movies.core.network.data.remote.constants.AccountMediaCategory
+import com.waffiq.bazz_movies.core.network.data.remote.constants.MediaType
 import com.waffiq.bazz_movies.core.network.data.remote.pagingsources.GenericPagingSource
 import com.waffiq.bazz_movies.core.network.testutils.BaseMediaDataSourceTest
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager
@@ -15,35 +17,50 @@ import org.junit.Test
 
 class AccountRemoteDataSourceTest : BaseMediaDataSourceTest() {
 
+  private suspend fun stubGeneral(category: AccountMediaCategory, mediaType: MediaType) =
+    mockAccountApiService.getMediaList(
+      accountId = userId,
+      sessionId = sessionId,
+      category = category.asApiValue(),
+      mediaType = mediaType.asApiValue(),
+      page = 1,
+    )
+
+  private suspend fun stubFavoriteMovies() =
+    stubGeneral(AccountMediaCategory.FAVORITE, MediaType.MOVIES)
+
+  private suspend fun stubFavoriteTv() = stubGeneral(AccountMediaCategory.FAVORITE, MediaType.TV)
+
+  private suspend fun stubWatchlistMovies() =
+    stubGeneral(AccountMediaCategory.WATCHLIST, MediaType.MOVIES)
+
+  private suspend fun stubWatchlistTv() = stubGeneral(AccountMediaCategory.WATCHLIST, MediaType.TV)
+
   @Test
   fun getFavoriteMovies_pagingFlow_returnsExpectedData() =
     runTest {
       val expected = listOf(DataDumpManager.movieDump6)
-      coEvery { mockAccountApiService.getFavoriteMovies(userId, sessionId, 1) } returns
-        defaultMediaResponse(expected)
+      coEvery { stubFavoriteMovies() } returns defaultMediaResponse(expected)
       accountRemoteDataSource.getFavoriteMovies(userId, sessionId).testPagingFlow(this, expected)
-      coVerify { mockAccountApiService.getFavoriteMovies(userId, sessionId, 1) }
+      coVerify { stubFavoriteMovies() }
     }
 
   @Test
   fun getWatchlistMovies_pagingFlow_returnsExpectedData() =
     runTest {
       val expected = listOf(DataDumpManager.movieDump2)
-      coEvery { mockAccountApiService.getWatchlistMovies(userId, sessionId, 1) } returns
-        defaultMediaResponse(expected)
+      coEvery { stubWatchlistMovies() } returns defaultMediaResponse(expected)
       accountRemoteDataSource.getWatchlistMovies(userId, sessionId).testPagingFlow(this, expected)
-      coVerify { mockAccountApiService.getWatchlistMovies(userId, sessionId, 1) }
+      coVerify { stubWatchlistMovies() }
     }
 
   @Test
   fun getFavoriteTv_pagingSource_returnsExpectedData() =
     runTest {
-      val pagingSource = GenericPagingSource {
-        mockAccountApiService.getFavoriteTv(userId, sessionId, 1).results
-      }
+      val pagingSource = GenericPagingSource { stubFavoriteTv().results }
       testPagingSource(
         mockResults = defaultMediaResponse(listOf(tvShowDump2)),
-        mockApiCall = { mockAccountApiService.getFavoriteTv(userId, sessionId, 1) },
+        mockApiCall = { stubFavoriteTv() },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
         assertEquals(null, page.prevKey)
@@ -55,21 +72,18 @@ class AccountRemoteDataSourceTest : BaseMediaDataSourceTest() {
   fun getFavoriteTv_pagingFlow_returnsExpectedData() =
     runTest {
       val expected = listOf(tvShowDump2)
-      coEvery { mockAccountApiService.getFavoriteTv(userId, sessionId, 1) } returns
-        defaultMediaResponse(expected)
+      coEvery { stubFavoriteTv() } returns defaultMediaResponse(expected)
       accountRemoteDataSource.getFavoriteTv(userId, sessionId).testPagingFlow(this, expected)
-      coVerify { mockAccountApiService.getFavoriteTv(userId, sessionId, 1) }
+      coVerify { stubFavoriteTv() }
     }
 
   @Test
   fun getWatchlistTv_pagingSource_returnsExpectedData() =
     runTest {
-      val pagingSource = GenericPagingSource {
-        mockAccountApiService.getWatchlistTv(userId, sessionId, 1).results
-      }
+      val pagingSource = GenericPagingSource { stubWatchlistTv().results }
       testPagingSource(
         mockResults = defaultMediaResponse(listOf(tvShowDump2)),
-        mockApiCall = { mockAccountApiService.getWatchlistTv(userId, sessionId, 1) },
+        mockApiCall = { stubWatchlistTv() },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
         assertEquals(null, page.prevKey)
@@ -81,9 +95,8 @@ class AccountRemoteDataSourceTest : BaseMediaDataSourceTest() {
   fun getWatchlistTv_pagingFlow_returnsExpectedData() =
     runTest {
       val expected = listOf(tvShowDump2)
-      coEvery { mockAccountApiService.getWatchlistTv(userId, sessionId, 1) } returns
-        defaultMediaResponse(expected)
+      coEvery { stubWatchlistTv() } returns defaultMediaResponse(expected)
       accountRemoteDataSource.getWatchlistTv(userId, sessionId).testPagingFlow(this, expected)
-      coVerify { mockAccountApiService.getWatchlistTv(userId, sessionId, 1) }
+      coVerify { stubWatchlistTv() }
     }
 }

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/movie/MovieRemoteDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/movie/MovieRemoteDataSourceTest.kt
@@ -12,7 +12,7 @@ import junit.framework.TestCase
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-class MoviePagingRemoteDataSourceTest : BaseMediaDataSourceTest() {
+class MovieRemoteDataSourceTest : BaseMediaDataSourceTest() {
 
   @Test
   fun getTopRatedMovies_pagingSource_returnsExpectedData() =
@@ -65,36 +65,6 @@ class MoviePagingRemoteDataSourceTest : BaseMediaDataSourceTest() {
       )
       movieRemoteDataSource.getPopularMovies().testPagingFlow(this, expected)
       coVerify { mockMovieApiService.getPopularMovies(1) }
-    }
-
-  @Test
-  fun getFavoriteMovies_pagingSource_returnsExpectedData() =
-    runTest {
-      val pagingSource = GenericPagingSource {
-        mockAccountApiService.getFavoriteMovies(userId, sessionId, 1).results
-      }
-      testPagingSource(
-        mockResults = defaultMediaResponse(listOf(DataDumpManager.movieDump6)),
-        mockApiCall = { mockAccountApiService.getFavoriteMovies(userId, sessionId, 1) },
-        loader = { pagingSource.toLoadResult() },
-      ) { page ->
-        TestCase.assertEquals(1, page.data.size)
-      }
-    }
-
-  @Test
-  fun getWatchlistMovies_pagingSource_returnsExpectedData() =
-    runTest {
-      val pagingSource = GenericPagingSource {
-        mockAccountApiService.getWatchlistMovies(userId, sessionId, 1).results
-      }
-      testPagingSource(
-        mockResults = defaultMediaResponse(listOf(DataDumpManager.movieDump2)),
-        mockApiCall = { mockAccountApiService.getWatchlistMovies(userId, sessionId, 1) },
-        loader = { pagingSource.toLoadResult() },
-      ) { page ->
-        TestCase.assertEquals(1, page.data.size)
-      }
     }
 
   @Test


### PR DESCRIPTION
### Changes Made

- Replace duplicated favorite/watchlist endpoints with a single generic endpoint
- Add `MediaType` and `AccountMediaCategory` enums for API path generation
- Reduce duplicated API service definitions