### PR TITLE
chore(ui): rename styles to follow Android theme conventions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
     <activity
       android:name=".RoutingActivity"
       android:exported="true"
-      android:theme="@style/SplashScreenTheme">
+      android:theme="@style/Theme.App.SplashScreen">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,7 +18,7 @@
 
   <com.google.android.material.bottomnavigation.BottomNavigationView
     android:id="@+id/bottom_navigation"
-    style="@style/MyBottomNavigationStyle"
+    style="@style/Widget.App.BottomNavigationView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="bottom"

--- a/core/designsystem/src/main/res/layout/divider.xml
+++ b/core/designsystem/src/main/res/layout/divider.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.divider.MaterialDivider xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="1dp"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  app:dividerColor="@color/gray_700" />

--- a/core/designsystem/src/main/res/layout/illustration_error.xml
+++ b/core/designsystem/src/main/res/layout/illustration_error.xml
@@ -20,7 +20,7 @@
 
   <TextView
     android:id="@+id/tv_something_wrong"
-    style="@style/TextHeader1"
+    style="@style/TextAppearance.App.Header1"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
@@ -30,7 +30,7 @@
 
   <TextView
     android:id="@+id/tv_error_description"
-    style="@style/TextDivider"
+    style="@style/TextAppearance.App.Divider"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
@@ -40,14 +40,14 @@
 
   <com.google.android.material.button.MaterialButton
     android:id="@+id/btn_try_again"
-    style="@style/ButtonTryAgain"
+    style="@style/Widget.App.Button.TryAgain"
     android:layout_gravity="center"
     android:layout_marginTop="4dp"
     android:text="@string/try_again" />
 
   <com.google.android.material.loadingindicator.LoadingIndicator
     android:id="@+id/progress_circular"
-    style="@style/MyProgressBar"
+    style="@style/Widget.App.ProgressBar"
     android:layout_marginTop="8dp"
     android:visibility="gone"
     tools:visibility="visible" />

--- a/core/designsystem/src/main/res/layout/illustration_no_data.xml
+++ b/core/designsystem/src/main/res/layout/illustration_no_data.xml
@@ -17,7 +17,7 @@
 
   <TextView
     android:id="@+id/tv_header_no_data"
-    style="@style/TextHeader1"
+    style="@style/TextAppearance.App.Header1"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/default_margin_parent_20"
@@ -26,7 +26,7 @@
 
   <TextView
     android:id="@+id/tv_no_data"
-    style="@style/TextDivider"
+    style="@style/TextAppearance.App.Divider"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center"

--- a/core/designsystem/src/main/res/layout/item_cast.xml
+++ b/core/designsystem/src/main/res/layout/item_cast.xml
@@ -28,7 +28,7 @@
       android:adjustViewBounds="true"
       android:contentDescription="@string/picture"
       android:scaleType="centerCrop"
-      app:shapeAppearanceOverlay="@style/circleImage"
+      app:shapeAppearanceOverlay="@style/ShapeAppearance.App.Circle"
       tools:background="@tools:sample/avatars" />
 
     <!-- Name -->
@@ -37,7 +37,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginTop="4dp"
-      android:theme="@style/TextCast"
+      android:theme="@style/TextAppearance.App.Cast"
       tools:text="Sam Worthington" />
 
     <TextView
@@ -46,14 +46,14 @@
       android:layout_gravity="center"
       android:text="@string/as"
       android:textColor="@color/gray_400"
-      android:theme="@style/TextCast" />
+      android:theme="@style/TextAppearance.App.Cast" />
 
     <!-- Character names-->
     <TextView
       android:id="@+id/tv_cast_character"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:theme="@style/TextCast"
+      android:theme="@style/TextAppearance.App.Cast"
       tools:text="Jake Sully" />
 
   </LinearLayout>

--- a/core/designsystem/src/main/res/layout/item_favorite.xml
+++ b/core/designsystem/src/main/res/layout/item_favorite.xml
@@ -9,11 +9,11 @@
   <!-- LEFT RevealableListItem - Swipe RIGHT to reveal (Delete action) -->
   <com.google.android.material.listitem.ListItemRevealLayout
     android:id="@+id/reveal_layout_start"
-    style="@style/ListItemRevealLayout.Start">
+    style="@style/Widget.App.ListItemRevealLayout.Start">
 
     <Button
       android:id="@+id/btn_delete"
-      style="@style/ListItemReveal.Button.Start"
+      style="@style/Widget.App.ListItemReveal.Button.Start"
       android:contentDescription="@string/remove_from_favorite" />
 
   </com.google.android.material.listitem.ListItemRevealLayout>
@@ -21,7 +21,7 @@
   <!-- Main content -->
   <com.google.android.material.listitem.ListItemCardView
     android:id="@+id/container_result"
-    style="@style/ListItemCardView">
+    style="@style/Widget.App.ListItemCardView">
 
     <LinearLayout
       android:layout_width="match_parent"
@@ -36,7 +36,7 @@
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:contentDescription="@string/picture"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
         tools:layout_height="100dp"
         tools:src="@color/red_matte" />
 
@@ -49,7 +49,7 @@
         <!-- Name/title -->
         <TextView
           android:id="@+id/tv_title"
-          style="@style/TextHeader3"
+          style="@style/TextAppearance.App.Header3"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:ellipsize="end"
@@ -60,7 +60,7 @@
         <!-- Released year/department-->
         <TextView
           android:id="@+id/tv_year_released"
-          style="@style/TextDivider"
+          style="@style/TextAppearance.App.Divider"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="6dp"
@@ -69,7 +69,7 @@
         <!-- Genre/playing as -->
         <TextView
           android:id="@+id/tv_genre"
-          style="@style/TextDivider"
+          style="@style/TextAppearance.App.Divider"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="6dp"
@@ -85,11 +85,11 @@
   <!-- RIGHT RevealableListItem - Swipe LEFT to reveal (Add to Watchlist action) -->
   <com.google.android.material.listitem.ListItemRevealLayout
     android:id="@+id/reveal_layout_end"
-    style="@style/ListItemRevealLayout.End">
+    style="@style/Widget.App.ListItemRevealLayout.End">
 
     <Button
       android:id="@+id/btn_watchlist"
-      style="@style/ListItemReveal.Button.End"
+      style="@style/Widget.App.ListItemReveal.Button.End"
       android:contentDescription="@string/add_to_watchlist"
       app:icon="@drawable/ic_watchlist_outlined" />
 

--- a/core/designsystem/src/main/res/layout/item_image_slider.xml
+++ b/core/designsystem/src/main/res/layout/item_image_slider.xml
@@ -13,7 +13,7 @@
     android:layout_margin="48dp"
     android:adjustViewBounds="true"
     android:contentDescription="@string/actress_photo"
-    app:shapeAppearanceOverlay="@style/roundedCornersPoster"
+    app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
     tools:src="@tools:sample/avatars" />
 
 </FrameLayout>

--- a/core/designsystem/src/main/res/layout/item_list.xml
+++ b/core/designsystem/src/main/res/layout/item_list.xml
@@ -18,7 +18,7 @@
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
-    app:shapeAppearanceOverlay="@style/roundedCornersImageView"
+    app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
     tools:background="@drawable/ic_bazz_placeholder_poster"
     tools:layout_height="150dp"
     tools:layout_width="100dp" />

--- a/core/designsystem/src/main/res/layout/item_loading.xml
+++ b/core/designsystem/src/main/res/layout/item_loading.xml
@@ -9,7 +9,7 @@
   <!-- Error message -->
   <TextView
     android:id="@+id/error_msg"
-    style="@style/TextDivider"
+    style="@style/TextAppearance.App.Divider"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="center"
@@ -32,7 +32,7 @@
   <!-- Retry button -->
   <com.google.android.material.button.MaterialButton
     android:id="@+id/retry_button"
-    style="@style/ButtonTryAgain"
+    style="@style/Widget.App.Button.TryAgain"
     android:layout_gravity="center"
     android:text="@string/retry" />
 </LinearLayout>

--- a/core/designsystem/src/main/res/layout/item_media.xml
+++ b/core/designsystem/src/main/res/layout/item_media.xml
@@ -12,7 +12,7 @@
     android:layout_width="100dp"
     android:layout_height="150dp"
     android:contentDescription="@string/picture"
-    app:shapeAppearanceOverlay="@style/roundedCornersImageView"
+    app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
     tools:src="@drawable/ic_bazz_placeholder_poster" />
 
   <LinearLayout
@@ -37,7 +37,7 @@
 
     <TextView
       android:id="@+id/tv_year_released"
-      style="@style/TextBody"
+      style="@style/TextAppearance.App.Body"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="4dp"
@@ -46,7 +46,7 @@
 
     <TextView
       android:id="@+id/tv_genre"
-      style="@style/TextBody"
+      style="@style/TextAppearance.App.Body"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginTop="4dp"

--- a/core/designsystem/src/main/res/layout/item_play_for.xml
+++ b/core/designsystem/src/main/res/layout/item_play_for.xml
@@ -26,7 +26,7 @@
       android:layout_gravity="center"
       android:adjustViewBounds="true"
       android:contentDescription="@string/picture"
-      app:shapeAppearanceOverlay="@style/roundedCornersImageView"
+      app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
       tools:background="@tools:sample/avatars" />
 
     <!-- Name -->
@@ -35,7 +35,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginTop="4dp"
-      android:theme="@style/TextCast"
+      android:theme="@style/TextAppearance.App.Cast"
       tools:text="Sam Worthington" />
 
     <TextView
@@ -44,14 +44,14 @@
       android:layout_gravity="center"
       android:text="@string/as"
       android:textColor="@color/gray_400"
-      android:theme="@style/TextCast" />
+      android:theme="@style/TextAppearance.App.Cast" />
 
     <!-- Character names -->
     <TextView
       android:id="@+id/tv_cast_character"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:theme="@style/TextCast"
+      android:theme="@style/TextAppearance.App.Cast"
       tools:text="Jake Sully" />
 
   </LinearLayout>

--- a/core/designsystem/src/main/res/layout/item_poster.xml
+++ b/core/designsystem/src/main/res/layout/item_poster.xml
@@ -15,6 +15,6 @@
     android:adjustViewBounds="true"
     android:contentDescription="@string/picture"
     android:foreground="@drawable/bg_ripple_rounded_corner"
-    app:shapeAppearanceOverlay="@style/roundedCornersImageView"
+    app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
     tools:background="@drawable/ic_bazz_placeholder_poster" />
 </FrameLayout>

--- a/core/designsystem/src/main/res/layout/item_result.xml
+++ b/core/designsystem/src/main/res/layout/item_result.xml
@@ -27,7 +27,7 @@
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:contentDescription="@string/picture"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
         tools:layout_height="100dp"
         tools:src="@color/red_matte" />
 
@@ -40,7 +40,7 @@
         <!-- Name/title -->
         <TextView
           android:id="@+id/tv_title"
-          style="@style/TextHeader3"
+          style="@style/TextAppearance.App.Header3"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:ellipsize="end"
@@ -51,7 +51,7 @@
         <!-- Released year/department-->
         <TextView
           android:id="@+id/tv_year_released"
-          style="@style/TextDivider"
+          style="@style/TextAppearance.App.Divider"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="6dp"
@@ -60,7 +60,7 @@
         <!-- Genre/playing as -->
         <TextView
           android:id="@+id/tv_genre"
