### PR TITLE
refactor(network): fetch external id via appended detail person

### DIFF
--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/person/PersonRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/person/PersonRemoteDataSource.kt
@@ -2,7 +2,6 @@ package com.waffiq.bazz_movies.core.network.data.remote.datasource.person
 
 import com.waffiq.bazz_movies.core.coroutines.IoDispatcher
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.DetailPersonResponse
-import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ExternalIDPersonResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ImagePersonResponse
 import com.waffiq.bazz_movies.core.network.data.remote.retrofit.services.PersonApiService
 import com.waffiq.bazz_movies.core.network.utils.helpers.SafeApiCallHelper.executeApiCall
@@ -27,12 +26,6 @@ class PersonRemoteDataSource @Inject constructor(
   override fun getPersonImages(id: Int): Flow<NetworkResult<ImagePersonResponse>> =
     executeApiCall(
       apiCall = { personApiService.getPersonImages(id) },
-      ioDispatcher = ioDispatcher,
-    )
-
-  override fun getPersonExternalIds(id: Int): Flow<NetworkResult<ExternalIDPersonResponse>> =
-    executeApiCall(
-      apiCall = { personApiService.getPersonExternalIds(id) },
       ioDispatcher = ioDispatcher,
     )
 }

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/person/PersonRemoteDataSourceInterface.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/person/PersonRemoteDataSourceInterface.kt
@@ -1,7 +1,6 @@
 package com.waffiq.bazz_movies.core.network.data.remote.datasource.person
 
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.DetailPersonResponse
-import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ExternalIDPersonResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ImagePersonResponse
 import com.waffiq.bazz_movies.core.network.utils.result.NetworkResult
 import kotlinx.coroutines.flow.Flow
@@ -9,5 +8,4 @@ import kotlinx.coroutines.flow.Flow
 interface PersonRemoteDataSourceInterface {
   fun getPersonDetails(id: Int): Flow<NetworkResult<DetailPersonResponse>>
   fun getPersonImages(id: Int): Flow<NetworkResult<ImagePersonResponse>>
-  fun getPersonExternalIds(id: Int): Flow<NetworkResult<ExternalIDPersonResponse>>
 }

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/DetailPersonResponse.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/DetailPersonResponse.kt
@@ -50,4 +50,7 @@ data class DetailPersonResponse(
 
   @Json(name = "combined_credits")
   val combinedCredits: CombinedCreditResponse? = null,
+
+  @Json(name = "external_ids")
+  val externalIds: ExternalIDPersonResponse? = null,
 )

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/PersonApiService.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/PersonApiService.kt
@@ -9,7 +9,7 @@ import retrofit2.http.Query
 
 interface PersonApiService {
 
-  @GET("3/person/{personId}?append_to_response=combined_credits")
+  @GET("3/person/{personId}?append_to_response=combined_credits,external_ids")
   suspend fun getPersonDetails(
     @Path("personId") personId: Int,
     @Query("language") language: String = "en-US",

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/PersonApiService.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/PersonApiService.kt
@@ -1,7 +1,6 @@
 package com.waffiq.bazz_movies.core.network.data.remote.retrofit.services
 
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.DetailPersonResponse
-import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ExternalIDPersonResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ImagePersonResponse
 import retrofit2.Response
 import retrofit2.http.GET
@@ -21,9 +20,4 @@ interface PersonApiService {
     @Path("personId") personId: Int,
     @Query("language") language: String = "en-US",
   ): Response<ImagePersonResponse>
-
-  @GET("3/person/{personId}/external_ids")
-  suspend fun getPersonExternalIds(
-    @Path("personId") personId: Int,
-  ): Response<ExternalIDPersonResponse>
 }

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/account/AccountRemoteDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/account/AccountRemoteDataSourceTest.kt
@@ -11,8 +11,8 @@ import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testPagingFlow
 import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testPagingSource
 import io.mockk.coEvery
 import io.mockk.coVerify
-import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class AccountRemoteDataSourceTest : BaseMediaDataSourceTest() {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/movie/MovieRemoteDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/movie/MovieRemoteDataSourceTest.kt
@@ -12,8 +12,8 @@ import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testPagingFlow
 import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testPagingSource
 import io.mockk.coEvery
 import io.mockk.coVerify
-import junit.framework.TestCase
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class MovieRemoteDataSourceTest : BaseMediaDataSourceTest() {
@@ -28,7 +28,7 @@ class MovieRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockMovieApiService.getTopRatedMovies(1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(2, page.data.size)
+        assertEquals(2, page.data.size)
       }
     }
 
@@ -54,7 +54,7 @@ class MovieRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockMovieApiService.getPopularMovies(1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(1, page.data.size)
+        assertEquals(1, page.data.size)
       }
     }
 
@@ -81,7 +81,7 @@ class MovieRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockMovieApiService.getMovieRecommendations(12345678, 1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(1, page.data.size)
+        assertEquals(1, page.data.size)
       }
     }
 
@@ -108,7 +108,7 @@ class MovieRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockMovieApiService.getUpcomingMovies("cn", 1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(1, page.data.size)
+        assertEquals(1, page.data.size)
       }
     }
 
@@ -135,7 +135,7 @@ class MovieRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockMovieApiService.getNowPlayingMovies("gb", 1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(1, page.data.size)
+        assertEquals(1, page.data.size)
       }
     }
 

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/person/PersonRemoteDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/person/PersonRemoteDataSourceTest.kt
@@ -2,7 +2,6 @@ package com.waffiq.bazz_movies.core.network.data.remote.datasource.person
 
 import com.waffiq.bazz_movies.core.network.testutils.BaseMediaDataSourceTest
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.detailPersonResponse
-import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.externalIDPersonResponseDump
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.imagePersonResponseDump
 import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testError404Response
 import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testErrorResponse
@@ -173,82 +172,4 @@ class PersonRemoteDataSourceTest : BaseMediaDataSourceTest() {
       )
     }
   // endregion getPersonImages EDGE CASE
-
-  @Test
-  fun getPersonExternalIds_whenSuccessful_returnsExpectedResponse() =
-    runTest {
-      testSuccessResponse(
-        apiEndpoint = { mockPersonApiService.getPersonExternalIds(114253) },
-        mockApiResponse = success(externalIDPersonResponseDump),
-        dataSourceEndpointCall = { personRemoteDataSource.getPersonExternalIds(114253) },
-        expectedData = externalIDPersonResponseDump,
-      )
-    }
-
-  @Test
-  fun getPersonExternalIds_whenServerError_returnsExpectedStatusMessageResponse() =
-    runTest {
-      testErrorResponse(
-        apiEndpoint = { mockPersonApiService.getPersonExternalIds(114253) },
-        errorResponse = backendErrorResponse,
-        dataSourceEndpointCall = { personRemoteDataSource.getPersonExternalIds(114253) },
-        expectedErrorMessage = backendErrorMessage,
-      )
-    }
-
-  // region getPersonExternalIds EDGE CASE
-  @Test
-  fun getPersonExternalIds_whenAPIRespondsWith404_returnsExpectedResponse() =
-    runTest {
-      testError404Response(
-        apiEndpoint = { mockPersonApiService.getPersonExternalIds(114253) },
-        dataSourceEndpointCall = { personRemoteDataSource.getPersonExternalIds(114253) },
-      )
-    }
-
-  @Test
-  fun getPersonExternalIds_whenNetworkErrorOccurs_returnsExpectedResponse() =
-    runTest {
-      testUnknownHostExceptionResponse(
-        apiEndpoint = { mockPersonApiService.getPersonExternalIds(114253) },
-        dataSourceEndpointCall = { personRemoteDataSource.getPersonExternalIds(114253) },
-      )
-    }
-
-  @Test
-  fun getPersonExternalIds_whenTimeoutOccurs_returnsErrorResponse() =
-    runTest {
-      testSocketTimeoutExceptionResponse(
-        apiEndpoint = { mockPersonApiService.getPersonExternalIds(114253) },
-        dataSourceEndpointCall = { personRemoteDataSource.getPersonExternalIds(114253) },
-      )
-    }
-
-  @Test
-  fun getPersonExternalIds_whenHttpExceptionOccurs_returnsErrorResponse() =
-    runTest {
-      testHttpExceptionResponse(
-        apiEndpoint = { mockPersonApiService.getPersonExternalIds(114253) },
-        dataSourceEndpointCall = { personRemoteDataSource.getPersonExternalIds(114253) },
-      )
-    }
-
-  @Test
-  fun getPersonExternalIds_whenIOExceptionOccurs_returnsErrorResponse() =
-    runTest {
-      testIOExceptionResponse(
-        apiEndpoint = { mockPersonApiService.getPersonExternalIds(114253) },
-        dataSourceEndpointCall = { personRemoteDataSource.getPersonExternalIds(114253) },
-      )
-    }
-
-  @Test
-  fun getPersonExternalIds_whenExceptionOccurs_returnsErrorResponse() =
-    runTest {
-      testGeneralExceptionResponse(
-        apiEndpoint = { mockPersonApiService.getPersonExternalIds(114253) },
-        dataSourceEndpointCall = { personRemoteDataSource.getPersonExternalIds(114253) },
-      )
-    }
-  // endregion getPersonExternalIds EDGE CASE
 }

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/search/SearchRemoteDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/search/SearchRemoteDataSourceTest.kt
@@ -8,8 +8,8 @@ import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testPagingFlowSe
 import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testPagingSearchSource
 import io.mockk.coEvery
 import io.mockk.coVerify
