### PR TITLE
chore(ci): update qltysh coverage action to v2.2.1

### DIFF
--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -748,10 +748,10 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: ${{ github.workspace }}/**/build/reports/jacoco/createDebugCombinedCoverageReport/createDebugCombinedCoverageReport.xml
 
-      # https://github.com/qltysh/qlty-action/commit/a19242102d17e497f437d7466aa01b528537e899
-      # v2.2.0
+      # https://github.com/qltysh/qlty-action/commit/fd52dc852530a708d68c3b7342f8d33d1df4cd55
+      # v2.2.1
       - name: Upload coverage reports to Qlty
-        uses: qltysh/qlty-action/coverage@a19242102d17e497f437d7466aa01b528537e899
+        uses: qltysh/qlty-action/coverage@fd52dc852530a708d68c3b7342f8d33d1df4cd55
         with:
           token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: ${{ github.workspace }}/**/build/reports/jacoco/createDebugCombinedCoverageReport/createDebugCombinedCoverageReport.xml


### PR DESCRIPTION
### Changes Made

- Bump the qltysh/qlty-action coverage step in .github/workflows/android_test.yml from commit a192421 (v2.2.0) to fd52dc8 ([v2.2.1](https://github.com/qltysh/qlty-action/releases/tag/v2.2.1)).
- Updates the pinned action SHA and accompanying comment to use the latest patch release.