### PR TITLE
chore: migrate Glide annotation processing to KSP

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -205,8 +205,7 @@ turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 # Image Loading
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
-glide-compiler = { group = "com.github.bumptech.glide", name = "compiler", version.ref = "glide" }
-# libs.versions.toml
+glide-compiler = { group = "com.github.bumptech.glide", name = "ksp", version.ref = "glide" }
 glide-okhttp3 = { group = "com.github.bumptech.glide", name = "okhttp3-integration", version.ref = "glide" }
 
 # Google Services


### PR DESCRIPTION
### Changes Made

- Replace Glide annotation processing with KSP
- Align Glide with the project's KSP-based build configuration
- See
  -  https://bumptech.github.io/glide/doc/download-setup.html#kotlin---ksp
  - https://mvnrepository.com/artifact/com.github.bumptech.glide/ksp