-import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SearchRemoteDataSourceTest : BaseMediaDataSourceTest() {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/trending/TrendingRemoteDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/trending/TrendingRemoteDataSourceTest.kt
@@ -12,8 +12,8 @@ import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testPagingFlow
 import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testPagingSource
 import io.mockk.coEvery
 import io.mockk.coVerify
-import junit.framework.TestCase
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class TrendingRemoteDataSourceTest : BaseMediaDataSourceTest() {
@@ -29,7 +29,7 @@ class TrendingRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockTrendingApiService.getTrendingThisWeek("id", 1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(3, page.data.size)
+        assertEquals(3, page.data.size)
       }
     }
 
@@ -55,13 +55,13 @@ class TrendingRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockTrendingApiService.getTrendingToday("ca", 1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(2, page.data.size)
-        TestCase.assertEquals("Squid Game", page.data[0].name)
-        TestCase.assertEquals("Wicked", page.data[1].title)
-        TestCase.assertEquals(tvShowDump1, page.data[0])
-        TestCase.assertEquals(movieDump7, page.data[1])
-        TestCase.assertEquals(null, page.prevKey)
-        TestCase.assertEquals(2, page.nextKey)
+        assertEquals(2, page.data.size)
+        assertEquals("Squid Game", page.data[0].name)
+        assertEquals("Wicked", page.data[1].title)
+        assertEquals(tvShowDump1, page.data[0])
+        assertEquals(movieDump7, page.data[1])
+        assertEquals(null, page.prevKey)
+        assertEquals(2, page.nextKey)
       }
     }
 

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/tv/TvPagingRemoteDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/tv/TvPagingRemoteDataSourceTest.kt
@@ -10,8 +10,8 @@ import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testPagingFlow
 import com.waffiq.bazz_movies.core.network.testutils.TestHelper.testPagingSource
 import io.mockk.coEvery
 import io.mockk.coVerify
-import junit.framework.TestCase
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class TvPagingRemoteDataSourceTest : BaseMediaDataSourceTest() {
@@ -29,8 +29,8 @@ class TvPagingRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockTvApiService.getPopularTv("id", airDate, 1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(null, page.prevKey)
-        TestCase.assertEquals(2, page.nextKey)
+        assertEquals(null, page.prevKey)
+        assertEquals(2, page.nextKey)
       }
     }
 
@@ -61,8 +61,8 @@ class TvPagingRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockTvApiService.getAiringTv("id", airDate, airDateEnd, 1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(null, page.prevKey)
-        TestCase.assertEquals(2, page.nextKey)
+        assertEquals(null, page.prevKey)
+        assertEquals(2, page.nextKey)
       }
     }
 
@@ -91,8 +91,8 @@ class TvPagingRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockTvApiService.getTvRecommendations(98765, 1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(null, page.prevKey)
-        TestCase.assertEquals(2, page.nextKey)
+        assertEquals(null, page.prevKey)
+        assertEquals(2, page.nextKey)
       }
     }
 
@@ -120,8 +120,8 @@ class TvPagingRemoteDataSourceTest : BaseMediaDataSourceTest() {
         mockApiCall = { mockTvApiService.getTopRatedTv(1) },
         loader = { pagingSource.toLoadResult() },
       ) { page ->
-        TestCase.assertEquals(null, page.prevKey)
-        TestCase.assertEquals(2, page.nextKey)
+        assertEquals(null, page.prevKey)
+        assertEquals(2, page.nextKey)
       }
     }
 

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/pagingsources/GenericPagingSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/pagingsources/GenericPagingSourceTest.kt
@@ -15,9 +15,9 @@ import com.waffiq.bazz_movies.core.network.utils.common.Constants.INITIAL_PAGE_I
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.fail
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNull
+import org.junit.Assert.fail
 import org.junit.Test
 import retrofit2.HttpException
 import java.io.IOException

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/pagingsources/SearchPagingSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/pagingsources/SearchPagingSourceTest.kt
@@ -18,8 +18,8 @@ import com.waffiq.bazz_movies.core.network.utils.common.Constants.INITIAL_PAGE_I
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import junit.framework.TestCase.fail
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.fail
 import org.junit.Test
 import retrofit2.HttpException
 import java.io.IOException

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/countryip/CountryIPResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/countryip/CountryIPResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.countryip
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.countryIPResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class CountryIPResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/omdb/OMDbDetailsResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/omdb/OMDbDetailsResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.omdb
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.omdbDetailsResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class OMDbDetailsResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/MediaResponseItemTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/MediaResponseItemTest.kt
@@ -2,7 +2,7 @@ package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.movieDump1
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.tvShowDump1
-import junit.framework.TestCase.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/MediaResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/MediaResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.movieDump1
-import junit.framework.TestCase.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class MediaResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/AccountDetailsResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/AccountDetailsResponseTest.kt
@@ -1,9 +1,9 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.account
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.accountDetailsResponse
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AccountDetailsResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/AuthenticationResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/AuthenticationResponseTest.kt
@@ -1,10 +1,10 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.account
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.authenticationResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AuthenticationResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/AvatarItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/AvatarItemResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.account
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class AvatarItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/AvatarTMDbResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/AvatarTMDbResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.account
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class AvatarTMDbResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/CreateSessionResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/CreateSessionResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.account
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.createSessionResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CreateSessionResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/GravatarResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/account/GravatarResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.account
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class GravatarResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/GenresItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/GenresItemResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class GenresItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/ProductionCountriesItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/ProductionCountriesItemResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ProductionCountriesItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/castcrew/MediaCastItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/castcrew/MediaCastItemResponseTest.kt
@@ -1,9 +1,9 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.castcrew
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.mediaCastItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MediaCastItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/castcrew/MediaCreditsResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/castcrew/MediaCreditsResponseTest.kt
@@ -2,7 +2,7 @@ package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.cas
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.mediaCastItemResponseDump
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.mediaCrewItemResponseDump
-import junit.framework.TestCase.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class MediaCreditsResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/castcrew/MediaCrewItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/castcrew/MediaCrewItemResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.castcrew
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.mediaCrewItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class MediaCrewItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/movie/BelongsToCollectionResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/movie/BelongsToCollectionResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.movie
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.belongsToCollectionDeadpoolDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class BelongsToCollectionResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/movie/DetailMovieResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/movie/DetailMovieResponseTest.kt
@@ -2,9 +2,9 @@ package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.mov
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.detailMovieResponseDump
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.watchProvidersResultsMap
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DetailMovieResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/releasedates/ReleaseDatesItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/releasedates/ReleaseDatesItemResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.releasedates
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ReleaseDatesItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/releasedates/ReleaseDatesItemValueResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/releasedates/ReleaseDatesItemValueResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.releasedates
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ReleaseDatesItemValueResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/releasedates/ReleaseDatesResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/releasedates/ReleaseDatesResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.releasedates
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ReleaseDatesResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/ContentRatingsItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/ContentRatingsItemResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.contentRatingsItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ContentRatingsItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/ContentRatingsResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/ContentRatingsResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.contentRatingsResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ContentRatingsResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/CreatedByItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/CreatedByItemResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.createdByItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class CreatedByItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/DetailTvResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/DetailTvResponseTest.kt
@@ -5,9 +5,9 @@ import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.Prod
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.detailTvResponseDump
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.nextEpisodeToAirResponse
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.watchProvidersResultsMap
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DetailTvResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/ExternalIdResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/ExternalIdResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.externalIdResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ExternalIdResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/LastEpisodeToAirResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/LastEpisodeToAirResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.lastEpisodeToAirResponse1
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class LastEpisodeToAirResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/NetworksItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/NetworksItemResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.networksItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class NetworksItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/ProductionCompaniesItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/ProductionCompaniesItemResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.productionCompaniesItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ProductionCompaniesItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/SeasonsItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/SeasonsItemResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.seasonsItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class SeasonsItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/SpokenLanguagesItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/tv/SpokenLanguagesItemResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.tv
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.spokenLanguagesItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class SpokenLanguagesItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/videomedia/VideoItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/videomedia/VideoItemResponseTest.kt
@@ -1,10 +1,10 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.videomedia
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.videoItemMovieResponseDump1
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VideoItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/videomedia/VideoResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/media/videomedia/VideoResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.media.videomedia
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNotNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 
 class VideoResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/CastItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/CastItemResponseTest.kt