-          style="@style/TextDivider"
+          style="@style/TextAppearance.App.Divider"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="6dp"

--- a/core/designsystem/src/main/res/layout/item_result_shimmer.xml
+++ b/core/designsystem/src/main/res/layout/item_result_shimmer.xml
@@ -21,7 +21,7 @@
       android:layout_height="100dp"
       android:adjustViewBounds="true"
       android:contentDescription="@string/picture"
-      app:shapeAppearanceOverlay="@style/roundedCornersImageView"
+      app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
       tools:layout_height="100dp"
       tools:src="@color/red_matte" />
 
@@ -34,7 +34,7 @@
       <!-- Name/title -->
       <TextView
         android:id="@+id/tv_title"
-        style="@style/TextHeader3"
+        style="@style/TextAppearance.App.Header3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:ellipsize="end"
@@ -46,7 +46,7 @@
       <!-- Released year/department-->
       <TextView
         android:id="@+id/tv_year_released"
-        style="@style/TextDivider"
+        style="@style/TextAppearance.App.Divider"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="6dp"
@@ -56,7 +56,7 @@
       <!-- Genre/playing as -->
       <TextView
         android:id="@+id/tv_genre"
-        style="@style/TextDivider"
+        style="@style/TextAppearance.App.Divider"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="6dp"

--- a/core/designsystem/src/main/res/layout/item_watchlist.xml
+++ b/core/designsystem/src/main/res/layout/item_watchlist.xml
@@ -9,11 +9,11 @@
   <!-- LEFT RevealableListItem - Swipe RIGHT to reveal (Delete action) -->
   <com.google.android.material.listitem.ListItemRevealLayout
     android:id="@+id/reveal_layout_start"
-    style="@style/ListItemRevealLayout.Start">
+    style="@style/Widget.App.ListItemRevealLayout.Start">
 
     <Button
       android:id="@+id/btn_delete"
-      style="@style/ListItemReveal.Button.Start"
+      style="@style/Widget.App.ListItemReveal.Button.Start"
       android:contentDescription="@string/remove_from_watchlist" />
 
   </com.google.android.material.listitem.ListItemRevealLayout>
@@ -21,7 +21,7 @@
   <!-- Main content -->
   <com.google.android.material.listitem.ListItemCardView
     android:id="@+id/container_result"
-    style="@style/ListItemCardView">
+    style="@style/Widget.App.ListItemCardView">
 
     <LinearLayout
       android:layout_width="match_parent"
@@ -36,7 +36,7 @@
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:contentDescription="@string/picture"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
         tools:layout_height="100dp"
         tools:src="@color/red_matte" />
 
@@ -49,7 +49,7 @@
         <!-- Name/title -->
         <TextView
           android:id="@+id/tv_title"
-          style="@style/TextHeader3"
+          style="@style/TextAppearance.App.Header3"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:ellipsize="end"
@@ -60,7 +60,7 @@
         <!-- Released year/department-->
         <TextView
           android:id="@+id/tv_year_released"
-          style="@style/TextDivider"
+          style="@style/TextAppearance.App.Divider"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="6dp"
@@ -69,7 +69,7 @@
         <!-- Genre/playing as -->
         <TextView
           android:id="@+id/tv_genre"
-          style="@style/TextDivider"
+          style="@style/TextAppearance.App.Divider"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="6dp"
@@ -85,11 +85,11 @@
   <!-- RIGHT RevealableListItem - Swipe LEFT to reveal (Add to Watchlist action) -->
   <com.google.android.material.listitem.ListItemRevealLayout
     android:id="@+id/reveal_layout_end"
-    style="@style/ListItemRevealLayout.End">
+    style="@style/Widget.App.ListItemRevealLayout.End">
 
     <Button
       android:id="@+id/btn_watchlist"
-      style="@style/ListItemReveal.Button.End"
+      style="@style/Widget.App.ListItemReveal.Button.End"
       android:contentDescription="@string/add_to_favorite"
       app:icon="@drawable/ic_hearth" />
 

--- a/core/designsystem/src/main/res/layout/list_item_media_swipe.xml
+++ b/core/designsystem/src/main/res/layout/list_item_media_swipe.xml
@@ -8,11 +8,11 @@
   <!--  Swipe RIGHT (Delete action)-->
   <com.google.android.material.listitem.ListItemRevealLayout
     android:id="@+id/reveal_layout_start"
-    style="@style/ListItemRevealLayout.Start">
+    style="@style/Widget.App.ListItemRevealLayout.Start">
 
     <com.google.android.material.button.MaterialButton
       android:id="@+id/btn_action_start"
-      style="@style/ListItemReveal.Button.Start" />
+      style="@style/Widget.App.ListItemReveal.Button.Start" />
 
   </com.google.android.material.listitem.ListItemRevealLayout>
 
@@ -33,11 +33,11 @@
   <!--  Swipe LEFT (Favorite/Watchlist action)-->
   <com.google.android.material.listitem.ListItemRevealLayout
     android:id="@+id/reveal_layout_end"
-    style="@style/ListItemRevealLayout.End">
+    style="@style/Widget.App.ListItemRevealLayout.End">
 
     <com.google.android.material.button.MaterialButton
       android:id="@+id/btn_action_end"
-      style="@style/ListItemReveal.Button.End" />
+      style="@style/Widget.App.ListItemReveal.Button.End" />
 
   </com.google.android.material.listitem.ListItemRevealLayout>
 </com.google.android.material.listitem.ListItemLayout>

--- a/core/designsystem/src/main/res/values-night/themes.xml
+++ b/core/designsystem/src/main/res/values-night/themes.xml
@@ -15,12 +15,12 @@
     <!-- Color for all background -->
     <item name="android:windowBackground">@color/gray_1000</item>
 
-    <item name="android:windowAnimationStyle">@style/WindowAnimationStyle</item>
+    <item name="android:windowAnimationStyle">@style/Animation.App.Window</item>
 
     <item name="sideSheetDialogTheme">@style/ThemeOverlay.App.SideSheetDialog</item>
   </style>
 
-  <style name="Theme.BottomNavigationView.ActiveIndicator" parent="Widget.Material3.BottomNavigationView.ActiveIndicator">
+  <style name="Widget.App.BottomNavigationView.ActiveIndicator" parent="Widget.Material3.BottomNavigationView.ActiveIndicator">
     <item name="android:color">@color/gray_900</item>
   </style>
 </resources>

--- a/core/designsystem/src/main/res/values/themes.xml
+++ b/core/designsystem/src/main/res/values/themes.xml
@@ -16,25 +16,25 @@
     <!-- Color for all background -->
     <item name="android:windowBackground">@color/gray_1000</item>
 
-    <item name="android:windowAnimationStyle">@style/WindowAnimationStyle</item>
+    <item name="android:windowAnimationStyle">@style/Animation.App.Window</item>
 
     <item name="sideSheetDialogTheme">@style/ThemeOverlay.App.SideSheetDialog</item>
     <item name="bottomSheetDialogTheme">@style/ThemeOverlay.App.BottomSheetDialog</item>
   </style>
 
-  <style name="WindowAnimationStyle">
+  <style name="Animation.App.Window" parent="">
     <item name="android:windowEnterAnimation">@android:anim/fade_in</item>
     <item name="android:windowExitAnimation">@android:anim/fade_out</item>
   </style>
 
-  <style name="SplashScreenTheme" parent="Theme.SplashScreen">
+  <style name="Theme.App.SplashScreen" parent="Theme.SplashScreen">
     <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash</item>
     <item name="windowSplashScreenBackground">@color/gray_1000</item>
     <item name="windowSplashScreenAnimationDuration">300</item>
     <item name="postSplashScreenTheme">@style/Base.Theme.BAZZ_movies</item>
   </style>
 
-  <style name="FilterToggleOverlay" parent="Widget.Material3Expressive.Button.OutlinedButton">
+  <style name="Widget.App.Button.FilterToggle" parent="Widget.Material3Expressive.Button.OutlinedButton">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:minHeight">0dp</item>
@@ -51,7 +51,7 @@
     <item name="backgroundTint">@color/toggle_button_bg</item>
   </style>
 
-  <style name="FilterButtonGroupStyle" parent="Widget.Material3.MaterialButtonGroup.Connected">
+  <style name="Widget.App.ButtonGroup.Filter" parent="Widget.Material3.MaterialButtonGroup.Connected">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="fontFamily">@font/nunito_sans_bold</item>
@@ -61,18 +61,18 @@
     <item name="singleSelection">true</item>
   </style>
 
-  <style name="Theme.BottomNavigationView.ActiveIndicator" parent="Widget.Material3.BottomNavigationView.ActiveIndicator">
+  <style name="Widget.App.BottomNavigationView.ActiveIndicator" parent="Widget.Material3.BottomNavigationView.ActiveIndicator">
     <item name="android:color">@color/gray_900</item>
   </style>
 
-  <style name="MyBottomNavigationStyle" parent="Widget.Material3.BottomNavigationView">
-    <item name="itemTextAppearanceActive">@style/CustomBottomNavigationTextAppearance</item>
-    <item name="itemTextAppearanceInactive">@style/CustomBottomNavigationTextAppearance</item>
-    <item name="itemActiveIndicatorStyle">@style/Theme.BottomNavigationView.ActiveIndicator</item>
+  <style name="Widget.App.BottomNavigationView" parent="Widget.Material3.BottomNavigationView">
+    <item name="itemTextAppearanceActive">@style/TextAppearance.App.BottomNavigationView.Label</item>
+    <item name="itemTextAppearanceInactive">@style/TextAppearance.App.BottomNavigationView.Label</item>
+    <item name="itemActiveIndicatorStyle">@style/Widget.App.BottomNavigationView.ActiveIndicator</item>
     <item name="android:background">?attr/colorPrimary</item>
   </style>
 
-  <style name="CustomBottomNavigationTextAppearance">
+  <style name="TextAppearance.App.BottomNavigationView.Label" parent="">
     <item name="android:fontFamily">@font/nunito_sans_regular</item>
     <item name="android:textAppearance">@style/TextAppearance.Material3.LabelSmall</item>
     <item name="android:lineHeight" tools:targetApi="28">13sp</item>
@@ -89,19 +89,19 @@
     <item name="android:orientation">horizontal</item>
   </style>
 
-  <style name="MyDimStyle">
+  <style name="Widget.App.DimOverlay" parent="">
     <item name="android:background">@color/gray_900</item>
     <item name="android:layout_height">match_parent</item>
     <item name="android:layout_width">match_parent</item>
   </style>
 
-  <style name="MyDimStyleMatchParent">
+  <style name="Widget.App.DimOverlay.MatchParent" parent="">
     <item name="android:background">@color/gray_900</item>
     <item name="android:layout_height">match_parent</item>
     <item name="android:layout_width">match_parent</item>
   </style>
 
-  <style name="MyProgressBar">
+  <style name="Widget.App.ProgressBar" parent="">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_gravity">center</item>
@@ -111,7 +111,7 @@
     <item name="android:visibility">visible</item>
   </style>
 
-  <style name="MyLoginButtonPortrait" parent="Widget.Material3Expressive.Button">
+  <style name="Widget.App.Button.Login.Portrait" parent="Widget.Material3Expressive.Button">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_marginBottom">8dp</item>
@@ -123,7 +123,7 @@
     <item name="backgroundTint">@color/yellow</item>
   </style>
 
