### PR TITLE
chore(ci): remove testing dependencies package group from Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,15 +82,6 @@
       ],
     },
     {
-      groupName: 'testing libraries',
-      matchPackageNames: [
-        '/junit/',
-        '/androidx.test/',
-        '/androidx.arch.core:core-testing/',
-        '/com.google.truth/',
-      ],
-    },
-    {
       groupName: 'mocking libraries',
       matchPackageNames: [
         '/mockito/',


### PR DESCRIPTION
### Changes Made

- Remove the testing dependencies package group from Renovate configuration
- Allow testing-related dependencies to be updated in separate pull requests
- Grouped testing dependency updates can introduce incompatible versions between Kotlin test libraries and CodeQL. See:
  - https://github.com/waffiqaziz/BAZZ-Movies/pull/437 
  - https://github.com/waffiqaziz/BAZZ-Movies/pull/630
- Isolating updates makes issues easier to identify and prevents unrelated testing dependencies from being blocked by Kotlin-specific incompatibilities