### PR TITLE
fix: show fallback text when backdrop image is unavailable

### DIFF
--- a/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/BasicMediaDetailMapper.kt
+++ b/feature/detail/src/main/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/BasicMediaDetailMapper.kt
@@ -45,9 +45,9 @@ object BasicMediaDetailMapper {
       // updated data
       title = titleHandler(name, originalName),
       popularity = popularity?.toFloat() ?: 0f,
-      backdrop = backdropPath.toString(),
-      poster = posterPath.toString(),
-      overview = overview.toString(),
+      backdrop = backdropPath.orEmpty(),
+      poster = posterPath.orEmpty(),
+      overview = overview.orEmpty(),
       releaseDate = firstAirDate.orEmpty(),
     )
 
@@ -77,9 +77,9 @@ object BasicMediaDetailMapper {
       // updated data
       title = titleHandler(title, originalTitle),
       popularity = popularity?.toFloat() ?: 0f,
-      backdrop = backdropPath.toString(),
-      poster = posterPath.toString(),
-      overview = overview.toString(),
+      backdrop = backdropPath.orEmpty(),
+      poster = posterPath.orEmpty(),
+      overview = overview.orEmpty(),
       releaseDate = releaseDate.orEmpty(),
     )
 

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/testutils/DummyData.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/testutils/DummyData.kt
@@ -563,7 +563,6 @@ object DummyData {
     keywords = mediaKeywords,
     voteAverage = 8.0,
     status = "Released",
-    releaseDate = "2025-07-01",
     runtime = 120,
     imdbId = "tt9999999",
     budget = 1000000,
@@ -571,6 +570,10 @@ object DummyData {
     popularity = 4444.0,
     videos = video,
     watchProviders = watchProviders,
+    releaseDate = "2025-07-01",
+    posterPath = "posterPath",
+    backdropPath = "backdropPath",
+    overview = "overview",
   )
   // endregion MOVIE
 
@@ -605,6 +608,9 @@ object DummyData {
     externalIds = tvExternalIds,
     videos = video,
     watchProviders = watchProviders,
+    posterPath = "posterPath",
+    backdropPath = "backdropPath",
+    overview = "overview",
   )
 
   // endregion TV

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/BasicMovieDetailMapperTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/BasicMovieDetailMapperTest.kt
@@ -60,6 +60,9 @@ class BasicMovieDetailMapperTest {
       popularity = null,
       videos = null,
       watchProviders = null,
+      backdropPath = null,
+      posterPath = null,
+      overview = null,
       releaseDate = null,
     ).stubToMediaDetail()
 
@@ -81,6 +84,9 @@ class BasicMovieDetailMapperTest {
       result.watchProviders,
     )
     assertEquals("", result.releaseDate)
+    assertEquals("", result.backdrop)
+    assertEquals("", result.poster)
+    assertEquals("", result.overview)
   }
 
   @Test

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/BasicTvDetailMapperTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/utils/mappers/BasicTvDetailMapperTest.kt
@@ -54,11 +54,14 @@ class BasicTvDetailMapperTest {
       status = null,
       numberOfSeasons = null,
       numberOfEpisodes = null,
-      firstAirDate = null,
       popularity = null,
       videos = null,
       watchProviders = null,
       externalIds = null,
+      backdropPath = null,
+      posterPath = null,
+      overview = null,
+      firstAirDate = null,
     ).stubToMediaDetail()
 
     assertEquals(0, result.id)
@@ -71,7 +74,6 @@ class BasicTvDetailMapperTest {
     assertNull(result.status)
     assertNull(result.totalSeasons)
     assertNull(result.totalEpisodes)
-    assertEquals("", result.releaseDate)
     assertEquals(9.0f, validTvDetail.popularity)
     assertEquals(0f, result.popularity)
     assertNull(result.trailer)
@@ -79,6 +81,10 @@ class BasicTvDetailMapperTest {
       WatchProvidersUiState.Error("No watch providers available"),
       result.watchProviders,
     )
+    assertEquals("", result.backdrop)
+    assertEquals("", result.poster)
+    assertEquals("", result.overview)
+    assertEquals("", result.releaseDate)
   }
 
   @Test


### PR DESCRIPTION
### Changes Made

- Fix an issue where the fallback "No Backdrop" text is not displayed when the backdrop image was unavailable or null