-  <style name="MyTransparentButton" parent="Widget.Material3.Button.TextButton">
+  <style name="Widget.App.Button.Transparent" parent="Widget.Material3.Button.TextButton">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:fontFamily">@font/nunito_sans_regular</item>
@@ -134,7 +134,7 @@
     <item name="cornerRadius">@dimen/button_radius</item>
   </style>
 
-  <style name="MyLoginButtonLand" parent="Widget.Material3.Button">
+  <style name="Widget.App.Button.Login.Land" parent="Widget.Material3.Button">
     <item name="android:layout_width">450dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_marginBottom">4dp</item>
@@ -145,7 +145,7 @@
     <item name="android:backgroundTint">@color/yellow</item>
   </style>
 
-  <style name="ButtonTryAgain" parent="ThemeOverlay.Material3.Button">
+  <style name="Widget.App.Button.TryAgain" parent="ThemeOverlay.Material3.Button">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_marginBottom">4dp</item>
@@ -178,37 +178,37 @@
     <item name="closeIcon">@drawable/ic_cross</item>
   </style>
 
-  <style name="TextTabLayoutStyle" parent="Widget.Material3.TabLayout">
+  <style name="Widget.App.TabLayout" parent="Widget.Material3.TabLayout">
     <item name="android:textSize">12sp</item>
     <item name="textAllCaps">false</item>
     <item name="fontFamily">@font/nunito_sans_semi_bold</item>
   </style>
 
-  <style name="TextHeader1">
+  <style name="TextAppearance.App.Header1" parent="">
     <item name="android:textAppearance">@style/TextAppearance.Material3.HeadlineSmall</item>
     <item name="android:textColor">?attr/colorOnPrimary</item>
     <item name="fontFamily">@font/nunito_sans_bold</item>
   </style>
 
-  <style name="TextHeader2">
+  <style name="TextAppearance.App.Header2" parent="">
     <item name="android:textAppearance">@style/TextAppearance.Material3.TitleMedium</item>
     <item name="android:textColor">?attr/colorOnPrimary</item>
     <item name="fontFamily">@font/nunito_sans_bold</item>
   </style>
 
-  <style name="TextHeader3">
+  <style name="TextAppearance.App.Header3" parent="">
     <item name="android:textAppearance">@style/TextAppearance.Material3.TitleSmall</item>
     <item name="android:textColor">?attr/colorOnPrimary</item>
     <item name="fontFamily">@font/nunito_sans_bold</item>
   </style>
 
-  <style name="TextDivider">
+  <style name="TextAppearance.App.Divider" parent="">
     <item name="android:textAppearance">@style/TextAppearance.Material3.BodyMedium</item>
     <item name="android:textColor">@color/gray_400</item>
     <item name="fontFamily">@font/nunito_sans_regular</item>
   </style>
 
-  <style name="TextCast">
+  <style name="TextAppearance.App.Cast" parent="">
     <item name="android:textAppearance">@style/TextAppearance.Material3.LabelSmall</item>
     <item name="android:maxLines">1</item>
     <item name="android:layout_gravity">center</item>
@@ -218,19 +218,19 @@
     <item name="fontFamily">@font/nunito_sans_regular</item>
   </style>
 
-  <style name="TextMetadata">
+  <style name="TextAppearance.App.Metadata" parent="">
     <item name="android:textAppearance">@style/TextAppearance.Material3.LabelMedium</item>
     <item name="android:textColor">@color/gray_200</item>
     <item name="fontFamily">@font/nunito_sans_regular</item>
   </style>
 
-  <style name="TextBody">
+  <style name="TextAppearance.App.Body" parent="">
     <item name="android:textAppearance">@style/TextAppearance.Material3.BodyMedium</item>
     <item name="android:textColor">@color/gray_200</item>
     <item name="fontFamily">@font/nunito_sans_regular</item>
   </style>
 
-  <style name="TextScore">
+  <style name="TextAppearance.App.Score" parent="">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:textAppearance">@style/TextAppearance.Material3.BodyLarge</item>
@@ -240,7 +240,7 @@
     <item name="android:text">@string/not_available</item>
   </style>
 
-  <style name="TextScoreHeader">
+  <style name="TextAppearance.App.Score.Header" parent="">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_marginTop">4dp</item>
@@ -299,7 +299,7 @@
     <item name="android:visibility">gone</item>
   </style>
 
-  <style name="ButtonMoreStyle">
+  <style name="Widget.App.Button.More" parent="">
     <item name="android:paddingStart">20dp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_width">match_parent</item>
@@ -311,28 +311,28 @@
     <item name="fontFamily">@font/nunito_sans_regular</item>
   </style>
 
-  <style name="customButton">
+  <style name="Widget.App.Button.Compact" parent="">
     <item name="textAllCaps">false</item>
     <item name="android:minHeight">39dp</item>
     <item name="android:textColor">?attr/colorOnPrimary</item>
   </style>
 
-  <style name="roundedCornersImageView" parent="">
+  <style name="ShapeAppearance.App.ImageView.Rounded" parent="">
     <item name="cornerFamily">rounded</item>
     <item name="cornerSize">@dimen/button_radius</item>
   </style>
 
-  <style name="roundedCornersPoster" parent="">
+  <style name="ShapeAppearance.App.Poster.Rounded" parent="">
     <item name="cornerFamily">rounded</item>
     <item name="cornerSize">@dimen/button_radius</item>
   </style>
 
-  <style name="circleImage" parent="">
+  <style name="ShapeAppearance.App.Circle" parent="">
     <item name="cornerFamily">rounded</item>
     <item name="cornerSize">50%</item>
   </style>
 
-  <style name="CustomAlertDialogTheme" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+  <style name="ThemeOverlay.App.AlertDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
     <item name="colorSurfaceContainerHigh">@color/gray_850</item>
     <item name="colorOnSurface">@color/gray_200</item>
     <item name="colorPrimary">@color/gray_200</item>
@@ -340,14 +340,14 @@
     <item name="android:textColorSecondaryInverse">@color/gray_300</item>
     <item name="android:fontFamily">@font/nunito_sans_regular</item>
     <item name="android:backgroundTint">@color/gray_850</item>
-    <item name="materialAlertDialogBodyTextStyle">@style/CustomDialogBodyText</item>
+    <item name="materialAlertDialogBodyTextStyle">@style/TextAppearance.App.AlertDialog.Body</item>
   </style>
 
-  <style name="CustomDialogBodyText" parent="MaterialAlertDialog.Material3.Body.Text">
+  <style name="TextAppearance.App.AlertDialog.Body" parent="MaterialAlertDialog.Material3.Body.Text">
     <item name="android:textColor">@color/gray_300</item>
   </style>
 
-  <style name="ChipTextAppearance" parent="TextAppearance.MaterialComponents.Chip">
+  <style name="TextAppearance.App.Chip" parent="TextAppearance.MaterialComponents.Chip">
     <item name="android:fontFamily">@font/nunito_sans_regular</item>
   </style>
 
@@ -360,7 +360,7 @@
     <item name="bottomSheetStyle">@style/ModalBottomSheetDialog</item>
   </style>
 
-  <style name="MyIconButtonStyle" parent="ThemeOverlay.Material3Expressive.Button.IconButton.Standard">
+  <style name="Widget.App.Button.IconButton" parent="ThemeOverlay.Material3Expressive.Button.IconButton.Standard">
     <item name="materialIconButtonStyle">
       @style/Widget.Material3Expressive.Button.IconButton.Standard
     </item>
@@ -389,21 +389,21 @@
     <item name="cornerSize">32dp</item>
   </style>
 
-  <style name="ListItemRevealLayout.Start" parent="Widget.Material3.ListItemRevealLayout">
+  <style name="Widget.App.ListItemRevealLayout.Start" parent="Widget.Material3.ListItemRevealLayout">
     <item name="android:layout_height">match_parent</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_gravity">start</item>
     <item name="primaryActionSwipeMode">direct</item>
   </style>
 
-  <style name="ListItemRevealLayout.End" parent="Widget.Material3.ListItemRevealLayout">
+  <style name="Widget.App.ListItemRevealLayout.End" parent="Widget.Material3.ListItemRevealLayout">
     <item name="android:layout_height">match_parent</item>
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_gravity">end</item>
     <item name="primaryActionSwipeMode">direct</item>
   </style>
 
-  <style name="ListItemReveal.Button.Start" parent="Widget.Material3.Button.IconButton.Filled">
+  <style name="Widget.App.ListItemReveal.Button.Start" parent="Widget.Material3.Button.IconButton.Filled">
     <item name="android:layout_height">match_parent</item>
     <item name="android:layout_width">64dp</item>
     <item name="android:layout_marginStart">2dp</item>
@@ -417,7 +417,7 @@
     <item name="primaryActionSwipeMode">direct</item>
   </style>
 
-  <style name="ListItemReveal.Button.End" parent="Widget.Material3.Button.IconButton.Filled">
+  <style name="Widget.App.ListItemReveal.Button.End" parent="Widget.Material3.Button.IconButton.Filled">
     <item name="android:layout_width">64dp</item>
     <item name="android:layout_height">match_parent</item>
     <item name="android:layout_marginStart">2dp</item>
@@ -430,7 +430,7 @@
     <item name="primaryActionSwipeMode">direct</item>
   </style>
 
-  <style name="ListItemCardView" parent="Widget.Material3.ListItemCardView">
+  <style name="Widget.App.ListItemCardView" parent="Widget.Material3.ListItemCardView">
     <item name="listItemCardViewStyle">?attr/listItemCardViewStyle</item>
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>
@@ -438,22 +438,22 @@
     <item name="shapeAppearance">?attr/listItemShapeAppearanceSingle</item>
   </style>
 
-  <style name="CollapsedTitleStyle" parent="TextAppearance.Material3.TitleMedium">
+  <style name="TextAppearance.App.CollapsingToolbar.Title.Collapsed" parent="TextAppearance.Material3.TitleMedium">
     <item name="fontFamily">@font/nunito_sans_bold</item>
     <item name="android:fontFamily">@font/nunito_sans_bold</item>
   </style>
 
-  <style name="CollapsedSubtitleStyle" parent="TextAppearance.Material3.BodySmall">
+  <style name="TextAppearance.App.CollapsingToolbar.Subtitle.Collapsed" parent="TextAppearance.Material3.BodySmall">
     <item name="fontFamily">@font/nunito_sans_bold</item>
     <item name="android:fontFamily">@font/nunito_sans_bold</item>
   </style>
 
-  <style name="ExtendedTitleStyle" parent="TextAppearance.Material3.HeadlineSmall.Emphasized">
+  <style name="TextAppearance.App.CollapsingToolbar.Title.Expanded" parent="TextAppearance.Material3.HeadlineSmall.Emphasized">
     <item name="fontFamily">@font/nunito_sans_bold</item>
     <item name="android:fontFamily">@font/nunito_sans_bold</item>
   </style>
 
-  <style name="ExpandedSubtitleStyle" parent="TextAppearance.Material3.BodyLarge">
+  <style name="TextAppearance.App.CollapsingToolbar.Subtitle.Expanded" parent="TextAppearance.Material3.BodyLarge">
     <item name="fontFamily">@font/nunito_sans_bold</item>
     <item name="android:fontFamily">@font/nunito_sans_bold</item>
     <item name="android:maxLines">2</item>
