### PR TITLE
chore: prevent trending button shows when error state

### DIFF
--- a/feature/home/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/home/ui/fragment/FeaturedFragmentTest.kt
+++ b/feature/home/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/home/ui/fragment/FeaturedFragmentTest.kt
@@ -23,7 +23,12 @@ import com.waffiq.bazz_movies.feature.home.R.id.btn_trending_today
 import com.waffiq.bazz_movies.feature.home.R.id.button_group
 import com.waffiq.bazz_movies.feature.home.R.id.illustration_error_featured
 import com.waffiq.bazz_movies.feature.home.R.id.img_main_featured
+import com.waffiq.bazz_movies.feature.home.R.id.layout_header_movie_playing_now_featured
+import com.waffiq.bazz_movies.feature.home.R.id.layout_header_trending_featured
+import com.waffiq.bazz_movies.feature.home.R.id.layout_header_upcoming_movie_featured
+import com.waffiq.bazz_movies.feature.home.R.id.rv_movie_playing_now_featured
 import com.waffiq.bazz_movies.feature.home.R.id.rv_trending
+import com.waffiq.bazz_movies.feature.home.R.id.rv_upcoming_movie_featured
 import com.waffiq.bazz_movies.feature.home.R.id.swipe_refresh_featured
 import com.waffiq.bazz_movies.feature.home.testutils.BaseHomeFragmentTest
 import com.waffiq.bazz_movies.feature.home.ui.domain.TrendingPeriod
@@ -100,6 +105,14 @@ class FeaturedFragmentTest : BaseHomeFragmentTest() {
 
     waitUntilVisible(withId(illustration_error_featured))
     img_main_featured.isNotDisplayed()
+    layout_header_trending_featured.isNotDisplayed()
+    button_group.isNotDisplayed()
+    btn_more_trending_featured.isNotDisplayed()
+    rv_trending.isNotDisplayed()
+    layout_header_upcoming_movie_featured.isNotDisplayed()
+    rv_upcoming_movie_featured.isNotDisplayed()
+    layout_header_movie_playing_now_featured.isNotDisplayed()
+    rv_movie_playing_now_featured.isNotDisplayed()
   }
 
   @Test

--- a/feature/home/src/main/kotlin/com/waffiq/bazz_movies/feature/home/ui/fragment/FeaturedFragment.kt
+++ b/feature/home/src/main/kotlin/com/waffiq/bazz_movies/feature/home/ui/fragment/FeaturedFragment.kt
@@ -216,6 +216,7 @@ class FeaturedFragment : BaseHomeFragment() {
     binding.apply {
       imgMainFeatured.isVisible = isVisible
       buttonGroup.isVisible = isVisible
+      layoutHeaderTrendingFeatured.isVisible = isVisible
       rvTrending.isVisible = isVisible
       layoutHeaderUpcomingMovieFeatured.isVisible = isVisible
       rvUpcomingMovieFeatured.isVisible = isVisible

--- a/feature/home/src/main/kotlin/com/waffiq/bazz_movies/feature/home/utils/helpers/HomeFragmentHelper.kt
+++ b/feature/home/src/main/kotlin/com/waffiq/bazz_movies/feature/home/utils/helpers/HomeFragmentHelper.kt
@@ -101,7 +101,7 @@ object HomeFragmentHelper {
     lifecycleScope.launch {
       loadStateFlow.debounce(DEBOUNCE_VERY_LONG).distinctUntilChanged().collectLatest { loadState ->
         when {
-          (loadState.refresh is LoadState.Loading || loadState.append is LoadState.Loading) -> {
+          loadState.refresh is LoadState.Loading || loadState.append is LoadState.Loading -> {
             onLoading()
           }
 


### PR DESCRIPTION
### Changes Made

- Hide trending views, included the more button when error state
- Prevent trending overflow with illustration error