@@ -1,9 +1,9 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.castItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CastItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/CombinedCreditResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/CombinedCreditResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.combinedCreditResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class CombinedCreditResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/CrewItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/CrewItemResponseTest.kt
@@ -1,9 +1,9 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.crewItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CrewItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/DetailPersonResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/DetailPersonResponseTest.kt
@@ -1,11 +1,11 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.detailPersonResponse
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DetailPersonResponseTest {
@@ -50,6 +50,7 @@ class DetailPersonResponseTest {
     assertNull(detailPersonResponse.adult)
     assertNull(detailPersonResponse.homepage)
     assertNull(detailPersonResponse.combinedCredits)
+    assertNull(detailPersonResponse.externalIds)
   }
 
   @Test

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/ExternalIDPersonResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/ExternalIDPersonResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.externalIDPersonResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ExternalIDPersonResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/ImagePersonResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/ImagePersonResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.imagePersonResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ImagePersonResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/ProfilesItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/person/ProfilesItemResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.profileItemResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ProfilesItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/post/PostFavoriteWatchlistResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/post/PostFavoriteWatchlistResponseTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.post
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class PostFavoriteWatchlistResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/post/PostResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/post/PostResponseTest.kt
@@ -1,9 +1,9 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.post
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.postResponseDump
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PostResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/search/KnownForItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/search/KnownForItemResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.search
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.knownForItemResponseDump2
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class KnownForItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/search/MultiSearchItemResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/search/MultiSearchItemResponseTest.kt
@@ -2,9 +2,9 @@ package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.search
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.movieSearchDump
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.personDump1
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MultiSearchItemResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/search/MultiSearchResponseTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/responses/tmdb/search/MultiSearchResponseTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.search
 
 import com.waffiq.bazz_movies.core.network.testutils.DataDumpManager.personDump1
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class MultiSearchResponseTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/adapter/RatedResponseAdapterTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/adapter/RatedResponseAdapterTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.retrofit.adapter
 
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.state.RatedResponse
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class RatedResponseAdapterTest {
@@ -24,7 +24,7 @@ class RatedResponseAdapterTest {
   fun fromJson_withCorrectMap_returnsValueResponse() {
     val result = adapter.fromJson(mapOf("value" to 4.5))
     assertTrue(result is RatedResponse.Value)
-    assertEquals(4.5, (result as RatedResponse.Value).value)
+    assertEquals(4.5, (result as RatedResponse.Value).value, 0.0001)
   }
 
   @Test

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/adapter/RatedResponseAdapterToJsonTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/adapter/RatedResponseAdapterToJsonTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.core.network.data.remote.retrofit.adapter
 
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.state.RatedResponse
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class RatedResponseAdapterToJsonTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/interceptors/ApiKeyInterceptorTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/interceptors/ApiKeyInterceptorTest.kt
@@ -1,7 +1,5 @@
 package com.waffiq.bazz_movies.core.network.data.remote.retrofit.interceptors
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertTrue
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -9,6 +7,8 @@ import okhttp3.Response
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/di/NetworkConfigModuleTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/di/NetworkConfigModuleTest.kt
@@ -4,9 +4,9 @@ import com.waffiq.bazz_movies.core.network.domain.DebugConfigImpl
 import com.waffiq.bazz_movies.core.network.domain.IDebugConfig
 import io.mockk.every
 import io.mockk.mockk
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/di/NetworkModuleTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/di/NetworkModuleTest.kt
@@ -7,10 +7,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNotNull
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import retrofit2.Retrofit

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/domain/DebugConfigImplTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/domain/DebugConfigImplTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.core.network.domain
 
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DebugConfigImplTest {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/testutils/DataDumpManager.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/testutils/DataDumpManager.kt
@@ -1115,6 +1115,20 @@ object DataDumpManager {
     crew = listOf(crewItemResponseDump, crewItemResponse2, crewItemResponse3),
   )
 
+  val externalIDPersonResponseDump = ExternalIDPersonResponse(
+    id = 114253,
+    freebaseMid = "/m/027xw9j",
+    freebaseId = null,
+    imdbId = "nm1375030",
+    tvrageId = null,
+    wikidataId = "Q7518724",
+    facebookId = null,
+    instagramId = null,
+    tiktokId = null,
+    twitterId = "simonfarnaby",
+    youtubeId = null,
+  )
+
   val detailPersonResponse = DetailPersonResponse(
     alsoKnownAs = listOf(
       "ฮีธ เลดเจอร์",
@@ -1152,6 +1166,7 @@ object DataDumpManager {
     adult = false,
     homepage = null,
     combinedCredits = combinedCreditResponseDump,
+    externalIds = externalIDPersonResponseDump,
   )
 
   val profileItemResponseDump = ProfilesItemResponse(
@@ -1223,20 +1238,6 @@ object DataDumpManager {
         height = 872,
       ),
     ),
-  )
-
-  val externalIDPersonResponseDump = ExternalIDPersonResponse(
-    id = 114253,
-    freebaseMid = "/m/027xw9j",
-    freebaseId = null,
-    imdbId = "nm1375030",
-    tvrageId = null,
-    wikidataId = "Q7518724",
-    facebookId = null,
-    instagramId = null,
-    tiktokId = null,
-    twitterId = "simonfarnaby",
-    youtubeId = null,
   )
 
   val postResponseSuccessDump = PostFavoriteWatchlistResponse(

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/testutils/PagingSourceTestHelper.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/testutils/PagingSourceTestHelper.kt
@@ -5,10 +5,10 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.network.utils.common.Constants.INITIAL_PAGE_INDEX
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
-import junit.framework.TestCase.fail
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.fail
 import retrofit2.HttpException
 
 object PagingSourceTestHelper {

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/testutils/TestHelper.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/testutils/TestHelper.kt
@@ -14,14 +14,14 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import retrofit2.HttpException
 import retrofit2.Response
 import java.io.IOException

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/utils/helpers/SafeApiCallHelperTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/utils/helpers/SafeApiCallHelperTest.kt
@@ -5,12 +5,12 @@ import com.waffiq.bazz_movies.core.network.utils.helpers.SafeApiCallHelper.safeA
 import com.waffiq.bazz_movies.core.network.utils.result.NetworkResult
 import io.mockk.every
 import io.mockk.mockk
-import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import retrofit2.HttpException

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/utils/mappers/NetworkMapperTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/utils/mappers/NetworkMapperTest.kt
@@ -8,9 +8,9 @@ import com.waffiq.bazz_movies.core.network.utils.mappers.NetworkMapper.toFavorit
 import com.waffiq.bazz_movies.core.network.utils.mappers.NetworkMapper.toUpdateFavoriteParams
 import com.waffiq.bazz_movies.core.network.utils.mappers.NetworkMapper.toUpdateWatchlistParams
 import com.waffiq.bazz_movies.core.network.utils.mappers.NetworkMapper.toWatchlistRequest
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NetworkMapperTest {

--- a/feature/person/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/person/testutils/BasePersonActivityTest.kt
+++ b/feature/person/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/person/testutils/BasePersonActivityTest.kt
@@ -11,10 +11,8 @@ import com.waffiq.bazz_movies.core.common.utils.Event
 import com.waffiq.bazz_movies.core.models.MediaCastItem
 import com.waffiq.bazz_movies.feature.person.domain.model.CastItem
 import com.waffiq.bazz_movies.feature.person.domain.model.DetailPerson
-import com.waffiq.bazz_movies.feature.person.domain.model.ExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ProfilesItem
 import com.waffiq.bazz_movies.feature.person.testutils.DummyData.testDetailPerson
-import com.waffiq.bazz_movies.feature.person.testutils.DummyData.testExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.testutils.DummyData.testImagesList
 import com.waffiq.bazz_movies.feature.person.testutils.DummyData.testKnownForList
 import com.waffiq.bazz_movies.feature.person.testutils.DummyData.testMediaCastItem
@@ -32,7 +30,6 @@ abstract class BasePersonActivityTest {
   protected val detailPersonLiveData = MutableLiveData<DetailPerson>()
   protected val imagePersonLiveData = MutableLiveData<List<ProfilesItem>>()
   protected val creditPersonLiveData = MutableLiveData<List<CastItem>>()
-  protected val externalIdPersonLiveData = MutableLiveData<ExternalIDPerson>()
   protected val errorStateLiveData = MutableLiveData<Event<String>>()
   protected val loadingStateLiveData = MutableLiveData<Boolean>()
   protected lateinit var context: Context
@@ -52,20 +49,17 @@ abstract class BasePersonActivityTest {
     creditPersonLiveData.postValue(testKnownForList)
     detailPersonLiveData.postValue(testDetailPerson)
     imagePersonLiveData.postValue(testImagesList)
-    externalIdPersonLiveData.postValue(testExternalIDPerson)
   }
 
   protected fun setupViewModelMocks(mockPersonViewModel: PersonViewModel) {
     every { mockPersonViewModel.detailPerson } returns detailPersonLiveData
     every { mockPersonViewModel.castList } returns creditPersonLiveData
     every { mockPersonViewModel.imagePerson } returns imagePersonLiveData
-    every { mockPersonViewModel.externalIdPerson } returns externalIdPersonLiveData
     every { mockPersonViewModel.errorState } returns errorStateLiveData
     every { mockPersonViewModel.loadingState } returns loadingStateLiveData
 
     every { mockPersonViewModel.getDetailPerson(any()) } just Runs
     every { mockPersonViewModel.getImagePerson(any()) } just Runs
-    every { mockPersonViewModel.getExternalIDPerson(any()) } just Runs
   }
 
   protected fun setupNavigatorMocks(mockNavigator: INavigator) {

--- a/feature/person/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/person/testutils/DummyData.kt
+++ b/feature/person/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/person/testutils/DummyData.kt
@@ -17,32 +17,6 @@ object DummyData {
       profilePath = "/test_profile.jpg",
     )
 
-  val testDetailPerson =
-    DetailPerson(
-      id = 123,
-      name = "Test Actor",
-      biography = "Test biography for the actor",
-      birthday = "1990-01-01",
-      placeOfBirth = "Test City",
-      homepage = "https://example.com",
-    )
-
-  val testCastItem =
-    CastItem(
-      id = 456,
-      title = "Test Movie",
-      character = "Test Character",
-      posterPath = "/test_poster.jpg",
-      releaseDate = "2023-01-01",
-    )
-
-  val testProfileItem =
-    ProfilesItem(
-      filePath = "/test_image.jpg",
-      width = 500,
-      height = 750,
-    )
-
   val testExternalIDPerson =
     ExternalIDPerson(
       id = 123,
@@ -53,6 +27,24 @@ object DummyData {
       tiktokId = null,
       youtubeId = null,
       wikidataId = "Q123456",
+    )
+
+  val testDetailPerson =
+    DetailPerson(
+      id = 123,
+      name = "Test Actor",
+      biography = "Test biography for the actor",
+      birthday = "1990-01-01",
+      placeOfBirth = "Test City",
+      homepage = "https://example.com",
+      externalIds = testExternalIDPerson,
+    )
+
+  val testProfileItem =
+    ProfilesItem(
+      filePath = "/test_image.jpg",
+      width = 500,
+      height = 750,
     )
 
   val testKnownForList =

--- a/feature/person/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivityTest.kt
+++ b/feature/person/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivityTest.kt
@@ -370,6 +370,18 @@ class PersonActivityTest : BasePersonActivityTest() {
     }
 
   @Test
+  fun socialMediaLinks_whenExternalIdIsNull_shouldHidden() =
+    runTest {
+      context.launchPersonActivity {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+          detailPersonLiveData.postValue(testDetailPerson.copy(externalIds = null))
+        }
+
+        view_group_social_media.isGone()
+      }
+    }
+
+  @Test
   fun socialMediaLinks_withNullId_shouldHidden() =
     runTest {
       context.launchPersonActivity {

--- a/feature/person/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivityTest.kt
+++ b/feature/person/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivityTest.kt
@@ -115,7 +115,6 @@ class PersonActivityTest : BasePersonActivityTest() {
           loadingStateLiveData.postValue(true)
           detailPersonLiveData.postValue(testDetailPerson)
           imagePersonLiveData.postValue(listOf(testProfileItem))
-          externalIdPersonLiveData.postValue(testExternalIDPerson)
           loadingStateLiveData.postValue(false)
         }
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
@@ -133,7 +132,6 @@ class PersonActivityTest : BasePersonActivityTest() {
 
         verify { mockPersonViewModel.getDetailPerson(any<Int>()) }
         verify { mockPersonViewModel.getImagePerson(any<Int>()) }
-        verify { mockPersonViewModel.getExternalIDPerson(any<Int>()) }
       }
     }
 
@@ -220,7 +218,6 @@ class PersonActivityTest : BasePersonActivityTest() {
       context.launchPersonActivity(testMediaCastItem.copy(id = null)) {
         verify(exactly = 0) { mockPersonViewModel.getImagePerson(any()) }
         verify(exactly = 0) { mockPersonViewModel.getDetailPerson(any()) }
-        verify(exactly = 0) { mockPersonViewModel.getExternalIDPerson(any()) }
       }
     }
 
@@ -341,15 +338,9 @@ class PersonActivityTest : BasePersonActivityTest() {
   @Test
   fun socialMediaLinks_withValidIds_shouldVisible() =
     runTest {
-      val testExternalIds = testExternalIDPerson.copy(
-        instagramId = "test_instagram",
-        twitterId = "test_twitter",
-        facebookId = "test_facebook",
-      )
-
       context.launchPersonActivity {
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
-          externalIdPersonLiveData.postValue(testExternalIds)
+          detailPersonLiveData.postValue(testDetailPerson)
         }
         view_group_social_media.isDisplayed()
         btn_instagram.isDisplayed()
@@ -371,7 +362,19 @@ class PersonActivityTest : BasePersonActivityTest() {
 
       context.launchPersonActivity {
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
-          externalIdPersonLiveData.postValue(testExternalIds)
+          detailPersonLiveData.postValue(testDetailPerson.copy(externalIds = testExternalIds))
+        }
+
+        view_group_social_media.isGone()
+      }
+    }
+
+  @Test
+  fun socialMediaLinks_withNullId_shouldHidden() =
+    runTest {
+      context.launchPersonActivity {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+          detailPersonLiveData.postValue(testDetailPerson.copy(externalIds = null))
         }
 
         view_group_social_media.isGone()

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/data/repository/PersonRepositoryImpl.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/data/repository/PersonRepositoryImpl.kt
@@ -4,11 +4,9 @@ import com.waffiq.bazz_movies.core.mappers.NetworkResultMapper.toOutcome
 import com.waffiq.bazz_movies.core.models.Outcome
 import com.waffiq.bazz_movies.core.network.data.remote.datasource.person.PersonRemoteDataSource
 import com.waffiq.bazz_movies.feature.person.domain.model.DetailPerson
-import com.waffiq.bazz_movies.feature.person.domain.model.ExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ImagePerson
 import com.waffiq.bazz_movies.feature.person.domain.repository.IPersonRepository
 import com.waffiq.bazz_movies.feature.person.utils.mapper.PersonMapper.toDetailPerson
-import com.waffiq.bazz_movies.feature.person.utils.mapper.PersonMapper.toExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.utils.mapper.PersonMapper.toImagePerson
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -24,7 +22,4 @@ class PersonRepositoryImpl @Inject constructor(
 
   override fun getImagePerson(id: Int): Flow<Outcome<ImagePerson>> =
     personRemoteDataSource.getPersonImages(id).toOutcome { it.toImagePerson() }
-
-  override fun getExternalIDPerson(id: Int): Flow<Outcome<ExternalIDPerson>> =
-    personRemoteDataSource.getPersonExternalIds(id).toOutcome { it.toExternalIDPerson() }
 }

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/DetailPerson.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/DetailPerson.kt
@@ -16,4 +16,5 @@ data class DetailPerson(
   val adult: Boolean? = null,
   val homepage: String? = null,
   val credits: CombinedCreditPerson? = null,
+  val externalIds: ExternalIDPerson? = null,
 )

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/ExternalIDPerson.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/ExternalIDPerson.kt
@@ -12,4 +12,13 @@ data class ExternalIDPerson(
   val tvrageId: String? = null,
   val facebookId: String? = null,
   val instagramId: String? = null,
-)
+) {
+  fun hasAnySocialMediaIds(): Boolean =
+    listOf(
+      instagramId,
+      twitterId,
+      facebookId,
+      tiktokId,
+      youtubeId,
+    ).any { !it.isNullOrEmpty() }
+}

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/domain/repository/IPersonRepository.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/domain/repository/IPersonRepository.kt
@@ -2,12 +2,10 @@ package com.waffiq.bazz_movies.feature.person.domain.repository
 
 import com.waffiq.bazz_movies.core.models.Outcome
 import com.waffiq.bazz_movies.feature.person.domain.model.DetailPerson
-import com.waffiq.bazz_movies.feature.person.domain.model.ExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ImagePerson
 import kotlinx.coroutines.flow.Flow
 
 interface IPersonRepository {
   fun getDetailPerson(id: Int): Flow<Outcome<DetailPerson>>
   fun getImagePerson(id: Int): Flow<Outcome<ImagePerson>>
-  fun getExternalIDPerson(id: Int): Flow<Outcome<ExternalIDPerson>>
 }

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/domain/usecase/GetDetailPersonInteractor.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/domain/usecase/GetDetailPersonInteractor.kt
@@ -2,7 +2,6 @@ package com.waffiq.bazz_movies.feature.person.domain.usecase
 
 import com.waffiq.bazz_movies.core.models.Outcome
 import com.waffiq.bazz_movies.feature.person.domain.model.DetailPerson
-import com.waffiq.bazz_movies.feature.person.domain.model.ExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ImagePerson
 import com.waffiq.bazz_movies.feature.person.domain.repository.IPersonRepository
 import kotlinx.coroutines.flow.Flow
@@ -16,7 +15,4 @@ class GetDetailPersonInteractor @Inject constructor(
 
   override fun getImagePerson(id: Int): Flow<Outcome<ImagePerson>> =
     personRepository.getImagePerson(id)
-
-  override fun getExternalIDPerson(id: Int): Flow<Outcome<ExternalIDPerson>> =
-    personRepository.getExternalIDPerson(id)
 }

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/domain/usecase/GetDetailPersonUseCase.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/domain/usecase/GetDetailPersonUseCase.kt
@@ -2,12 +2,10 @@ package com.waffiq.bazz_movies.feature.person.domain.usecase
 
 import com.waffiq.bazz_movies.core.models.Outcome
 import com.waffiq.bazz_movies.feature.person.domain.model.DetailPerson
-import com.waffiq.bazz_movies.feature.person.domain.model.ExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ImagePerson
 import kotlinx.coroutines.flow.Flow
 
 interface GetDetailPersonUseCase {
   fun getDetailPerson(id: Int): Flow<Outcome<DetailPerson>>
   fun getImagePerson(id: Int): Flow<Outcome<ImagePerson>>
-  fun getExternalIDPerson(id: Int): Flow<Outcome<ExternalIDPerson>>
 }

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivity.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivity.kt
@@ -52,7 +52,6 @@ import com.waffiq.bazz_movies.feature.person.utils.helper.DialogHelper.setupTran
 import com.waffiq.bazz_movies.feature.person.utils.helper.ParcelableHelper.extractMediaCastItemFromIntent
 import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.formatBirthInfo
 import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.formatDeathInfo
-import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.hasAnySocialMediaIds
 import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.setupSocialLink
 import com.waffiq.bazz_movies.navigation.INavigator
 import dagger.hilt.android.AndroidEntryPoint
@@ -182,20 +181,24 @@ class PersonActivity : AppCompatActivity() {
   }
 
   private fun showSocialMediaPerson() {
-    personViewModel.detailPerson.observe(this) {
-      if (hasAnySocialMediaIds(it.externalIds)) {
-        binding.viewGroupSocialMedia.isVisible = true
-        setupSocialLink(it.externalIds?.instagramId, binding.btnInstagram, INSTAGRAM_LINK)
-        setupSocialLink(it.externalIds?.twitterId, binding.btnX, X_LINK)
-        setupSocialLink(it.externalIds?.facebookId, binding.btnFacebook, FACEBOOK_LINK)
-        setupSocialLink(it.externalIds?.tiktokId, binding.btnTiktok, TIKTOK_PERSON_LINK)
-        setupSocialLink(it.externalIds?.youtubeId, binding.btnYoutube, YOUTUBE_CHANNEL_LINK)
-      } else {
+    personViewModel.detailPerson.observe(this) { person ->
+      val externalIds = person.externalIds
+
+      if (externalIds == null) {
         binding.viewGroupSocialMedia.isVisible = false
+        return@observe
       }
 
-      setupSocialLink(it.externalIds?.imdbId, binding.btnImdb, IMDB_PERSON_LINK)
-      setupSocialLink(it.externalIds?.wikidataId, binding.btnWikidata, WIKIDATA_PERSON_LINK)
+      binding.viewGroupSocialMedia.isVisible = externalIds.hasAnySocialMediaIds()
+
+      setupSocialLink(externalIds.instagramId, binding.btnInstagram, INSTAGRAM_LINK)
+      setupSocialLink(externalIds.twitterId, binding.btnX, X_LINK)
+      setupSocialLink(externalIds.facebookId, binding.btnFacebook, FACEBOOK_LINK)
+      setupSocialLink(externalIds.tiktokId, binding.btnTiktok, TIKTOK_PERSON_LINK)
+      setupSocialLink(externalIds.youtubeId, binding.btnYoutube, YOUTUBE_CHANNEL_LINK)
+
+      setupSocialLink(externalIds.imdbId, binding.btnImdb, IMDB_PERSON_LINK)
+      setupSocialLink(externalIds.wikidataId, binding.btnWikidata, WIKIDATA_PERSON_LINK)
     }
   }
 

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivity.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivity.kt
@@ -182,22 +182,20 @@ class PersonActivity : AppCompatActivity() {
   }
 
   private fun showSocialMediaPerson() {
-    dataExtra.id?.let { personViewModel.getExternalIDPerson(it) }
-    personViewModel.externalIdPerson.observe(this) { externalID ->
-
-      if (hasAnySocialMediaIds(externalID)) {
+    personViewModel.detailPerson.observe(this) {
+      if (hasAnySocialMediaIds(it.externalIds)) {
         binding.viewGroupSocialMedia.isVisible = true
-        setupSocialLink(externalID.instagramId, binding.btnInstagram, INSTAGRAM_LINK)
-        setupSocialLink(externalID.twitterId, binding.btnX, X_LINK)
-        setupSocialLink(externalID.facebookId, binding.btnFacebook, FACEBOOK_LINK)
-        setupSocialLink(externalID.tiktokId, binding.btnTiktok, TIKTOK_PERSON_LINK)
-        setupSocialLink(externalID.youtubeId, binding.btnYoutube, YOUTUBE_CHANNEL_LINK)
+        setupSocialLink(it.externalIds?.instagramId, binding.btnInstagram, INSTAGRAM_LINK)
+        setupSocialLink(it.externalIds?.twitterId, binding.btnX, X_LINK)
+        setupSocialLink(it.externalIds?.facebookId, binding.btnFacebook, FACEBOOK_LINK)
+        setupSocialLink(it.externalIds?.tiktokId, binding.btnTiktok, TIKTOK_PERSON_LINK)
+        setupSocialLink(it.externalIds?.youtubeId, binding.btnYoutube, YOUTUBE_CHANNEL_LINK)
       } else {
         binding.viewGroupSocialMedia.isVisible = false
       }
 
-      setupSocialLink(externalID.imdbId, binding.btnImdb, IMDB_PERSON_LINK)
-      setupSocialLink(externalID.wikidataId, binding.btnWikidata, WIKIDATA_PERSON_LINK)
+      setupSocialLink(it.externalIds?.imdbId, binding.btnImdb, IMDB_PERSON_LINK)
+      setupSocialLink(it.externalIds?.wikidataId, binding.btnWikidata, WIKIDATA_PERSON_LINK)
     }
   }
 

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonViewModel.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonViewModel.kt
@@ -9,7 +9,6 @@ import com.waffiq.bazz_movies.core.common.utils.Event
 import com.waffiq.bazz_movies.core.models.Outcome
 import com.waffiq.bazz_movies.feature.person.domain.model.CastItem
 import com.waffiq.bazz_movies.feature.person.domain.model.DetailPerson
-import com.waffiq.bazz_movies.feature.person.domain.model.ExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ProfilesItem
 import com.waffiq.bazz_movies.feature.person.domain.usecase.GetDetailPersonUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -33,9 +32,6 @@ class PersonViewModel @Inject constructor(
     it.credits?.cast.orEmpty()
   }
 
-  private val _externalIdPerson = MutableLiveData<ExternalIDPerson>()
-  val externalIdPerson: LiveData<ExternalIDPerson> get() = _externalIdPerson
-
   private val _errorState = MutableLiveData<Event<String>>()
   val errorState: LiveData<Event<String>> get() = _errorState
 
@@ -55,13 +51,6 @@ class PersonViewModel @Inject constructor(
     executeUseCase(
       flowProvider = { getDetailPersonUseCase.getImagePerson(id) },
       onSuccess = { _imagePerson.value = it.profiles.orEmpty() },
-    )
-  }
-
-  fun getExternalIDPerson(id: Int) {
-    executeUseCase(
-      flowProvider = { getDetailPersonUseCase.getExternalIDPerson(id) },
-      onSuccess = { _externalIdPerson.value = it },
     )
   }
 

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/utils/helper/PersonPageHelper.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/utils/helper/PersonPageHelper.kt
@@ -58,12 +58,16 @@ object PersonPageHelper {
   fun getAge(birthday: String, currentDate: LocalDate = LocalDate.now()) =
     ChronoUnit.YEARS.between(LocalDate.parse(birthday), currentDate)
 
-  fun hasAnySocialMediaIds(externalID: ExternalIDPerson): Boolean =
-    !externalID.instagramId.isNullOrEmpty() ||
-      !externalID.twitterId.isNullOrEmpty() ||
-      !externalID.facebookId.isNullOrEmpty() ||
-      !externalID.tiktokId.isNullOrEmpty() ||
-      !externalID.youtubeId.isNullOrEmpty()
+  fun hasAnySocialMediaIds(externalID: ExternalIDPerson?): Boolean =
+    if (externalID != null) {
+      !externalID.instagramId.isNullOrEmpty() ||
+        !externalID.twitterId.isNullOrEmpty() ||
+        !externalID.facebookId.isNullOrEmpty() ||
+        !externalID.tiktokId.isNullOrEmpty() ||
+        !externalID.youtubeId.isNullOrEmpty()
+    } else {
+      false
+    }
 
   fun Context.formatBirthInfo(
     birthday: String?,

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/utils/helper/PersonPageHelper.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/utils/helper/PersonPageHelper.kt
@@ -10,7 +10,6 @@ import androidx.core.view.isVisible
 import com.waffiq.bazz_movies.core.designsystem.R.string.no_data
 import com.waffiq.bazz_movies.core.designsystem.R.string.years_old
 import com.waffiq.bazz_movies.core.utils.DateFormatter.dateFormatterStandard
-import com.waffiq.bazz_movies.feature.person.domain.model.ExternalIDPerson
 import java.time.LocalDate
 import java.time.Period
 import java.time.temporal.ChronoUnit
@@ -57,17 +56,6 @@ object PersonPageHelper {
 
   fun getAge(birthday: String, currentDate: LocalDate = LocalDate.now()) =
     ChronoUnit.YEARS.between(LocalDate.parse(birthday), currentDate)
-
-  fun hasAnySocialMediaIds(externalID: ExternalIDPerson?): Boolean =
-    if (externalID != null) {
-      !externalID.instagramId.isNullOrEmpty() ||
-        !externalID.twitterId.isNullOrEmpty() ||
-        !externalID.facebookId.isNullOrEmpty() ||
-        !externalID.tiktokId.isNullOrEmpty() ||
-        !externalID.youtubeId.isNullOrEmpty()
-    } else {
-      false
-    }
 
   fun Context.formatBirthInfo(
     birthday: String?,

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/utils/mapper/PersonMapper.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/utils/mapper/PersonMapper.kt
@@ -15,7 +15,6 @@ import com.waffiq.bazz_movies.feature.person.domain.model.DetailPerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ImagePerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ProfilesItem
-import kotlin.collections.sortedByDescending
 
 object PersonMapper {
 
@@ -91,6 +90,7 @@ object PersonMapper {
       adult = adult,
       homepage = homepage,
       credits = combinedCredits?.toCombinedCredit(),
+      externalIds = externalIds?.toExternalIDPerson(),
     )
 
   fun ImagePersonResponse.toImagePerson() =

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/data/repository/PersonRepositoryImplTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/data/repository/PersonRepositoryImplTest.kt
@@ -1,14 +1,12 @@
 package com.waffiq.bazz_movies.feature.person.data.repository
 
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.DetailPersonResponse
-import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ExternalIDPersonResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.person.ImagePersonResponse
 import com.waffiq.bazz_movies.core.test.RepositoryTestHelper.testLoadingState
 import com.waffiq.bazz_movies.core.test.RepositoryTestHelper.testSuccessfulCall
 import com.waffiq.bazz_movies.core.test.RepositoryTestHelper.testUnsuccessfulCall
 import com.waffiq.bazz_movies.feature.person.testutils.BasePersonRepositoryImplTest
 import com.waffiq.bazz_movies.feature.person.utils.mapper.PersonMapper.toDetailPerson
-import com.waffiq.bazz_movies.feature.person.utils.mapper.PersonMapper.toExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.utils.mapper.PersonMapper.toImagePerson
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -83,41 +81,6 @@ class PersonRepositoryImplTest : BasePersonRepositoryImplTest() {
         dataSourceCall = { mockPersonRemoteDataSource.getPersonImages(id) },
         repositoryCall = { repository.getImagePerson(id) },
         verifyDataSourceCall = { coVerify { mockPersonRemoteDataSource.getPersonImages(id) } },
-      )
-    }
-
-  @Test
-  fun getExternalIDPerson_whenSuccessful_returnsSuccessResult() =
-    runTest {
-      val mockResponse = mockk<ExternalIDPersonResponse>(relaxed = true)
-      testSuccessfulCall(
-        mockResponse = mockResponse,
-        dataSourceCall = { mockPersonRemoteDataSource.getPersonExternalIds(id) },
-        repositoryCall = { repository.getExternalIDPerson(id) },
-        expectedData = mockResponse.toExternalIDPerson(),
-        verifyDataSourceCall = {
-          coVerify(atLeast = 1) { mockPersonRemoteDataSource.getPersonExternalIds(id) }
-        },
-      )
-    }
-
-  @Test
-  fun getExternalIDPerson_whenUnsuccessful_returnsErrorResult() =
-    runTest {
-      testUnsuccessfulCall(
-        dataSourceCall = { mockPersonRemoteDataSource.getPersonExternalIds(id) },
-        repositoryCall = { repository.getExternalIDPerson(id) },
-        verifyDataSourceCall = { coVerify { mockPersonRemoteDataSource.getPersonExternalIds(id) } },
-      )
-    }
-
-  @Test
-  fun getExternalIDPerson_whenLoadingEmitted_returnsLoadingOutcome() =
-    runTest {
-      testLoadingState(
-        dataSourceCall = { mockPersonRemoteDataSource.getPersonExternalIds(id) },
-        repositoryCall = { repository.getExternalIDPerson(id) },
-        verifyDataSourceCall = { coVerify { mockPersonRemoteDataSource.getPersonExternalIds(id) } },
       )
     }
 }

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/CastItemTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/CastItemTest.kt
@@ -1,8 +1,8 @@
 package com.waffiq.bazz_movies.feature.person.domain.model
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class CastItemTest {
@@ -23,7 +23,7 @@ class CastItemTest {
     assertNull(castItem.creditId)
     assertEquals(castItem.mediaType, "movie")
     assertNull(castItem.originalName)
-    assertEquals(castItem.popularity, 0.0)
+    assertEquals(castItem.popularity, 0.0, 0.0001)
     assertEquals(castItem.voteAverage, 0f)
     assertNull(castItem.name)
     assertEquals(castItem.id, 0)

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/CombinedCreditPersonTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/CombinedCreditPersonTest.kt
@@ -1,6 +1,6 @@
 package com.waffiq.bazz_movies.feature.person.domain.model
 
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class CombinedCreditPersonTest {

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/CrewItemTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/CrewItemTest.kt
@@ -1,6 +1,6 @@
 package com.waffiq.bazz_movies.feature.person.domain.model
 
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class CrewItemTest {

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/DetailPersonTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/DetailPersonTest.kt
@@ -1,7 +1,7 @@
 package com.waffiq.bazz_movies.feature.person.domain.model
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -28,6 +28,7 @@ class DetailPersonTest {
     assertNull(detailPerson.adult)
     assertNull(detailPerson.homepage)
     assertNull(detailPerson.credits)
+    assertNull(detailPerson.externalIds)
   }
 
   @Test

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/ExternalIDPersonTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/ExternalIDPersonTest.kt
@@ -1,0 +1,24 @@
+package com.waffiq.bazz_movies.feature.person.domain.model
+
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ExternalIDPersonTest {
+
+  @Test
+  fun externalIdPerson_withNullValue_returnsDefaultValue() {
+    val externalIDPerson = ExternalIDPerson()
+
+    assertNull(externalIDPerson.imdbId)
+    assertNull(externalIDPerson.freebaseMid)
+    assertNull(externalIDPerson.tiktokId)
+    assertNull(externalIDPerson.wikidataId)
+    assertNull(externalIDPerson.id)
+    assertNull(externalIDPerson.freebaseId)
+    assertNull(externalIDPerson.twitterId)
+    assertNull(externalIDPerson.youtubeId)
+    assertNull(externalIDPerson.tvrageId)
+    assertNull(externalIDPerson.facebookId)
+    assertNull(externalIDPerson.instagramId)
+  }
+}

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/ExternalIDPersonTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/ExternalIDPersonTest.kt
@@ -1,6 +1,8 @@
 package com.waffiq.bazz_movies.feature.person.domain.model
 
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ExternalIDPersonTest {
@@ -20,5 +22,35 @@ class ExternalIDPersonTest {
     assertNull(externalIDPerson.tvrageId)
     assertNull(externalIDPerson.facebookId)
     assertNull(externalIDPerson.instagramId)
+  }
+
+  @Test
+  fun hasAnySocialMediaIds_whenCheckingVariousIds_returnsExpectedResult() {
+    // should return true if there's id
+    assertTrue(ExternalIDPerson(instagramId = "instagramId").hasAnySocialMediaIds())
+    assertTrue(ExternalIDPerson(twitterId = "twitterId").hasAnySocialMediaIds())
+    assertTrue(ExternalIDPerson(facebookId = "facebookId").hasAnySocialMediaIds())
+    assertTrue(ExternalIDPerson(tiktokId = "tiktokId").hasAnySocialMediaIds())
+    assertTrue(ExternalIDPerson(youtubeId = "youtubeId").hasAnySocialMediaIds())
+
+    // should return false if there's no id at all
+    assertFalse(ExternalIDPerson().hasAnySocialMediaIds())
+    assertFalse(ExternalIDPerson(instagramId = "").hasAnySocialMediaIds())
+    assertFalse(ExternalIDPerson(twitterId = "").hasAnySocialMediaIds())
+    assertFalse(ExternalIDPerson(facebookId = "").hasAnySocialMediaIds())
+    assertFalse(ExternalIDPerson(tiktokId = "").hasAnySocialMediaIds())
+    assertFalse(ExternalIDPerson(youtubeId = "").hasAnySocialMediaIds())
+    assertFalse(ExternalIDPerson().hasAnySocialMediaIds())
+
+    // all id is available
+    assertTrue(
+      ExternalIDPerson(
+        youtubeId = "youtubeId",
+        instagramId = "instagramId",
+        facebookId = "facebookId",
+        tiktokId = "tiktokId",
+        twitterId = "twitterId",
+      ).hasAnySocialMediaIds(),
+    )
   }
 }

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/ImagePersonTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/ImagePersonTest.kt
@@ -1,6 +1,6 @@
 package com.waffiq.bazz_movies.feature.person.domain.model
 
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ImagePersonTest {

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/ProfilesItemTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/model/ProfilesItemTest.kt
@@ -1,6 +1,6 @@
 package com.waffiq.bazz_movies.feature.person.domain.model
 
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ProfilesItemTest {

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/usecase/GetDetailPersonInteractorTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/domain/usecase/GetDetailPersonInteractorTest.kt
@@ -4,17 +4,16 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import com.waffiq.bazz_movies.core.models.Outcome
 import com.waffiq.bazz_movies.feature.person.domain.model.DetailPerson
-import com.waffiq.bazz_movies.feature.person.domain.model.ExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ImagePerson
 import com.waffiq.bazz_movies.feature.person.domain.model.ProfilesItem
 import com.waffiq.bazz_movies.feature.person.domain.repository.IPersonRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -51,20 +50,6 @@ class GetDetailPersonInteractorTest {
   private val imagePerson = ImagePerson(
     profiles = listOf(profilesItem),
     id = 12345,
-  )
-
-  private val externalIdPerson = ExternalIDPerson(
-    imdbId = "imdb_id",
-    freebaseMid = "freebase_m_id",
-    tiktokId = "tiktok_id",
-    wikidataId = "wikidata_id",
-    id = 1234567890,
-    freebaseId = "freebase_id",
-    twitterId = "twitter_id",
-    youtubeId = "youtube_id",
-    tvrageId = "tv_rage_id",
-    facebookId = "facebook_id",
-    instagramId = "instagram_id",
   )
 
   private val mockRepository: IPersonRepository = mockk()
@@ -152,45 +137,6 @@ class GetDetailPersonInteractorTest {
         awaitComplete()
       }
       coVerify { mockRepository.getImagePerson(personId) }
-    }
-
-  @Test
-  fun getExternalIDPerson_whenSuccessful_emitsSuccess() =
-    runTest {
-      coEvery { mockRepository.getExternalIDPerson(personId) } returns
-        flowSuccess(externalIdPerson)
-
-      getDetailPersonInteractor.getExternalIDPerson(personId).test {
-        val result = awaitSuccessData()
-        assertEquals("imdb_id", result.imdbId)
-        assertEquals("freebase_m_id", result.freebaseMid)
-        assertEquals("tiktok_id", result.tiktokId)
-        assertEquals("wikidata_id", result.wikidataId)
-        assertEquals(1234567890, result.id)
-        assertEquals("freebase_id", result.freebaseId)
-        assertEquals("twitter_id", result.twitterId)
-        assertEquals("youtube_id", result.youtubeId)
-        assertEquals("tv_rage_id", result.tvrageId)
-        assertEquals("facebook_id", result.facebookId)
-        assertEquals("instagram_id", result.instagramId)
-
-        awaitComplete()
-      }
-
-      coVerify(exactly = 1) { mockRepository.getExternalIDPerson(personId) }
-      coVerify { mockRepository.getExternalIDPerson(personId) }
-    }
-
-  @Test
-  fun getExternalIDPerson_whenUnsuccessful_emitsError() =
-    runTest {
-      coEvery { mockRepository.getExternalIDPerson(personId) } returns flowError
-
-      getDetailPersonInteractor.getExternalIDPerson(personId).test {
-        assertEquals(errorMessage, awaitOutcomeError())
-        awaitComplete()
-      }
-      coVerify { mockRepository.getExternalIDPerson(personId) }
     }
 
   private suspend fun <T> ReceiveTurbine<Outcome<T>>.awaitSuccessData(): T {

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonViewModelTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonViewModelTest.kt
@@ -101,17 +101,18 @@ class PersonViewModelTest : BasePersonViewModelTest() {
     }
 
   @Test
-  fun castList_whenCreditsNull_returnsEmptyList() = runTest {
-    personViewModel.castList.observeForever(observer)
-    coEvery { getDetailPersonUseCase.getDetailPerson(personId) } returns
-      successFlow(mockDetailPerson.copy(credits = null))
+  fun castList_whenCreditsNull_returnsEmptyList() =
+    runTest {
+      personViewModel.castList.observeForever(observer)
+      coEvery { getDetailPersonUseCase.getDetailPerson(personId) } returns
+        successFlow(mockDetailPerson.copy(credits = null))
 
-    personViewModel.getDetailPerson(personId)
-    advanceUntilIdle()
-    assertEquals(emptyList<CastItem>(), personViewModel.castList.value)
+      personViewModel.getDetailPerson(personId)
+      advanceUntilIdle()
+      assertEquals(emptyList<CastItem>(), personViewModel.castList.value)
 
-    personViewModel.castList.removeObserver(observer)
-  }
+      personViewModel.castList.removeObserver(observer)
+    }
 
   @Test
   fun getImagePerson_whenSuccessful_emitsSuccess() {
@@ -177,37 +178,6 @@ class PersonViewModelTest : BasePersonViewModelTest() {
         expectError = errorMessage,
         verifyBlock = {
           coVerify { getDetailPersonUseCase.getImagePerson(personId) }
-        },
-      )
-    }
-
-  @Test
-  fun getExternalIDPerson_whenSuccessful_emitsSuccess() =
-    runTest {
-      coEvery { getDetailPersonUseCase.getExternalIDPerson(personId) } returns
-        successFlow(mockExternalIDPerson)
-
-      testViewModel(
-        runBlock = { personViewModel.getExternalIDPerson(personId) },
-        liveData = personViewModel.externalIdPerson,
-        expectedSuccess = mockExternalIDPerson,
-        verifyBlock = {
-          coVerify { getDetailPersonUseCase.getExternalIDPerson(personId) }
-        },
-      )
-    }
-
-  @Test
-  fun getExternalIDPerson_whenUnsuccessful_emitsError() =
-    runTest {
-      coEvery { getDetailPersonUseCase.getExternalIDPerson(personId) } returns errorFlow
-
-      testViewModel(
-        runBlock = { personViewModel.getExternalIDPerson(personId) },
-        liveData = personViewModel.externalIdPerson,
-        expectError = errorMessage,
-        verifyBlock = {
-          coVerify { getDetailPersonUseCase.getExternalIDPerson(personId) }
         },
       )
     }

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/ui/adapter/ImagePagerAdapterTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/ui/adapter/ImagePagerAdapterTest.kt
@@ -6,9 +6,9 @@ import android.widget.FrameLayout
 import androidx.test.core.app.ApplicationProvider
 import com.waffiq.bazz_movies.core.designsystem.R.style.Base_Theme_BAZZ_movies
 import com.waffiq.bazz_movies.core.designsystem.databinding.ItemImageSliderBinding
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertSame
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/ui/adapter/ImagePersonAdapterTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/ui/adapter/ImagePersonAdapterTest.kt
@@ -10,11 +10,11 @@ import com.waffiq.bazz_movies.core.common.utils.Constants.TMDB_IMG_LINK_POSTER_W
 import com.waffiq.bazz_movies.core.designsystem.R.style.Base_Theme_BAZZ_movies
 import com.waffiq.bazz_movies.core.designsystem.databinding.ItemPosterBinding
 import com.waffiq.bazz_movies.feature.person.domain.model.ProfilesItem
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertSame
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/ui/adapter/KnownForAdapterTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/ui/adapter/KnownForAdapterTest.kt
@@ -15,11 +15,11 @@ import com.waffiq.bazz_movies.navigation.INavigator
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertSame
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/utils/helper/PersonPageHelperRoboTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/utils/helper/PersonPageHelperRoboTest.kt
@@ -12,9 +12,9 @@ import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.getAg
 import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.setupSocialLink
 import io.mockk.mockk
 import io.mockk.verify
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/utils/helper/PersonPageHelperTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/utils/helper/PersonPageHelperTest.kt
@@ -3,20 +3,16 @@ package com.waffiq.bazz_movies.feature.person.utils.helper
 import android.content.Context
 import com.waffiq.bazz_movies.core.designsystem.R.string.no_data
 import com.waffiq.bazz_movies.core.designsystem.R.string.years_old
-import com.waffiq.bazz_movies.feature.person.domain.model.ExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.formatBirthInfo
 import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.formatDeathInfo
 import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.getAge
 import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.getAgeDeath
-import com.waffiq.bazz_movies.feature.person.utils.helper.PersonPageHelper.hasAnySocialMediaIds
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.time.LocalDate
@@ -30,38 +26,6 @@ class PersonPageHelperTest {
   @Before
   fun setup() {
     every { context.getString(no_data) } returns "no data"
-  }
-
-  @Test
-  fun hasAnySocialMediaIds_whenCheckingVariousIds_returnsExpectedResult() {
-    // should return true if there's id
-    assertTrue(hasAnySocialMediaIds(ExternalIDPerson(instagramId = "instagramId")))
-    assertTrue(hasAnySocialMediaIds(ExternalIDPerson(twitterId = "twitterId")))
-    assertTrue(hasAnySocialMediaIds(ExternalIDPerson(facebookId = "facebookId")))
-    assertTrue(hasAnySocialMediaIds(ExternalIDPerson(tiktokId = "tiktokId")))
-    assertTrue(hasAnySocialMediaIds(ExternalIDPerson(youtubeId = "youtubeId")))
-
-    // should return false if there's no id at all
-    assertFalse(hasAnySocialMediaIds(null))
-    assertFalse(hasAnySocialMediaIds(ExternalIDPerson(instagramId = "")))
-    assertFalse(hasAnySocialMediaIds(ExternalIDPerson(twitterId = "")))
-    assertFalse(hasAnySocialMediaIds(ExternalIDPerson(facebookId = "")))
-    assertFalse(hasAnySocialMediaIds(ExternalIDPerson(tiktokId = "")))
-    assertFalse(hasAnySocialMediaIds(ExternalIDPerson(youtubeId = "")))
-    assertFalse(hasAnySocialMediaIds(ExternalIDPerson()))
-
-    // all id is available
-    assertTrue(
-      hasAnySocialMediaIds(
-        ExternalIDPerson(
-          youtubeId = "youtubeId",
-          instagramId = "instagramId",
-          facebookId = "facebookId",
-          tiktokId = "tiktokId",
-          twitterId = "twitterId",
-        ),
-      ),
-    )
   }
 
   @Test

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/utils/helper/PersonPageHelperTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/utils/helper/PersonPageHelperTest.kt
@@ -14,9 +14,9 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import io.mockk.verify
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.time.LocalDate
@@ -42,6 +42,7 @@ class PersonPageHelperTest {
     assertTrue(hasAnySocialMediaIds(ExternalIDPerson(youtubeId = "youtubeId")))
 
     // should return false if there's no id at all
+    assertFalse(hasAnySocialMediaIds(null))
     assertFalse(hasAnySocialMediaIds(ExternalIDPerson(instagramId = "")))
     assertFalse(hasAnySocialMediaIds(ExternalIDPerson(twitterId = "")))
     assertFalse(hasAnySocialMediaIds(ExternalIDPerson(facebookId = "")))

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/utils/mapper/PersonMapperTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/utils/mapper/PersonMapperTest.kt
@@ -11,8 +11,8 @@ import com.waffiq.bazz_movies.feature.person.utils.mapper.PersonMapper.toCombine
 import com.waffiq.bazz_movies.feature.person.utils.mapper.PersonMapper.toDetailPerson
 import com.waffiq.bazz_movies.feature.person.utils.mapper.PersonMapper.toExternalIDPerson
 import com.waffiq.bazz_movies.feature.person.utils.mapper.PersonMapper.toImagePerson
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class PersonMapperTest {


### PR DESCRIPTION
### Changes Made

- Replace the dedicated external id person API request with an appended response on the detail person endpoint