@@ -525,7 +525,7 @@
     <item name="iconTint">@color/yellow</item>
   </style>
 
-  <style name="CircleButton" parent="Widget.Material3Expressive.Button.IconButton.Filled">
+  <style name="Widget.App.Button.Circle" parent="Widget.Material3Expressive.Button.IconButton.Filled">
     <item name="android:layout_width">@dimen/button_size</item>
     <item name="android:layout_height">@dimen/button_size</item>
     <item name="android:insetLeft">0dp</item>
@@ -539,7 +539,7 @@
     <item name="iconTint">@color/yellow</item>
   </style>
 
-  <style name="BackButton" parent="CircleButton">
+  <style name="Widget.App.Button.Circle.Back" parent="Widget.App.Button.Circle">
     <item name="android:paddingBottom">8dp</item>
     <item name="android:paddingTop">8dp</item>
     <item name="android:paddingLeft">8.25dp</item>
@@ -548,33 +548,33 @@
     <item name="iconSize">28dp</item>
   </style>
 
-  <style name="AppBarLayoutStyle">
+  <style name="Widget.App.AppBarLayout" parent="">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:background">@null</item>
     <item name="android:translationZ">0.1dp</item>
   </style>
 
-  <style name="MaterialToolbarStyle">
+  <style name="Widget.App.Toolbar" parent="">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">@dimen/toolbar_height</item>
     <item name="android:clipToPadding">false</item>
     <item name="android:minHeight">0dp</item>
   </style>
 
-  <style name="CollapsingToolbarLayoutStyle">
+  <style name="Widget.App.CollapsingToolbarLayout" parent="">
     <item name="collapsedTitleTextColor">@color/white</item>
     <item name="collapsedTitleGravity">bottom</item>
-    <item name="collapsedTitleTextAppearance">@style/CollapsedTitleStyle</item>
+    <item name="collapsedTitleTextAppearance">@style/TextAppearance.App.CollapsingToolbar.Title.Collapsed</item>
     <item name="contentScrim">@color/gray_1000</item>
     <item name="expandedTitleGravity">bottom|center_horizontal</item>
     <item name="expandedTitleTextColor">@color/white</item>
     <item name="layout_scrollFlags">scroll|exitUntilCollapsed|enterAlwaysCollapsed</item>
-    <item name="expandedTitleTextAppearance">@style/ExtendedTitleStyle</item>
+    <item name="expandedTitleTextAppearance">@style/TextAppearance.App.CollapsingToolbar.Title.Expanded</item>
     <item name="titleCollapseMode">fade</item>
   </style>
 
-  <style name="CollapseImageViewStyle">
+  <style name="Widget.App.CollapsingToolbarLayout.ImageView" parent="">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">match_parent</item>
     <item name="android:foreground">@drawable/bg_gradient_shape</item>
@@ -583,13 +583,13 @@
     <item name="layout_collapseParallaxMultiplier">0.7</item>
   </style>
 
-  <style name="CreditsBottomSheetStyle" parent="ThemeOverlay.Material3.BottomSheetDialog">
+  <style name="ThemeOverlay.App.BottomSheetDialog.Credits" parent="ThemeOverlay.Material3.BottomSheetDialog">
     <item name="android:navigationBarColor">@color/gray_850</item>
     <item name="colorOnSurfaceVariant">@color/gray_700</item>
-    <item name="bottomSheetStyle">@style/MyBottomSheetStyle</item>
+    <item name="bottomSheetStyle">@style/Widget.App.BottomSheet</item>
   </style>
 
-  <style name="MyBottomSheetStyle" parent="Widget.Material3.BottomSheet.Modal">
+  <style name="Widget.App.BottomSheet" parent="Widget.Material3.BottomSheet.Modal">
     <item name="backgroundTint">@color/gray_900</item>
   </style>
 </resources>

--- a/feature/about/src/main/res/layout/activity_about.xml
+++ b/feature/about/src/main/res/layout/activity_about.xml
@@ -24,7 +24,7 @@
 
       <Button
         android:id="@+id/btn_back"
-        style="@style/BackButton"
+        style="@style/Widget.App.Button.Circle.Back"
         android:layout_gravity="start|bottom"
         android:layout_marginRight="@dimen/margin_between_item"
         android:translationY="7dp" />
@@ -54,14 +54,14 @@
     <!-- ========================== -->
     <TextView
       android:id="@+id/tv_about_header"
-      style="@style/TextHeader1"
+      style="@style/TextAppearance.App.Header1"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:text="@string/about" />
 
     <TextView
       android:id="@+id/tv_tmdb_attribute"
-      style="@style/TextBody"
+      style="@style/TextAppearance.App.Body"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginTop="8dp"
@@ -79,7 +79,7 @@
 
     <TextView
       android:id="@+id/tv_about_text"
-      style="@style/TextBody"
+      style="@style/TextAppearance.App.Body"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:text="@string/about_text" />
@@ -87,7 +87,7 @@
     <!-- ====== About button ====== -->
     <com.google.android.material.button.MaterialButton
       android:id="@+id/btn_about_us"
-      style="@style/MyTransparentButton"
+      style="@style/Widget.App.Button.Transparent"
       android:layout_gravity="center_horizontal"
       android:layout_marginTop="20dp"
       android:text="@string/about_us" />

--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/fragment/CreditsBottomSheet.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/ui/fragment/CreditsBottomSheet.kt
@@ -13,7 +13,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.tabs.TabLayout
 import com.waffiq.bazz_movies.core.designsystem.R.string.cast
 import com.waffiq.bazz_movies.core.designsystem.R.string.crew
-import com.waffiq.bazz_movies.core.designsystem.R.style.CreditsBottomSheetStyle
+import com.waffiq.bazz_movies.core.designsystem.R.style.ThemeOverlay_App_BottomSheetDialog_Credits
 import com.waffiq.bazz_movies.feature.detail.databinding.BottomSheetCreditsBinding
 import com.waffiq.bazz_movies.feature.detail.domain.model.MediaCredits
 import com.waffiq.bazz_movies.feature.detail.ui.adapter.CastAdapter
@@ -45,7 +45,7 @@ class CreditsBottomSheet : BottomSheetDialogFragment() {
   }
 
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
-    BottomSheetDialog(requireContext(), CreditsBottomSheetStyle)
+    BottomSheetDialog(requireContext(), ThemeOverlay_App_BottomSheetDialog_Credits)
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)

--- a/feature/detail/src/main/res/layout/activity_media_detail.xml
+++ b/feature/detail/src/main/res/layout/activity_media_detail.xml
@@ -13,17 +13,17 @@
   <!-- ========================== -->
   <com.google.android.material.appbar.AppBarLayout
     android:id="@+id/app_bar_layout"
-    style="@style/AppBarLayoutStyle">
+    style="@style/Widget.App.AppBarLayout">
 
     <com.google.android.material.appbar.MaterialToolbar
       android:id="@+id/toolbar"
-      style="@style/MaterialToolbarStyle"
+      style="@style/Widget.App.Toolbar"
       android:paddingBottom="@dimen/margin_each_item">
 
       <!-- Back button -->
       <Button
         android:id="@+id/btn_back"
-        style="@style/BackButton"
+        style="@style/Widget.App.Button.Circle.Back"
         android:layout_gravity="start|bottom" />
 
       <!-- Favorite watchlist button -->
@@ -109,7 +109,7 @@
           <!-- Backdrop image -->
           <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/iv_picture_backdrop"
-            style="@style/roundedCornersPoster"
+            style="@style/ShapeAppearance.App.ImageView.Rounded"
             android:layout_width="match_parent"
             android:layout_height="270dp"
             android:adjustViewBounds="true"
@@ -175,13 +175,13 @@
             android:contentDescription="@string/poster"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/iv_picture_backdrop"
-            app:shapeAppearanceOverlay="@style/roundedCornersPoster"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
             tools:src="@drawable/ic_bazz_placeholder_poster" />
 
           <!-- Title -->
           <TextView
             android:id="@+id/tv_title"
-            style="@style/TextHeader1"
+            style="@style/TextAppearance.App.Header1"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
@@ -197,7 +197,7 @@
           <!-- Release date -->
           <TextView
             android:id="@+id/tv_year_released"
-            style="@style/TextMetadata"
+            style="@style/TextAppearance.App.Metadata"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
@@ -208,7 +208,7 @@
           <!-- Region -->
           <TextView
             android:id="@+id/tv_region_release"
-            style="@style/TextMetadata"
+            style="@style/TextAppearance.App.Metadata"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_detail_info"
@@ -241,7 +241,7 @@
           <!-- TV/Movie -->
           <TextView
             android:id="@+id/tv_mediaType"
-            style="@style/TextMetadata"
+            style="@style/TextAppearance.App.Metadata"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/margin_detail_info"
@@ -264,7 +264,7 @@
           <!-- Duration -->
           <TextView
             android:id="@+id/tv_duration"
-            style="@style/TextMetadata"
+            style="@style/TextAppearance.App.Metadata"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_detail_info"
@@ -329,7 +329,7 @@
 
           <TextView
             android:id="@+id/tv_summary_header"
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
@@ -339,17 +339,17 @@
 
           <Button
             android:id="@+id/btn_sidebar"
-            style="@style/MyIconButtonStyle"
+            style="@style/Widget.App.Button.IconButton"
             android:layout_marginEnd="@dimen/default_margin_parent_20"
             android:contentDescription="@string/more_information"
-            android:theme="@style/MyIconButtonStyle"
+            android:theme="@style/Widget.App.Button.IconButton"
             app:icon="@drawable/ic_sidebar" />
 
         </LinearLayout>
 
         <io.github.glailton.expandabletextview.ExpandableTextView
           android:id="@+id/tv_overview"
-          style="@style/TextBody"
+          style="@style/TextAppearance.App.Body"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
@@ -387,7 +387,7 @@
 
           <TextView
             android:id="@+id/tv_cast_header"
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -429,7 +429,7 @@
 
           <TextView
             android:id="@+id/tv_recommendation_header"
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -465,14 +465,14 @@
   <!-- Background overlay on start -->
   <View
     android:id="@+id/background_dim_movie"
-    style="@style/MyDimStyle"
+    style="@style/Widget.App.DimOverlay"
     android:layout_gravity="center"
     android:visibility="visible"
     tools:visibility="gone" />
 
   <com.google.android.material.loadingindicator.LoadingIndicator
     android:id="@+id/progress_bar"
-    style="@style/MyProgressBar"
+    style="@style/Widget.App.ProgressBar"
     tools:visibility="visible" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/feature/detail/src/main/res/layout/bottom_sheet_credits.xml
+++ b/feature/detail/src/main/res/layout/bottom_sheet_credits.xml
@@ -25,7 +25,7 @@
     app:tabMode="fixed"
     app:tabSelectedTextColor="@color/yellow"
     app:tabTextColor="@color/gray_400"
-    app:tabTextAppearance="@style/TextTabLayoutStyle"/>
+    app:tabTextAppearance="@style/Widget.App.TabLayout"/>
 
   <androidx.recyclerview.widget.RecyclerView
     android:id="@+id/rv_credits"
