### PR TITLE
chore(ci): update qltysh/qlty-action to v2.2.3

### DIFF
--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -748,10 +748,10 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: ${{ github.workspace }}/**/build/reports/jacoco/createDebugCombinedCoverageReport/createDebugCombinedCoverageReport.xml
 
-      # https://github.com/qltysh/qlty-action/commit/fd52dc852530a708d68c3b7342f8d33d1df4cd55
-      # v2.2.1
+      # https://github.com/qltysh/qlty-action/commit/dafbc1e328f1f92525f1a3916724bd5fa01498e8
+      # v2.2.3
       - name: Upload coverage reports to Qlty
-        uses: qltysh/qlty-action/coverage@fd52dc852530a708d68c3b7342f8d33d1df4cd55
+        uses: qltysh/qlty-action/coverage@dafbc1e328f1f92525f1a3916724bd5fa01498e8
         with:
           token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: ${{ github.workspace }}/**/build/reports/jacoco/createDebugCombinedCoverageReport/createDebugCombinedCoverageReport.xml


### PR DESCRIPTION
### Changes Made

- Bump qltysh/qlty-action to [v2.2.3](https://github.com/qltysh/qlty-action/releases/tag/v2.2.3)