### PR TITLE
fix(ui): correct system navigation bar background color

### DIFF
--- a/core/designsystem/src/main/res/values/themes.xml
+++ b/core/designsystem/src/main/res/values/themes.xml
@@ -582,4 +582,13 @@
     <item name="layout_collapseParallaxMultiplier">0.7</item>
   </style>
 
+  <style name="CreditsBottomSheetStyle" parent="ThemeOverlay.Material3.BottomSheetDialog">
+    <item name="android:navigationBarColor">@color/gray_850</item>
+    <item name="colorOnSurfaceVariant">@color/gray_700</item>
+    <item name="bottomSheetStyle">@style/MyBottomSheetStyle</item>
+  </style>
+
+  <style name="MyBottomSheetStyle" parent="Widget.Material3.BottomSheet.Modal">
+    <item name="backgroundTint">@color/gray_900</item>
+  </style>
 </resources>

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/fragment/CreditsBottomSheet.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/fragment/CreditsBottomSheet.kt
@@ -44,9 +44,8 @@ class CreditsBottomSheet : BottomSheetDialogFragment() {
     return binding.root
   }
 
-  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-    return BottomSheetDialog(requireContext(), CreditsBottomSheetStyle)
-  }
+  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
+    BottomSheetDialog(requireContext(), CreditsBottomSheetStyle)
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/fragment/CreditsBottomSheet.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/fragment/CreditsBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.waffiq.bazz_movies.feature.detail.ui.fragment
 
+import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -12,6 +13,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.tabs.TabLayout
 import com.waffiq.bazz_movies.core.designsystem.R.string.cast
 import com.waffiq.bazz_movies.core.designsystem.R.string.crew
+import com.waffiq.bazz_movies.core.designsystem.R.style.CreditsBottomSheetStyle
 import com.waffiq.bazz_movies.feature.detail.databinding.BottomSheetCreditsBinding
 import com.waffiq.bazz_movies.feature.detail.domain.model.MediaCredits
 import com.waffiq.bazz_movies.feature.detail.ui.adapter.CastAdapter
@@ -40,6 +42,10 @@ class CreditsBottomSheet : BottomSheetDialogFragment() {
   ): View {
     binding = BottomSheetCreditsBinding.inflate(inflater, null, false)
     return binding.root
+  }
+
+  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+    return BottomSheetDialog(requireContext(), CreditsBottomSheetStyle)
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
### Changes Made

- Fix incorrect system navigation color when opening the full cast and crew page
- Replace the white color with Gray 850 to match the page background
- Improve visual consistency between the page and system navigation area