@@ -48,7 +48,7 @@
 
   <com.google.android.material.loadingindicator.LoadingIndicator
     android:id="@+id/loading_indicator"
-    style="@style/MyProgressBar"
+    style="@style/Widget.App.ProgressBar"
     android:visibility="gone" />
 
 </LinearLayout>

--- a/feature/detail/src/main/res/layout/chip_genre.xml
+++ b/feature/detail/src/main/res/layout/chip_genre.xml
@@ -10,7 +10,7 @@
     android:id="@+id/chip"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:textAppearance="@style/ChipTextAppearance"
+    android:textAppearance="@style/TextAppearance.App.Chip"
     android:textColor="@color/gray_600"
     app:chipBackgroundColor="@color/gray_900"
     app:chipStrokeColor="@color/gray_800"

--- a/feature/detail/src/main/res/layout/dialog_rating.xml
+++ b/feature/detail/src/main/res/layout/dialog_rating.xml
@@ -25,7 +25,7 @@
     app:layout_constraintTop_toTopOf="parent" />
 
   <TextView
-    style="@style/TextHeader1"
+    style="@style/TextAppearance.App.Header1"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:text="@string/your_rating"
@@ -46,7 +46,7 @@
 
   <com.google.android.material.button.MaterialButton
     android:id="@+id/btn_cancel"
-    style="@style/customButton"
+    style="@style/Widget.App.Button.Compact"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginTop="29dp"
@@ -59,7 +59,7 @@
 
   <com.google.android.material.button.MaterialButton
     android:id="@+id/btn_submit"
-    style="@style/customButton"
+    style="@style/Widget.App.Button.Compact"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:backgroundTint="@color/green"

--- a/feature/detail/src/main/res/layout/item_credits_person.xml
+++ b/feature/detail/src/main/res/layout/item_credits_person.xml
@@ -19,12 +19,12 @@
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
-    app:shapeAppearanceOverlay="@style/circleImage"
+    app:shapeAppearanceOverlay="@style/ShapeAppearance.App.Circle"
     tools:src="@tools:sample/avatars" />
 
   <TextView
     android:id="@+id/tv_name"
-    style="@style/TextBody"
+    style="@style/TextAppearance.App.Body"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:layout_marginStart="12dp"
@@ -41,7 +41,7 @@
     tools:text="Sam Worthington" />
 
   <TextView
-    style="@style/TextDivider"
+    style="@style/TextAppearance.App.Divider"
     android:id="@+id/tv_role"
     android:layout_width="0dp"
     android:layout_height="wrap_content"

--- a/feature/detail/src/main/res/layout/item_watch_provider.xml
+++ b/feature/detail/src/main/res/layout/item_watch_provider.xml
@@ -15,7 +15,7 @@
     android:backgroundTint="@android:color/transparent"
     android:clickable="true"
     android:focusable="true"
-    app:shapeAppearanceOverlay="@style/roundedCornersPoster"
+    app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
     tools:src="@color/yellow" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/feature/detail/src/main/res/layout/score_section.xml
+++ b/feature/detail/src/main/res/layout/score_section.xml
@@ -19,11 +19,11 @@
 
       <TextView
         android:id="@+id/tv_score_imdb"
-        style="@style/TextScore"
+        style="@style/TextAppearance.App.Score"
         tools:text="8.5" />
 
       <TextView
-        style="@style/TextScoreHeader"
+        style="@style/TextAppearance.App.Score.Header"
         android:text="@string/imdb" />
     </LinearLayout>
 
@@ -34,11 +34,11 @@
 
       <TextView
         android:id="@+id/tv_score_metascore"
-        style="@style/TextScore"
+        style="@style/TextAppearance.App.Score"
         tools:text="8.5" />
 
       <TextView
-        style="@style/TextScoreHeader"
+        style="@style/TextAppearance.App.Score.Header"
         android:text="@string/metascore" />
     </LinearLayout>
 
@@ -49,11 +49,11 @@
 
       <TextView
         android:id="@+id/tv_score_rotten_tomatoes"
-        style="@style/TextScore"
+        style="@style/TextAppearance.App.Score"
         tools:text="85%" />
 
       <TextView
-        style="@style/TextScoreHeader"
+        style="@style/TextAppearance.App.Score.Header"
         android:text="@string/r_tomatoes" />
     </LinearLayout>
 
@@ -64,11 +64,11 @@
 
       <TextView
         android:id="@+id/tv_score_tmdb"
-        style="@style/TextScore"
+        style="@style/TextAppearance.App.Score"
         tools:text="8.5" />
 
       <TextView
-        style="@style/TextScoreHeader"
+        style="@style/TextAppearance.App.Score.Header"
         android:text="@string/tmdb" />
     </LinearLayout>
 
@@ -79,11 +79,11 @@
 
       <TextView
         android:id="@+id/tv_score_your_score"
-        style="@style/TextScore"
+        style="@style/TextAppearance.App.Score"
         tools:text="8.5" />
 
       <TextView
-        style="@style/TextScoreHeader"
+        style="@style/TextAppearance.App.Score.Header"
         android:text="@string/your_score" />
     </LinearLayout>
 

--- a/feature/detail/src/main/res/layout/side_sheet_content.xml
+++ b/feature/detail/src/main/res/layout/side_sheet_content.xml
@@ -26,7 +26,7 @@
 
       <TextView
         android:id="@+id/tv_title"
-        style="@style/TextHeader1"
+        style="@style/TextAppearance.App.Header1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:ellipsize="end"
@@ -35,7 +35,7 @@
         tools:text="Zootopia 2" />
 
       <TextView
-        style="@style/TextHeader2"
+        style="@style/TextAppearance.App.Header2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
@@ -43,14 +43,14 @@
 
       <TextView
         android:id="@+id/tv_status"
-        style="@style/TextMetadata"
+        style="@style/TextAppearance.App.Metadata"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="6dp"
         tools:text="Released" />
 
       <TextView
-        style="@style/TextHeader2"
+        style="@style/TextAppearance.App.Header2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
@@ -58,7 +58,7 @@
 
       <TextView
         android:id="@+id/tv_language"
-        style="@style/TextMetadata"
+        style="@style/TextAppearance.App.Metadata"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="6dp"
@@ -66,7 +66,7 @@
 
       <TextView
         android:id="@+id/tv_budget_header"
-        style="@style/TextHeader2"
+        style="@style/TextAppearance.App.Header2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
@@ -74,7 +74,7 @@
 
       <TextView
         android:id="@+id/tv_budget"
-        style="@style/TextMetadata"
+        style="@style/TextAppearance.App.Metadata"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="6dp"
@@ -82,7 +82,7 @@
 
       <TextView
         android:id="@+id/tv_revenue_header"
-        style="@style/TextHeader2"
+        style="@style/TextAppearance.App.Header2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
@@ -90,14 +90,14 @@
 
       <TextView
         android:id="@+id/tv_revenue"
-        style="@style/TextMetadata"
+        style="@style/TextAppearance.App.Metadata"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="6dp"
         tools:text="$1,744,338,246.00" />
 
       <TextView
-        style="@style/TextHeader2"
+        style="@style/TextAppearance.App.Header2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"

--- a/feature/detail/src/main/res/layout/watch_providers_section.xml
+++ b/feature/detail/src/main/res/layout/watch_providers_section.xml
@@ -126,14 +126,14 @@
       android:orientation="horizontal">
 
       <TextView
-        style="@style/TextBody"
+        style="@style/TextAppearance.App.Body"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/data_powered_by" />
 
       <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_justwatch"
-        style="@style/MyTransparentButton"
+        style="@style/Widget.App.Button.Transparent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="-5dp"
@@ -145,7 +145,7 @@
 
     <TextView
       android:id="@+id/tv_watch_providers_message"
-      style="@style/TextBody"
+      style="@style/TextAppearance.App.Body"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginHorizontal="@dimen/default_margin_parent_20"

--- a/feature/favorite/src/main/res/layout/fragment_favorite.xml
+++ b/feature/favorite/src/main/res/layout/fragment_favorite.xml
@@ -44,6 +44,8 @@
 
     </com.google.android.material.tabs.TabLayout>
 
+    <include layout="@layout/divider"/>
+
   </com.google.android.material.appbar.AppBarLayout>
 
   <androidx.viewpager2.widget.ViewPager2

--- a/feature/favorite/src/main/res/layout/fragment_favorite.xml
+++ b/feature/favorite/src/main/res/layout/fragment_favorite.xml
@@ -25,7 +25,7 @@
       app:tabIndicatorColor="@color/yellow"
       app:tabRippleColor="@color/gray_300"
       app:tabSelectedTextColor="@color/yellow"
-      app:tabTextAppearance="@style/TextTabLayoutStyle"
+      app:tabTextAppearance="@style/Widget.App.TabLayout"
       app:tabTextColor="@color/white">
 
       <!-- Movies tab -->

--- a/feature/favorite/src/main/res/layout/fragment_favorite_child.xml
+++ b/feature/favorite/src/main/res/layout/fragment_favorite_child.xml
@@ -47,7 +47,7 @@
 
   <com.google.android.material.loadingindicator.LoadingIndicator
     android:id="@+id/progress_bar"
-    style="@style/MyProgressBar"
+    style="@style/Widget.App.ProgressBar"
     android:layout_marginBottom="@dimen/margin_to_centered"
     tools:visibility="visible" />
 

--- a/feature/home/src/main/res/layout/fragment_asian.xml
+++ b/feature/home/src/main/res/layout/fragment_asian.xml
@@ -39,7 +39,7 @@
             style="@style/LayoutHeaderTheme">
 
             <TextView
-              style="@style/TextHeader2"
+              style="@style/TextAppearance.App.Header2"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_gravity="center_vertical"
@@ -57,19 +57,19 @@
 
           <com.google.android.material.button.MaterialButtonToggleGroup
             android:id="@+id/button_group"
-            style="@style/FilterButtonGroupStyle"
+            style="@style/Widget.App.ButtonGroup.Filter"
             android:layout_marginHorizontal="@dimen/default_margin_parent_20"
             android:layout_marginBottom="8dp">
 
             <com.google.android.material.button.MaterialButton
               android:id="@+id/btn_anime_this_season"
-              style="@style/FilterToggleOverlay"
+              style="@style/Widget.App.Button.FilterToggle"
               android:checked="true"
               android:text="@string/this_season" />
 
             <com.google.android.material.button.MaterialButton
               android:id="@+id/btn_anime_all_time"
-              style="@style/FilterToggleOverlay"
+              style="@style/Widget.App.Button.FilterToggle"
               android:text="@string/all_time" />
 
           </com.google.android.material.button.MaterialButtonToggleGroup>
@@ -88,7 +88,7 @@
           android:layout_marginTop="12dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -117,7 +117,7 @@
           android:layout_marginTop="12dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -147,7 +147,7 @@
           android:layout_marginTop="12dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -176,7 +176,7 @@
           android:layout_marginTop="12dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"

--- a/feature/home/src/main/res/layout/fragment_featured.xml
+++ b/feature/home/src/main/res/layout/fragment_featured.xml
@@ -49,7 +49,7 @@
             style="@style/LayoutHeaderTheme">
 
             <TextView
