### PR TITLE
refactor(database): use paramete for favorite and watchlist DAO queries

### DIFF
--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -30,7 +30,8 @@ dependencies {
   api(project(":core:models"))
   implementation(project(":core:coroutines"))
   implementation(project(":core:utils"))
-  implementation("com.google.code.gson:gson:2.14.0")
+
+  implementation(libs.gson)
 
   testImplementation(project(":core:test"))
   testImplementation(libs.androidx.core.testing)

--- a/core/database/src/main/kotlin/com/waffiq/bazz_movies/core/database/data/datasource/FavoriteLocalDataSource.kt
+++ b/core/database/src/main/kotlin/com/waffiq/bazz_movies/core/database/data/datasource/FavoriteLocalDataSource.kt
@@ -1,5 +1,7 @@
 package com.waffiq.bazz_movies.core.database.data.datasource
 
+import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
+import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.coroutines.IoDispatcher
 import com.waffiq.bazz_movies.core.database.data.model.FavoriteEntity
 import com.waffiq.bazz_movies.core.database.data.room.FavoriteDao
@@ -17,16 +19,16 @@ class FavoriteLocalDataSource @Inject constructor(
 ) : FavoriteLocalDataSourceInterface {
 
   override val getFavoriteMovies: Flow<List<FavoriteEntity>> =
-    favoriteDao.getFavoriteMovies().flowOn(ioDispatcher)
+    favoriteDao.getFavorites(MOVIE_MEDIA_TYPE).flowOn(ioDispatcher)
 
   override val getFavoriteTv: Flow<List<FavoriteEntity>> =
-    favoriteDao.getFavoriteTv().flowOn(ioDispatcher)
+    favoriteDao.getFavorites(TV_MEDIA_TYPE).flowOn(ioDispatcher)
 
   override val getWatchlistMovies: Flow<List<FavoriteEntity>> =
-    favoriteDao.getWatchlistMovies().flowOn(ioDispatcher)
+    favoriteDao.getWatchlist(MOVIE_MEDIA_TYPE).flowOn(ioDispatcher)
 
   override val getWatchlistTv: Flow<List<FavoriteEntity>> =
-    favoriteDao.getWatchlistTv().flowOn(ioDispatcher)
+    favoriteDao.getWatchlist(TV_MEDIA_TYPE).flowOn(ioDispatcher)
 
   override suspend fun insert(favoriteEntityList: FavoriteEntity): DbResult<Int> =
     executeDbOperation { favoriteDao.insert(favoriteEntityList).toInt() }

--- a/core/database/src/main/kotlin/com/waffiq/bazz_movies/core/database/data/room/FavoriteDao.kt
+++ b/core/database/src/main/kotlin/com/waffiq/bazz_movies/core/database/data/room/FavoriteDao.kt
@@ -28,25 +28,31 @@ interface FavoriteDao {
     }
   }
 
-  @Query("SELECT * FROM $FAVORITE_TABLE_NAME WHERE is_favorited = 1 and mediaType = 'tv'")
-  fun getFavoriteTv(): Flow<List<FavoriteEntity>>
-
-  @Query("SELECT * FROM $FAVORITE_TABLE_NAME WHERE is_favorited = 1 and mediaType = 'movie'")
-  fun getFavoriteMovies(): Flow<List<FavoriteEntity>>
-
-  @Query("SELECT * FROM $FAVORITE_TABLE_NAME WHERE is_watchlist = 1 and mediaType = 'movie'")
-  fun getWatchlistMovies(): Flow<List<FavoriteEntity>>
-
-  @Query("SELECT * FROM $FAVORITE_TABLE_NAME WHERE is_watchlist = 1 and mediaType = 'tv'")
-  fun getWatchlistTv(): Flow<List<FavoriteEntity>>
+  @Query(
+    """
+    SELECT * FROM $FAVORITE_TABLE_NAME
+    WHERE is_favorited = 1
+    AND mediaType = :mediaType
+  """,
+  )
+  fun getFavorites(mediaType: String): Flow<List<FavoriteEntity>>
 
   @Query(
     """
-        SELECT * FROM $FAVORITE_TABLE_NAME
-        WHERE mediaId = :mediaId
-        AND mediaType = :mediaType
-        LIMIT 1
-    """,
+    SELECT * FROM $FAVORITE_TABLE_NAME
+    WHERE is_watchlist = 1
+    AND mediaType = :mediaType
+  """,
+  )
+  fun getWatchlist(mediaType: String): Flow<List<FavoriteEntity>>
+
+  @Query(
+    """
+    SELECT * FROM $FAVORITE_TABLE_NAME
+    WHERE mediaId = :mediaId
+    AND mediaType = :mediaType
+    LIMIT 1
+  """,
   )
   suspend fun getByMedia(mediaId: Int, mediaType: String): FavoriteEntity?
 
@@ -60,7 +66,7 @@ interface FavoriteDao {
         mediaType = entity.mediaType,
       )
 
-      // This code is defensive code when theres race condition or db corrupt
+      // This code is defensive code when there's race condition or db corrupt
       // Basically insert() returning -1L guarantees a conflict exists in DB,
       // so getByMedia() will always return non-null here.
       if (existing != null) {
@@ -74,7 +80,13 @@ interface FavoriteDao {
     }
   }
 
-  @Query("DELETE FROM $FAVORITE_TABLE_NAME WHERE mediaId = :mediaId and mediaType = :mediaType")
+  @Query(
+    """
+    DELETE FROM $FAVORITE_TABLE_NAME
+    WHERE mediaId = :mediaId
+    AND mediaType = :mediaType
+  """,
+  )
   suspend fun deleteItem(mediaId: Int, mediaType: String): Int // delete from table
 
   @Query("DELETE FROM $FAVORITE_TABLE_NAME")

--- a/core/database/src/test/kotlin/com/waffiq/bazz_movies/core/database/data/datasource/FavoriteLocalDataSourceTest.kt
+++ b/core/database/src/test/kotlin/com/waffiq/bazz_movies/core/database/data/datasource/FavoriteLocalDataSourceTest.kt
@@ -109,7 +109,7 @@ class FavoriteLocalDataSourceTest {
         localDataSource.deleteItemFromDB(favoriteMovieEntity.mediaId, favoriteMovieEntity.mediaType)
       assert(result is DbResult.Success && result.data == 1)
 
-      val remainingMovies = favoriteDao.getFavoriteMovies().first()
+      val remainingMovies = favoriteDao.getFavorites(MOVIE_MEDIA_TYPE).first()
       assert(remainingMovies.isEmpty())
     }
 
@@ -125,7 +125,7 @@ class FavoriteLocalDataSourceTest {
       val result = localDataSource.deleteAll()
       assert(result is DbResult.Success && result.data == fakeMovies.size)
 
-      val remainingMovies = favoriteDao.getFavoriteMovies().first()
+      val remainingMovies = favoriteDao.getFavorites(MOVIE_MEDIA_TYPE).first()
       assert(remainingMovies.isEmpty())
     }
 
@@ -148,7 +148,7 @@ class FavoriteLocalDataSourceTest {
       )
       assert(result is DbResult.Success && result.data == Unit)
 
-      val updatedMovie = favoriteDao.getFavoriteMovies().first().first()
+      val updatedMovie = favoriteDao.getFavorites(MOVIE_MEDIA_TYPE).first().first()
       assertTrue(updatedMovie.isFavorite)
       assert(updatedMovie.isFavorite && updatedMovie.isWatchlist)
     }
@@ -160,7 +160,7 @@ class FavoriteLocalDataSourceTest {
       favoriteDao.insert(favoriteMovieEntity.copy(id = 3, isFavorite = true))
       favoriteDao.insert(favoriteMovieEntity.copy(id = 4, isFavorite = true))
 
-      favoriteDao.getFavoriteMovies().test {
+      favoriteDao.getFavorites(MOVIE_MEDIA_TYPE).test {
         assertEquals(1, awaitItem().size)
         cancelAndIgnoreRemainingEvents()
       }
@@ -173,7 +173,7 @@ class FavoriteLocalDataSourceTest {
       favoriteDao.insert(favoriteMovieEntity.copy(id = 3, isFavorite = true))
       favoriteDao.insert(favoriteMovieEntity.copy(id = 4, mediaId = 231, isFavorite = true))
 
-      favoriteDao.getFavoriteMovies().test {
+      favoriteDao.getFavorites(MOVIE_MEDIA_TYPE).test {
         assertEquals(2, awaitItem().size)
         cancelAndIgnoreRemainingEvents()
       }

--- a/core/database/src/test/kotlin/com/waffiq/bazz_movies/core/database/data/room/FavoriteDaoTest.kt
+++ b/core/database/src/test/kotlin/com/waffiq/bazz_movies/core/database/data/room/FavoriteDaoTest.kt
@@ -5,6 +5,7 @@ import android.database.sqlite.SQLiteException
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
+import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.database.testdummy.DummyData.favoriteMovieEntity
 import com.waffiq.bazz_movies.core.database.testdummy.DummyData.favoriteTvEntity
@@ -56,7 +57,7 @@ class FavoriteDaoTest {
     runTest {
       favoriteDao.insert(favoriteTvEntity)
 
-      val favorites = favoriteDao.getFavoriteTv().first()
+      val favorites = favoriteDao.getFavorites(TV_MEDIA_TYPE).first()
       assertEquals(1, favorites.size)
       assertEquals(favoriteTvEntity.mediaId, favorites[0].mediaId)
     }
@@ -66,7 +67,7 @@ class FavoriteDaoTest {
     runTest {
       favoriteDao.insert(favoriteMovieEntity)
 
-      val favorites = favoriteDao.getFavoriteMovies().first()
+      val favorites = favoriteDao.getFavorites(MOVIE_MEDIA_TYPE).first()
       assertEquals(1, favorites.size)
       assertEquals(favoriteMovieEntity.mediaId, favorites[0].mediaId)
     }
@@ -101,7 +102,7 @@ class FavoriteDaoTest {
     runTest(UnconfinedTestDispatcher()) {
       favoriteDao.insert(watchlistMovieEntity)
 
-      favoriteDao.getWatchlistMovies().test {
+      favoriteDao.getWatchlist(MOVIE_MEDIA_TYPE).test {
         val firstEmission = awaitItem()
         assertEquals(1, firstEmission.size)
         assertEquals(watchlistMovieEntity.mediaId, firstEmission[0].mediaId)
@@ -126,7 +127,7 @@ class FavoriteDaoTest {
     runTest(UnconfinedTestDispatcher()) {
       favoriteDao.insert(watchlistTvEntity)
 
-      favoriteDao.getWatchlistTv().test {
+      favoriteDao.getWatchlist(TV_MEDIA_TYPE).test {
         val firstEmission = awaitItem()
         assertEquals(1, firstEmission.size)
         assertEquals(watchlistTvEntity.mediaId, firstEmission[0].mediaId)
@@ -217,7 +218,7 @@ class FavoriteDaoTest {
       val deleteCount = favoriteDao.deleteItem(103, TV_MEDIA_TYPE)
       assertEquals(1, deleteCount)
 
-      val favorites = favoriteDao.getFavoriteTv().first()
+      val favorites = favoriteDao.getFavorites(TV_MEDIA_TYPE).first()
       assertEquals(0, favorites.size)
     }
 
@@ -228,17 +229,17 @@ class FavoriteDaoTest {
       favoriteDao.insert(favoriteMovieEntity)
 
       // check if the item is inserted
-      val favoritesTv = favoriteDao.getFavoriteTv().first()
+      val favoritesTv = favoriteDao.getFavorites(TV_MEDIA_TYPE).first()
       assertEquals(1, favoritesTv.size)
 
-      val favoritesMovie = favoriteDao.getFavoriteMovies().first()
+      val favoritesMovie = favoriteDao.getFavorites(MOVIE_MEDIA_TYPE).first()
       assertEquals(1, favoritesMovie.size)
 
       val deleteCount = favoriteDao.deleteAll()
 
       assertEquals(2, deleteCount)
-      assertEquals(0, favoriteDao.getFavoriteTv().first().size)
-      assertEquals(0, favoriteDao.getFavoriteMovies().first().size)
+      assertEquals(0, favoriteDao.getFavorites(TV_MEDIA_TYPE).first().size)
+      assertEquals(0, favoriteDao.getFavorites(MOVIE_MEDIA_TYPE).first().size)
     }
 
   @Test
@@ -285,7 +286,7 @@ class FavoriteDaoTest {
       assertEquals(1, firstInsert)
       assertEquals(-1, secondInsert) // -1 indicates insert was ignored
 
-      val movies = favoriteDao.getFavoriteMovies().first()
+      val movies = favoriteDao.getFavorites(MOVIE_MEDIA_TYPE).first()
       assertEquals(1, movies.size)
       assertEquals("Original Title", movies[0].title)
       assertEquals(true, movies[0].isFavorite)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ material = "1.14.0"
 flexbox = "3.0.0"
 
 # Networking
+gson = "2.14.0"
 retrofit = "3.0.0"
 moshi = "1.15.2"
 okhttp = "5.3.2"
@@ -141,6 +142,7 @@ flexbox = { module = "com.google.android.flexbox:flexbox", version.ref = "flexbo
 google-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 # Networking
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-converter-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }


### PR DESCRIPTION
### Changes Made

- Add mediaType parameter to favorite query
- Add mediaType parameter to watchlist query
- Remove duplicated movie and tv specific DAO methods
- Move Gson dependency declaration to version catalog