### PR TITLE
chore: enable parallel Gradle tooling execution

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -7,6 +7,9 @@ org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=warn
 org.gradle.configuration-cache.parallel=true
 
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true
+
 # Kotlin optimizations
 kotlin.incremental=true
 kotlin.incremental.js=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,10 @@ android.enableJetifier=false
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
+# Enabled parallel sync for Gradle 9.4+
+# https://docs.gradle.org/current/userguide/performance.html#sec:configure_tooling_api_actions_parallelism
+org.gradle.tooling.parallel=true
+
 org.gradle.daemon=true
 
 # Enable caching between builds.


### PR DESCRIPTION
### Changes Made

- Enable parallel execution for Gradle tooling operations
- https://docs.gradle.org/current/userguide/performance.html#sec:configure_tooling_api_actions_parallelism