-              style="@style/TextHeader2"
+              style="@style/TextAppearance.App.Header2"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_gravity="center_vertical"
@@ -67,18 +67,18 @@
 
           <com.google.android.material.button.MaterialButtonToggleGroup
             android:id="@+id/button_group"
-            style="@style/FilterButtonGroupStyle"
+            style="@style/Widget.App.ButtonGroup.Filter"
             android:layout_marginBottom="8dp"
             android:layout_marginHorizontal="@dimen/default_margin_parent_20">
 
             <com.google.android.material.button.MaterialButton
               android:id="@+id/btn_trending_today"
-              style="@style/FilterToggleOverlay"
+              style="@style/Widget.App.Button.FilterToggle"
               android:text="@string/today" />
 
             <com.google.android.material.button.MaterialButton
               android:id="@+id/btn_trending_this_week"
-              style="@style/FilterToggleOverlay"
+              style="@style/Widget.App.Button.FilterToggle"
               android:checked="true"
               android:text="@string/this_week" />
 
@@ -105,7 +105,7 @@
           style="@style/LayoutHeaderTheme">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -142,7 +142,7 @@
           android:layout_marginTop="12dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"

--- a/feature/home/src/main/res/layout/fragment_home.xml
+++ b/feature/home/src/main/res/layout/fragment_home.xml
@@ -28,7 +28,7 @@
       app:tabMode="auto"
       app:tabRippleColor="?attr/colorSurface"
       app:tabSelectedTextColor="?attr/colorAccent"
-      app:tabTextAppearance="@style/TextTabLayoutStyle"
+      app:tabTextAppearance="@style/Widget.App.TabLayout"
       app:tabTextColor="@color/white">
 
       <!-- Featured tab -->

--- a/feature/home/src/main/res/layout/fragment_home.xml
+++ b/feature/home/src/main/res/layout/fragment_home.xml
@@ -54,10 +54,7 @@
 
     </com.google.android.material.tabs.TabLayout>
 
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="1dp"
-      android:background="@color/gray_700" />
+    <include layout="@layout/divider"/>
 
   </com.google.android.material.appbar.AppBarLayout>
 

--- a/feature/home/src/main/res/layout/fragment_movie.xml
+++ b/feature/home/src/main/res/layout/fragment_movie.xml
@@ -34,7 +34,7 @@
           android:layout_marginTop="@dimen/default_margin_parent_20">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -64,7 +64,7 @@
           android:layout_marginTop="16dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -101,7 +101,7 @@
           android:layout_marginTop="12dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -137,7 +137,7 @@
           android:layout_marginTop="12dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"

--- a/feature/home/src/main/res/layout/fragment_tv_series.xml
+++ b/feature/home/src/main/res/layout/fragment_tv_series.xml
@@ -34,7 +34,7 @@
           android:layout_marginTop="@dimen/default_margin_parent_20">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -70,7 +70,7 @@
           android:layout_marginTop="12dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -106,7 +106,7 @@
           android:layout_marginTop="12dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"
@@ -143,7 +143,7 @@
           android:layout_marginTop="12dp">
 
           <TextView
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="start|center_vertical"

--- a/feature/home/src/main/res/layout/item_wide.xml
+++ b/feature/home/src/main/res/layout/item_wide.xml
@@ -28,7 +28,7 @@
         android:adjustViewBounds="true"
         android:contentDescription="@string/picture"
         android:foreground="@drawable/bg_gradient_shape"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
         tools:src="@color/red_matte" />
 
       <com.google.android.material.card.MaterialCardView
@@ -44,7 +44,7 @@
 
         <TextView
           android:id="@+id/tv_year"
-          style="@style/TextBody"
+          style="@style/TextAppearance.App.Body"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:padding="6dp"
@@ -56,7 +56,7 @@
 
     <TextView
       android:id="@+id/tv_title"
-      style="@style/TextHeader3"
+      style="@style/TextAppearance.App.Header3"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginHorizontal="8dp"
@@ -79,7 +79,7 @@
 
     <TextView
       android:id="@+id/tv_genre"
-      style="@style/TextBody"
+      style="@style/TextAppearance.App.Body"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginHorizontal="8dp"

--- a/feature/home/src/main/res/layout/no_found_layout.xml
+++ b/feature/home/src/main/res/layout/no_found_layout.xml
@@ -22,7 +22,7 @@
 
       <TextView
         android:id="@+id/tv_message"
-        style="@style/TextBody"
+        style="@style/TextAppearance.App.Body"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"

--- a/feature/home/src/main/res/layout/shimmer_asian.xml
+++ b/feature/home/src/main/res/layout/shimmer_asian.xml
@@ -16,7 +16,7 @@
       style="@style/LayoutHeaderTheme">
 
       <TextView
-        style="@style/TextHeader2"
+        style="@style/TextAppearance.App.Header2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
@@ -25,18 +25,18 @@
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <com.google.android.material.button.MaterialButtonToggleGroup
-      style="@style/FilterButtonGroupStyle"
+      style="@style/Widget.App.ButtonGroup.Filter"
       android:layout_marginHorizontal="@dimen/default_margin_parent_20"
       android:layout_marginTop="10dp"
       android:layout_marginBottom="8dp">
 
       <com.google.android.material.button.MaterialButton
-        style="@style/FilterToggleOverlay"
+        style="@style/Widget.App.Button.FilterToggle"
         android:checked="true"
         android:text="@string/this_season" />
 
       <com.google.android.material.button.MaterialButton
-        style="@style/FilterToggleOverlay"
+        style="@style/Widget.App.Button.FilterToggle"
         android:text="@string/all_time" />
 
     </com.google.android.material.button.MaterialButtonToggleGroup>
@@ -50,7 +50,7 @@
     android:layout_marginTop="22dp" />
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"
@@ -64,7 +64,7 @@
     android:layout_marginTop="20dp" />
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"
@@ -84,7 +84,7 @@
     android:layout_marginTop="12dp" />
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"

--- a/feature/home/src/main/res/layout/shimmer_featured.xml
+++ b/feature/home/src/main/res/layout/shimmer_featured.xml
@@ -47,7 +47,7 @@
       <androidx.coordinatorlayout.widget.CoordinatorLayout style="@style/LayoutHeaderTheme">
 
         <TextView
-          style="@style/TextHeader2"
+          style="@style/TextAppearance.App.Header2"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_gravity="center_vertical"
@@ -63,16 +63,16 @@
       </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
       <com.google.android.material.button.MaterialButtonToggleGroup
-        style="@style/FilterButtonGroupStyle"
+        style="@style/Widget.App.ButtonGroup.Filter"
         android:layout_marginHorizontal="@dimen/default_margin_parent_20"
         android:layout_marginBottom="8dp">
 
         <com.google.android.material.button.MaterialButton
-          style="@style/FilterToggleOverlay"
+          style="@style/Widget.App.Button.FilterToggle"
           android:text="@string/today" />
 
         <com.google.android.material.button.MaterialButton
-          style="@style/FilterToggleOverlay"
+          style="@style/Widget.App.Button.FilterToggle"
           android:checked="true"
           android:text="@string/this_week" />
 
@@ -86,7 +86,7 @@
       android:layout_marginTop="12dp" />
 
     <TextView
-      style="@style/TextHeader2"
+      style="@style/TextAppearance.App.Header2"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginLeft="@dimen/default_margin_parent_20"
@@ -100,7 +100,7 @@
       android:layout_marginTop="20dp" />
 
     <TextView
-      style="@style/TextHeader2"
+      style="@style/TextAppearance.App.Header2"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginLeft="@dimen/default_margin_parent_20"

--- a/feature/home/src/main/res/layout/shimmer_item_horizontal.xml
+++ b/feature/home/src/main/res/layout/shimmer_item_horizontal.xml
@@ -20,49 +20,49 @@
         android:layout_width="100dp"
         android:layout_height="150dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
       <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="100dp"
         android:layout_height="150dp"
         android:layout_marginLeft="12dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
       <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="100dp"
         android:layout_height="150dp"
         android:layout_marginLeft="12dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
       <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="100dp"
         android:layout_height="150dp"
         android:layout_marginLeft="12dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
       <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="100dp"
         android:layout_height="150dp"
         android:layout_marginLeft="12dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
       <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="100dp"
         android:layout_height="150dp"
         android:layout_marginLeft="12dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
       <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="100dp"
         android:layout_height="150dp"
         android:layout_marginLeft="12dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
     </LinearLayout>
   </com.facebook.shimmer.ShimmerFrameLayout>

--- a/feature/home/src/main/res/layout/shimmer_item_poster.xml
+++ b/feature/home/src/main/res/layout/shimmer_item_poster.xml
@@ -18,6 +18,6 @@
       android:adjustViewBounds="true"
       android:background="@color/gray_700"
       android:contentDescription="@string/picture"
-      app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+      app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
   </com.facebook.shimmer.ShimmerFrameLayout>
 </FrameLayout>

--- a/feature/home/src/main/res/layout/shimmer_item_wide.xml
+++ b/feature/home/src/main/res/layout/shimmer_item_wide.xml
@@ -25,7 +25,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded"
         tools:ignore="UnusedAttribute" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
@@ -46,7 +46,7 @@
         android:layout_marginStart="8dp"
         android:layout_marginTop="10dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
       <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="280dp"
@@ -54,7 +54,7 @@
         android:layout_marginStart="8dp"
         android:layout_marginTop="10dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
     </LinearLayout>
   </com.facebook.shimmer.ShimmerFrameLayout>

--- a/feature/home/src/main/res/layout/shimmer_movie.xml
+++ b/feature/home/src/main/res/layout/shimmer_movie.xml
@@ -7,7 +7,7 @@
   android:orientation="vertical">
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"
@@ -22,7 +22,7 @@
     android:layout_marginTop="22dp" />
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"
@@ -42,7 +42,7 @@
     android:layout_marginTop="12dp" />
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"
@@ -56,7 +56,7 @@
     android:layout_marginTop="20dp" />
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"

--- a/feature/home/src/main/res/layout/shimmer_tv_series.xml
+++ b/feature/home/src/main/res/layout/shimmer_tv_series.xml
@@ -7,7 +7,7 @@
   android:orientation="vertical">
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"
@@ -22,7 +22,7 @@
     android:layout_marginTop="22dp" />
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"
@@ -36,7 +36,7 @@
     android:layout_marginTop="20dp" />
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"
@@ -56,7 +56,7 @@
     android:layout_marginTop="12dp" />
 
   <TextView
-    style="@style/TextHeader2"
+    style="@style/TextAppearance.App.Header2"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginLeft="@dimen/default_margin_parent_20"

--- a/feature/list/src/main/res/layout/activity_list.xml
+++ b/feature/list/src/main/res/layout/activity_list.xml
@@ -10,28 +10,28 @@
 
   <com.google.android.material.appbar.AppBarLayout
     android:id="@+id/appBarLayout"
-    style="@style/AppBarLayoutStyle">
+    style="@style/Widget.App.AppBarLayout">
 
     <com.google.android.material.appbar.CollapsingToolbarLayout
       android:id="@+id/collapse"
-      style="@style/CollapsingToolbarLayoutStyle"
+      style="@style/Widget.App.CollapsingToolbarLayout"
       android:layout_width="match_parent"
       android:layout_height="190dp"
       app:collapsedSubtitleTextColor="@color/gray_300"
