### PR TITLE
feat(auth): show fallback name for unnamed users

### DIFF
--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
   <string name="no_series_airing_this_week">It seems there are no series scheduled to air this week in %1$s. Try selecting a different country to explore more options.</string>
 
   <!-- MORE -->
+  <string name="user_no_name">Name not set</string>
   <string name="guest_user">Guest User</string>
   <string name="image_profile">Image Profile</string>
   <string name="faq">FAQ</string>

--- a/feature/more/src/main/kotlin/com/waffiq/bazz_movies/feature/more/ui/MoreFragment.kt
+++ b/feature/more/src/main/kotlin/com/waffiq/bazz_movies/feature/more/ui/MoreFragment.kt
@@ -33,6 +33,7 @@ import com.waffiq.bazz_movies.core.designsystem.R.string.all_data_deleted
 import com.waffiq.bazz_movies.core.designsystem.R.string.binding_error
 import com.waffiq.bazz_movies.core.designsystem.R.string.no
 import com.waffiq.bazz_movies.core.designsystem.R.string.sign_out_success
+import com.waffiq.bazz_movies.core.designsystem.R.string.user_no_name
 import com.waffiq.bazz_movies.core.designsystem.R.string.warning
 import com.waffiq.bazz_movies.core.designsystem.R.string.warning_signOut_guest_mode
 import com.waffiq.bazz_movies.core.designsystem.R.string.warning_signOut_logged_user
@@ -50,6 +51,7 @@ import com.waffiq.bazz_movies.core.user.ui.viewmodel.UserPreferenceViewModel
 import com.waffiq.bazz_movies.feature.more.databinding.FragmentMoreBinding
 import com.waffiq.bazz_movies.feature.more.ui.viewmodel.MoreLocalViewModel
 import com.waffiq.bazz_movies.feature.more.ui.viewmodel.MoreUserViewModel
+import com.waffiq.bazz_movies.feature.more.utils.Helper.validName
 import com.waffiq.bazz_movies.navigation.INavigator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -266,7 +268,7 @@ class MoreFragment : Fragment() {
 
   private fun setData(user: UserModel) {
     binding.apply {
-      tvFullName.text = user.name
+      tvFullName.text = user.name.validName(getString(user_no_name))
       tvUsername.text = user.username
       val link = if (!user.gravatarHash.isNullOrEmpty()) {
         "$GRAVATAR_LINK${user.gravatarHash}" + ".jpg?s=200"

--- a/feature/more/src/main/kotlin/com/waffiq/bazz_movies/feature/more/utils/Helper.kt
+++ b/feature/more/src/main/kotlin/com/waffiq/bazz_movies/feature/more/utils/Helper.kt
@@ -1,0 +1,5 @@
+package com.waffiq.bazz_movies.feature.more.utils
+
+object Helper {
+  fun String.validName(fallback: String): String = this.ifEmpty { fallback }
+}

--- a/feature/more/src/test/kotlin/com/waffiq/bazz_movies/feature/more/utils/HelperTest.kt
+++ b/feature/more/src/test/kotlin/com/waffiq/bazz_movies/feature/more/utils/HelperTest.kt
@@ -1,0 +1,18 @@
+package com.waffiq.bazz_movies.feature.more.utils
+
+import com.waffiq.bazz_movies.feature.more.utils.Helper.validName
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HelperTest {
+
+  @Test
+  fun validName_whenNameIsValid_returnsTheName(){
+    assertEquals("Name not set","".validName("Name not set"))
+  }
+
+  @Test
+  fun validName_whenNameIsEmpty_returnsFallback(){
+    assertEquals("Name User","Name User".validName(""))
+  }
+}


### PR DESCRIPTION
### Changes Made

- Show placeholder text when logged-in users have not set a display name
- Improve account UI consistency for incomplete profiles