### PR TITLE
chore(ci): enable detekt use Gradle worker api

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -30,3 +30,7 @@ warningsAsErrors=false
 # https://docs.gradle.org/current/userguide/isolated_projects.html
 org.gradle.unsafe.isolated-projects=true
 ksp.project.isolation.enabled=true
+
+# Let Detekt use Gradle's Worker API
+# https://detekt.dev/docs/gettingstarted/gradle/#options-for-detekt-gradle-properties
+detekt.use.worker.api=true


### PR DESCRIPTION
### Changes Made

 - Let Detekt use Gradle's Worker API
   https://detekt.dev/docs/gettingstarted/gradle/#options-for-detekt-gradle-properties