-      app:collapsedSubtitleTextAppearance="@style/CollapsedSubtitleStyle"
-      app:expandedSubtitleTextAppearance="@style/ExpandedSubtitleStyle"
+      app:collapsedSubtitleTextAppearance="@style/TextAppearance.App.CollapsingToolbar.Subtitle.Collapsed"
+      app:expandedSubtitleTextAppearance="@style/TextAppearance.App.CollapsingToolbar.Subtitle.Expanded"
       app:expandedSubtitleTextColor="@color/gray_300">
 
       <ImageView
         android:id="@+id/iv_picture"
-        style="@style/CollapseImageViewStyle"
+        style="@style/Widget.App.CollapsingToolbarLayout.ImageView"
         android:contentDescription="@string/poster"
         tools:layout_height="350dp"
         tools:src="@tools:sample/backgrounds/scenic" />
 
       <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
-        style="@style/MaterialToolbarStyle"
+        style="@style/Widget.App.Toolbar"
         android:paddingBottom="8dp"
         app:layout_collapseMode="pin"
         tools:subtitle="Medium Subtitle"
@@ -39,13 +39,13 @@
 
         <Button
           android:id="@+id/btn_back"
-          style="@style/BackButton"
+          style="@style/Widget.App.Button.Circle.Back"
           android:layout_gravity="start|bottom"
           android:translationY="2dp" />
 
         <com.google.android.material.button.MaterialButton
           android:id="@+id/btn_toggle_layout"
-          style="@style/CircleButton"
+          style="@style/Widget.App.Button.Circle"
           android:layout_gravity="end|bottom"
           android:layout_marginEnd="16dp"
           android:contentDescription="@string/toggle_list_layout"
@@ -88,7 +88,7 @@
 
   <com.google.android.material.loadingindicator.LoadingIndicator
     android:id="@+id/loading_indicator"
-    style="@style/MyProgressBar"
+    style="@style/Widget.App.ProgressBar"
     tools:visibility="visible" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/feature/login/src/main/res/layout-land/activity_login.xml
+++ b/feature/login/src/main/res/layout-land/activity_login.xml
@@ -61,7 +61,7 @@
   <!-- Forget password button -->
   <com.google.android.material.button.MaterialButton
     android:id="@+id/btn_forget_password"
-    style="@style/MyTransparentButton"
+    style="@style/Widget.App.Button.Transparent"
     android:layout_marginEnd="@dimen/default_margin_parent_20"
     android:text="@string/forget_password"
     app:layout_constraintBottom_toBottomOf="@+id/layout_bazz_movies"
@@ -141,7 +141,7 @@
   <!-- Login button -->
   <Button
     android:id="@+id/btn_login"
-    style="@style/MyLoginButtonLand"
+    style="@style/Widget.App.Button.Login.Land"
     android:contentDescription="@string/login"
     android:text="@string/login"
     app:layout_constraintBottom_toTopOf="@+id/tv_guest"
@@ -152,7 +152,7 @@
   <!-- Guest button -->
   <com.google.android.material.button.MaterialButton
     android:id="@+id/tv_guest"
-    style="@style/MyTransparentButton"
+    style="@style/Widget.App.Button.Transparent"
     android:text="@string/guest_session"
     app:layout_constraintBottom_toTopOf="@+id/tv_joinTMDB"
     app:layout_constraintEnd_toEndOf="@+id/btn_login"
@@ -162,7 +162,7 @@
   <!-- Create account button -->
   <com.google.android.material.button.MaterialButton
     android:id="@+id/tv_joinTMDB"
-    style="@style/MyTransparentButton"
+    style="@style/Widget.App.Button.Transparent"
     android:layout_marginBottom="8dp"
     android:gravity="center"
     android:text="@string/join_tmdb"
@@ -177,7 +177,7 @@
 
   <com.google.android.material.loadingindicator.LoadingIndicator
     android:id="@+id/progress_bar"
-    style="@style/MyProgressBar"
+    style="@style/Widget.App.ProgressBar"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/feature/login/src/main/res/layout/activity_login.xml
+++ b/feature/login/src/main/res/layout/activity_login.xml
@@ -110,7 +110,7 @@
 
   <com.google.android.material.button.MaterialButton
     android:id="@+id/btn_forget_password"
-    style="@style/MyTransparentButton"
+    style="@style/Widget.App.Button.Transparent"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="12dp"
@@ -122,7 +122,7 @@
   <!-- Login button -->
   <Button
     android:id="@+id/btn_login"
-    style="@style/MyLoginButtonPortrait"
+    style="@style/Widget.App.Button.Login.Portrait"
     android:layout_marginHorizontal="@dimen/default_margin_parent_20"
     android:contentDescription="@string/login"
     android:text="@string/login"
@@ -135,7 +135,7 @@
   <!-- Guest button -->
   <com.google.android.material.button.MaterialButton
     android:id="@+id/tv_guest"
-    style="@style/MyTransparentButton"
+    style="@style/Widget.App.Button.Transparent"
     android:layout_marginBottom="15dp"
     android:text="@string/guest_session"
     app:layout_constraintBottom_toTopOf="@+id/tv_joinTMDB"
@@ -146,7 +146,7 @@
   <!-- Create account button -->
   <com.google.android.material.button.MaterialButton
     android:id="@+id/tv_joinTMDB"
-    style="@style/MyTransparentButton"
+    style="@style/Widget.App.Button.Transparent"
     android:layout_marginBottom="?attr/actionBarSize"
     android:gravity="center"
     android:text="@string/join_tmdb"
@@ -161,7 +161,7 @@
 
   <com.google.android.material.loadingindicator.LoadingIndicator
     android:id="@+id/progress_bar"
-    style="@style/MyProgressBar"
+    style="@style/Widget.App.ProgressBar"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/feature/more/src/main/kotlin/com/waffiq/bazz_movies/feature/more/ui/MoreDialogManager.kt
+++ b/feature/more/src/main/kotlin/com/waffiq/bazz_movies/feature/more/ui/MoreDialogManager.kt
@@ -9,7 +9,7 @@ import com.waffiq.bazz_movies.core.designsystem.R.string.warning_restore_will_ov
 import com.waffiq.bazz_movies.core.designsystem.R.string.warning_signOut_guest_mode
 import com.waffiq.bazz_movies.core.designsystem.R.string.warning_signOut_logged_user
 import com.waffiq.bazz_movies.core.designsystem.R.string.yes
-import com.waffiq.bazz_movies.core.designsystem.R.style.CustomAlertDialogTheme
+import com.waffiq.bazz_movies.core.designsystem.R.style.ThemeOverlay_App_AlertDialog
 
 class MoreDialogManager(
   private val context: Context,
@@ -18,7 +18,7 @@ class MoreDialogManager(
   private val onRestoreConfirmed: (Uri) -> Unit,
 ) {
   fun showSignOutLoggedIn(sessionId: String) {
-    MaterialAlertDialogBuilder(context, CustomAlertDialogTheme)
+    MaterialAlertDialogBuilder(context, ThemeOverlay_App_AlertDialog)
       .setTitle(context.getString(warning))
       .setMessage(context.getString(warning_signOut_logged_user))
       .setNegativeButton(context.getString(no)) { dialog, _ -> dialog.dismiss() }
@@ -30,7 +30,7 @@ class MoreDialogManager(
   }
 
   fun showSignOutGuestMode() {
-    MaterialAlertDialogBuilder(context, CustomAlertDialogTheme)
+    MaterialAlertDialogBuilder(context, ThemeOverlay_App_AlertDialog)
       .setTitle(context.getString(warning))
       .setMessage(context.getString(warning_signOut_guest_mode))
       .setNegativeButton(context.getString(no)) { dialog, _ -> dialog.dismiss() }
@@ -42,7 +42,7 @@ class MoreDialogManager(
   }
 
   fun showConfirmRestore(uri: Uri) {
-    MaterialAlertDialogBuilder(context, CustomAlertDialogTheme)
+    MaterialAlertDialogBuilder(context, ThemeOverlay_App_AlertDialog)
       .setTitle(context.getString(warning))
       .setMessage(context.getString(warning_restore_will_overwrite))
       .setNegativeButton(context.getString(no)) { dialog, _ -> dialog.dismiss() }

--- a/feature/more/src/main/res/layout/fragment_more.xml
+++ b/feature/more/src/main/res/layout/fragment_more.xml
@@ -30,7 +30,7 @@
           android:layout_height="48dp"
           android:layout_gravity="center_vertical"
           android:contentDescription="@string/image_profile"
-          app:shapeAppearanceOverlay="@style/circleImage"
+          app:shapeAppearanceOverlay="@style/ShapeAppearance.App.Circle"
           tools:src="@drawable/ic_bazz_logo" />
 
         <LinearLayout
@@ -43,7 +43,7 @@
 
           <TextView
             android:id="@+id/tv_fullName"
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             tools:text="Name" />
@@ -94,7 +94,7 @@
               app:srcCompat="@drawable/ic_region" />
 
             <TextView
-              style="@style/TextBody"
+              style="@style/TextAppearance.App.Body"
               android:layout_width="0dp"
               android:layout_height="wrap_content"
               android:layout_marginStart="12dp"
@@ -145,7 +145,7 @@
               app:srcCompat="@drawable/ic_faq" />
 
             <TextView
-              style="@style/TextBody"
+              style="@style/TextAppearance.App.Body"
               android:layout_width="0dp"
               android:layout_height="wrap_content"
               android:layout_marginStart="12dp"
@@ -179,7 +179,7 @@
               app:srcCompat="@drawable/ic_lamp" />
 
             <TextView
-              style="@style/TextBody"
+              style="@style/TextAppearance.App.Body"
               android:layout_width="0dp"
               android:layout_height="wrap_content"
               android:layout_marginStart="12dp"
@@ -212,7 +212,7 @@
               app:srcCompat="@drawable/ic_about" />
 
             <TextView
-              style="@style/TextBody"
+              style="@style/TextAppearance.App.Body"
               android:layout_width="0dp"
               android:layout_height="wrap_content"
               android:layout_marginStart="12dp"
@@ -252,7 +252,7 @@
               tools:ignore="UseCompoundDrawables">
 
               <TextView
-                style="@style/TextBody"
+                style="@style/TextAppearance.App.Body"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
@@ -281,7 +281,7 @@
               tools:ignore="UseCompoundDrawables">
 
               <TextView
-                style="@style/TextBody"
+                style="@style/TextAppearance.App.Body"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
@@ -316,7 +316,7 @@
             tools:ignore="UseCompoundDrawables">
 
             <TextView
-              style="@style/TextBody"
+              style="@style/TextAppearance.App.Body"
               android:layout_width="0dp"
               android:layout_height="wrap_content"
               android:layout_weight="1"
@@ -345,7 +345,7 @@
             tools:ignore="UseCompoundDrawables">
 
             <TextView
-              style="@style/TextBody"
+              style="@style/TextAppearance.App.Body"
               android:layout_width="0dp"
               android:layout_height="wrap_content"
               android:layout_weight="1"
@@ -384,7 +384,7 @@
 
   <com.google.android.material.loadingindicator.LoadingIndicator
     android:id="@+id/progress_bar"
-    style="@style/MyProgressBar"
+    style="@style/Widget.App.ProgressBar"
     android:visibility="gone"
     tools:visibility="visible" />
 

--- a/feature/person/src/main/res/layout/activity_person.xml
+++ b/feature/person/src/main/res/layout/activity_person.xml
@@ -13,11 +13,11 @@
   <!-- ========================== -->
   <com.google.android.material.appbar.AppBarLayout
     android:id="@+id/app_bar_layout"
-    style="@style/AppBarLayoutStyle">
+    style="@style/Widget.App.AppBarLayout">
 
     <com.google.android.material.appbar.CollapsingToolbarLayout
       android:id="@+id/collapse"
-      style="@style/CollapsingToolbarLayoutStyle"
+      style="@style/Widget.App.CollapsingToolbarLayout"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       app:maxLines="2"
@@ -25,7 +25,7 @@
 
       <ImageView
         android:id="@+id/iv_picture"
-        style="@style/CollapseImageViewStyle"
+        style="@style/Widget.App.CollapsingToolbarLayout.ImageView"
         android:adjustViewBounds="true"
         android:contentDescription="@string/picture"
         tools:layout_height="450dp"
@@ -33,13 +33,13 @@
 
       <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
-        style="@style/MaterialToolbarStyle"
+        style="@style/Widget.App.Toolbar"
         android:paddingBottom="18dp"
         app:layout_collapseMode="pin">
 
         <Button
           android:id="@+id/btn_back"
-          style="@style/BackButton"
+          style="@style/Widget.App.Button.Circle.Back"
           android:layout_gravity="start|bottom"
           android:translationY="12dp" />
 
@@ -88,37 +88,37 @@
 
           <Button
             android:id="@+id/btn_instagram"
-            style="@style/MyIconButtonStyle"
+            style="@style/Widget.App.Button.IconButton"
             android:contentDescription="@string/open_actor_actress_instagram_page"
-            android:theme="@style/MyIconButtonStyle"
+            android:theme="@style/Widget.App.Button.IconButton"
             app:icon="@drawable/ic_instagram" />
 
           <Button
             android:id="@+id/btn_x"
-            style="@style/MyIconButtonStyle"
+            style="@style/Widget.App.Button.IconButton"
             android:contentDescription="@string/open_actor_x_account"
-            android:theme="@style/MyIconButtonStyle"
+            android:theme="@style/Widget.App.Button.IconButton"
             app:icon="@drawable/ic_x" />
 
           <Button
             android:id="@+id/btn_facebook"
-            style="@style/MyIconButtonStyle"
+            style="@style/Widget.App.Button.IconButton"
             android:contentDescription="@string/open_actor_actress_facebook_page"
-            android:theme="@style/MyIconButtonStyle"
+            android:theme="@style/Widget.App.Button.IconButton"
             app:icon="@drawable/ic_facebook" />
 
           <Button
             android:id="@+id/btn_tiktok"
-            style="@style/MyIconButtonStyle"
+            style="@style/Widget.App.Button.IconButton"
             android:contentDescription="@string/open_actor_actress_tiktok_page"
-            android:theme="@style/MyIconButtonStyle"
+            android:theme="@style/Widget.App.Button.IconButton"
             app:icon="@drawable/ic_tiktok" />
 
           <Button
             android:id="@+id/btn_youtube"
-            style="@style/MyIconButtonStyle"
+            style="@style/Widget.App.Button.IconButton"
             android:contentDescription="@string/open_actor_actress_youtube_channel"
-            android:theme="@style/MyIconButtonStyle"
+            android:theme="@style/Widget.App.Button.IconButton"
             app:icon="@drawable/ic_youtube" />
 
         </LinearLayout>
@@ -135,7 +135,7 @@
         <!-- List playing on -->
         <TextView
           android:id="@+id/tv_known_for"
-          style="@style/TextHeader2"
+          style="@style/TextAppearance.App.Header2"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginStart="@dimen/default_margin_parent_20"
@@ -162,7 +162,7 @@
 
           <TextView
             android:id="@+id/tv_biography_header"
-            style="@style/TextHeader2"
+            style="@style/TextAppearance.App.Header2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/biography"
@@ -183,18 +183,18 @@
 
             <Button
               android:id="@+id/btn_imdb"
-              style="@style/MyIconButtonStyle"
+              style="@style/Widget.App.Button.IconButton"
               android:contentDescription="@string/open_actor_actress_imdb_page"
-              android:theme="@style/MyIconButtonStyle"
+              android:theme="@style/Widget.App.Button.IconButton"
               android:visibility="gone"
               app:icon="@drawable/ic_imdb"
               tools:visibility="visible" />
 
             <Button
               android:id="@+id/btn_wikidata"
-              style="@style/MyIconButtonStyle"
+              style="@style/Widget.App.Button.IconButton"
               android:contentDescription="@string/open_actor_actress_wikidata_page"
-              android:theme="@style/MyIconButtonStyle"
+              android:theme="@style/Widget.App.Button.IconButton"
               android:visibility="gone"
               app:icon="@drawable/ic_wikidata"
               tools:visibility="visible" />
@@ -208,9 +208,9 @@
 
             <Button
               android:id="@+id/btn_link"
-              style="@style/MyIconButtonStyle"
+              style="@style/Widget.App.Button.IconButton"
               android:contentDescription="@string/open_actor_actress_home_page"
-              android:theme="@style/MyIconButtonStyle"
+              android:theme="@style/Widget.App.Button.IconButton"
               android:visibility="gone"
               app:icon="@drawable/ic_link"
               tools:visibility="visible" />
@@ -222,7 +222,7 @@
         <!-- Biography -->
         <io.github.glailton.expandabletextview.ExpandableTextView
           android:id="@+id/tv_biography"
-          style="@style/TextBody"
+          style="@style/TextAppearance.App.Body"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
@@ -244,7 +244,7 @@
         <!-- Born -->
         <TextView
           android:id="@+id/tv_born_header"
-          style="@style/TextHeader2"
+          style="@style/TextAppearance.App.Header2"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
@@ -253,7 +253,7 @@
 
         <TextView
           android:id="@+id/tv_born"
-          style="@style/TextBody"
+          style="@style/TextAppearance.App.Body"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
@@ -266,7 +266,7 @@
         <!-- Date of death-->
         <TextView
           android:id="@+id/tv_dead_header"
-          style="@style/TextHeader2"
+          style="@style/TextAppearance.App.Header2"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
@@ -275,7 +275,7 @@
 
         <TextView
           android:id="@+id/tv_death"
-          style="@style/TextBody"
+          style="@style/TextAppearance.App.Body"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
@@ -288,7 +288,7 @@
         <!-- List of photos -->
         <TextView
           android:id="@+id/tv_photos_header"
-          style="@style/TextHeader2"
+          style="@style/TextAppearance.App.Header2"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginHorizontal="@dimen/default_margin_parent_20"
@@ -318,13 +318,13 @@
   <!-- Background on start -->
   <View
     android:id="@+id/background_dim_person"
-    style="@style/MyDimStyle"
+    style="@style/Widget.App.DimOverlay"
     android:visibility="visible"
     tools:visibility="gone" />
 
   <com.google.android.material.loadingindicator.LoadingIndicator
     android:id="@+id/progress_bar"
-    style="@style/MyProgressBar"
+    style="@style/Widget.App.ProgressBar"
     android:layout_marginTop="200dp"
     tools:visibility="visible" />
 

--- a/feature/search/src/main/res/layout/illustration_search.xml
+++ b/feature/search/src/main/res/layout/illustration_search.xml
@@ -16,7 +16,7 @@
 
   <TextView
     android:id="@+id/tv_search_any_movies"
-    style="@style/TextHeader1"
+    style="@style/TextAppearance.App.Header1"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/default_margin_parent_20"
@@ -25,7 +25,7 @@
 
   <TextView
     android:id="@+id/tv_explore_tmdb"
-    style="@style/TextDivider"
+    style="@style/TextAppearance.App.Divider"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center"

--- a/feature/search/src/main/res/layout/illustration_search_no_result.xml
+++ b/feature/search/src/main/res/layout/illustration_search_no_result.xml
@@ -16,7 +16,7 @@
 
   <TextView
     android:id="@+id/tv_header_noResult"
-    style="@style/TextHeader1"
+    style="@style/TextAppearance.App.Header1"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginTop="-40dp"
@@ -24,7 +24,7 @@
 
   <TextView
     android:id="@+id/tv_no_data"
-    style="@style/TextDivider"
+    style="@style/TextAppearance.App.Divider"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center"

--- a/feature/search/src/main/res/layout/shimmer_item_result.xml
+++ b/feature/search/src/main/res/layout/shimmer_item_result.xml
@@ -16,7 +16,7 @@
       android:adjustViewBounds="true"
       android:contentDescription="@string/picture"
       android:src="@color/gray_700"
-      app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+      app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
     <LinearLayout
       android:layout_width="wrap_content"
@@ -29,28 +29,28 @@
         android:layout_width="220dp"
         android:layout_height="20dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
       <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="100dp"
         android:layout_height="18dp"
         android:layout_marginTop="9dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
       <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="150dp"
         android:layout_height="18dp"
         android:layout_marginTop="9dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
       <com.google.android.material.imageview.ShapeableImageView
         android:layout_width="130dp"
         android:layout_height="18dp"
         android:layout_marginTop="9dp"
         android:src="@color/gray_700"
-        app:shapeAppearanceOverlay="@style/roundedCornersImageView" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.App.ImageView.Rounded" />
 
     </LinearLayout>
   </LinearLayout>

--- a/feature/watchlist/src/main/res/layout/fragment_watchlist.xml
+++ b/feature/watchlist/src/main/res/layout/fragment_watchlist.xml
@@ -44,6 +44,8 @@
 
     </com.google.android.material.tabs.TabLayout>
 
+    <include layout="@layout/divider"/>
+
   </com.google.android.material.appbar.AppBarLayout>
 
   <androidx.viewpager2.widget.ViewPager2

--- a/feature/watchlist/src/main/res/layout/fragment_watchlist.xml
+++ b/feature/watchlist/src/main/res/layout/fragment_watchlist.xml
@@ -25,7 +25,7 @@
       app:tabIndicatorColor="@color/yellow"
       app:tabRippleColor="@color/gray_300"
       app:tabSelectedTextColor="@color/yellow"
-      app:tabTextAppearance="@style/TextTabLayoutStyle"
+      app:tabTextAppearance="@style/Widget.App.TabLayout"
       app:tabTextColor="@color/white">
 
       <!-- Movies tab -->

--- a/feature/watchlist/src/main/res/layout/fragment_watchlist_child.xml
+++ b/feature/watchlist/src/main/res/layout/fragment_watchlist_child.xml
@@ -47,7 +47,7 @@
 
   <com.google.android.material.loadingindicator.LoadingIndicator
     android:id="@+id/progress_bar"
-    style="@style/MyProgressBar"
+    style="@style/Widget.App.ProgressBar"
     android:layout_marginBottom="@dimen/margin_to_centered"
     tools:visibility="visible" />
 


### PR DESCRIPTION
### Changes Made

- Rename styles name inside `themes.xml` to follow Android theme conventions
- Use shared Material divider `divider.xml` for tab layout across the project

References:

- https://developer.android.com/develop/ui/views/theming/themes
- https://medium.com/androiddevelopers/android-styling-themes-vs-styles-ebe05f917578