### PR TITLE
test: migrate Google Truth assertions to JUnit for consistency

### DIFF
--- a/core/adapter/build.gradle.kts
+++ b/core/adapter/build.gradle.kts
@@ -15,5 +15,4 @@ dependencies {
 
   testImplementation(libs.androidx.test.core)
   testImplementation(libs.robolectric)
-  testImplementation(libs.truth)
 }

--- a/core/adapter/src/test/kotlin/com/bazz_movies/core/adapter/BindAdapterHelperTest.kt
+++ b/core/adapter/src/test/kotlin/com/bazz_movies/core/adapter/BindAdapterHelperTest.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import android.view.LayoutInflater
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.imageview.ShapeableImageView
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.designsystem.databinding.ItemMediaBinding
 import com.waffiq.bazz_movies.core.models.MediaItem
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -48,10 +48,10 @@ class BindAdapterHelperTest {
       binding.bindMetaData(mediaItem)
     }
 
-    assertThat(binding.tvTitle.text.toString()).isEqualTo("The Matrix")
-    assertThat(binding.tvTitle.text.toString()).isNotEmpty()
-    assertThat(binding.tvGenre.text.toString()).isNotEmpty()
-    assertThat(binding.ratingBar.rating).isGreaterThan(0f)
-    assertThat(binding.tvRating.text.toString()).isNotEmpty()
+    assertEquals(binding.tvTitle.text.toString(), "The Matrix")
+    assertTrue(binding.tvTitle.text.toString().isNotEmpty())
+    assertTrue(binding.tvGenre.text.toString().isNotEmpty())
+    assertTrue(binding.ratingBar.rating > 0f)
+    assertTrue(binding.tvRating.text.toString().isNotEmpty())
   }
 }

--- a/core/favoritewatchlist/build.gradle.kts
+++ b/core/favoritewatchlist/build.gradle.kts
@@ -36,5 +36,4 @@ dependencies {
   testImplementation(libs.kotlin.test.junit)
   testImplementation(libs.mockk)
   testImplementation(libs.robolectric)
-  testImplementation(libs.truth)
 }

--- a/core/favoritewatchlist/src/test/kotlin/com/waffiq/bazz_movies/core/favoritewatchlist/LiveDataCollectors.kt
+++ b/core/favoritewatchlist/src/test/kotlin/com/waffiq/bazz_movies/core/favoritewatchlist/LiveDataCollectors.kt
@@ -1,12 +1,13 @@
 package com.waffiq.bazz_movies.core.favoritewatchlist
 
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.favoritewatchlist.testutils.DummyData.favoriteMoviesList
 import com.waffiq.bazz_movies.core.favoritewatchlist.testutils.DummyData.favoriteTvList
 import com.waffiq.bazz_movies.core.favoritewatchlist.testutils.DummyData.watchlistMovieList
 import com.waffiq.bazz_movies.core.favoritewatchlist.testutils.DummyData.watchlistTvList
 import com.waffiq.bazz_movies.core.favoritewatchlist.ui.viewmodel.SharedDBViewModel
 import com.waffiq.bazz_movies.core.models.Favorite
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 
 /**
  * Collects LiveData from the [SharedDBViewModel] for testing purposes.
@@ -26,16 +27,16 @@ class LiveDataCollectors(viewModel: SharedDBViewModel) {
   }
 
   fun assertAllDataTransformed() {
-    assertThat(observedFavoriteTvs).isNotEmpty()
-    assertThat(observedFavoriteTvs[0]).isEqualTo(favoriteTvList)
+    assertTrue(observedFavoriteTvs.isNotEmpty())
+    assertEquals(observedFavoriteTvs[0], favoriteTvList)
 
-    assertThat(observedFavoriteMovies).isNotEmpty()
-    assertThat(observedFavoriteMovies[0]).isEqualTo(favoriteMoviesList)
+    assertTrue(observedFavoriteMovies.isNotEmpty())
+    assertEquals(observedFavoriteMovies[0], favoriteMoviesList)
 
-    assertThat(observedWatchlistTvs).isNotEmpty()
-    assertThat(observedWatchlistTvs[0]).isEqualTo(watchlistTvList)
+    assertTrue(observedWatchlistTvs.isNotEmpty())
+    assertEquals(observedWatchlistTvs[0], watchlistTvList)
 
-    assertThat(observedWatchlistMovies).isNotEmpty()
-    assertThat(observedWatchlistMovies[0]).isEqualTo(watchlistMovieList)
+    assertTrue(observedWatchlistMovies.isNotEmpty())
+    assertEquals(observedWatchlistMovies[0], watchlistMovieList)
   }
 }

--- a/core/favoritewatchlist/src/test/kotlin/com/waffiq/bazz_movies/core/favoritewatchlist/ui/viewmodel/SharedDBViewModelTest.kt
+++ b/core/favoritewatchlist/src/test/kotlin/com/waffiq/bazz_movies/core/favoritewatchlist/ui/viewmodel/SharedDBViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.waffiq.bazz_movies.core.favoritewatchlist.ui.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.common.utils.Event
 import com.waffiq.bazz_movies.core.database.domain.usecase.FavoriteLocalDatabaseUseCase
 import com.waffiq.bazz_movies.core.database.utils.DbResult
@@ -26,6 +25,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -58,10 +58,10 @@ class SharedDBViewModelTest {
   fun localDatabaseUseCase_whenCalled_returnsFlowCorrectly() {
     // Verify LiveData properties are initialized
     with(viewModel) {
-      assertThat(favoriteTvFromDB).isNotNull()
-      assertThat(favoriteMoviesFromDB).isNotNull()
-      assertThat(watchlistMoviesDB).isNotNull()
-      assertThat(watchlistTvSeriesDB).isNotNull()
+      assertNotNull(favoriteTvFromDB)
+      assertNotNull(favoriteMoviesFromDB)
+      assertNotNull(watchlistMoviesDB)
+      assertNotNull(watchlistTvSeriesDB)
     }
 
     // Verify correct flows are accessed
@@ -83,8 +83,8 @@ class SharedDBViewModelTest {
         viewModel.insertToDB(favorite)
       }
 
-      assertThat(results).hasSize(1)
-      assertThat(results[0].peekContent()).isEqualTo(dbResult)
+      assertEquals(1, results.size)
+      assertEquals(dbResult, results[0].peekContent())
       coVerify { localDatabaseUseCase.insertToDB(favorite) }
     }
 
@@ -165,10 +165,10 @@ class SharedDBViewModelTest {
     operation()
     advanceUntilIdle()
 
-    assertThat(dbResults).hasSize(1)
-    assertThat(dbResults[0].peekContent()).isEqualTo(dbResult)
-    assertThat(undoResults).hasSize(1)
-    assertThat(undoResults[0].peekContent()).isEqualTo(favorite)
+    assertEquals(1, dbResults.size)
+    assertEquals(dbResult, dbResults[0].peekContent())
+    assertEquals(1, undoResults.size)
+    assertEquals(favorite, undoResults[0].peekContent())
 
     verification()
   }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
   testImplementation(libs.kotlinx.coroutines.test)
   testImplementation(libs.mockk)
   testImplementation(libs.mockwebserver)
-  testImplementation(libs.truth)
   testImplementation(libs.turbine)
 }
 

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/pagingsources/SearchPagingSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/pagingsources/SearchPagingSourceTest.kt
@@ -1,7 +1,6 @@
 package com.waffiq.bazz_movies.core.network.data.remote.pagingsources
 
 import androidx.paging.PagingSource
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.search.MultiSearchResponse
 import com.waffiq.bazz_movies.core.network.data.remote.responses.tmdb.search.MultiSearchResponseItem
 import com.waffiq.bazz_movies.core.network.data.remote.retrofit.services.SearchApiService
@@ -19,6 +18,8 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import retrofit2.HttpException
@@ -85,8 +86,8 @@ class SearchPagingSourceTest {
       val result = pagingSource.load(PagingSource.LoadParams.Refresh(INITIAL_PAGE_INDEX, 2, false))
 
       if (result is PagingSource.LoadResult.Error) {
-        assertThat(result.throwable).isInstanceOf(Exception::class.java)
-        assertThat(result.throwable.message).isEqualTo("Response data is null")
+        assertTrue(result.throwable is Exception)
+        assertEquals(result.throwable.message, "Response data is null")
       } else {
         fail("Expected LoadResult.Error but got $result")
       }

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/TvApiServiceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/retrofit/services/TvApiServiceTest.kt
@@ -1,14 +1,14 @@
 package com.waffiq.bazz_movies.core.network.data.remote.retrofit.services
 
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.network.testutils.BaseApiServiceTest
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
-import kotlin.test.assertEquals
 
 class TvApiServiceTest : BaseApiServiceTest() {
 
-  // This test only to make sure moshi can convert json to data class
+  // This test only to make sure moshi can convert JSON to data class
   // We test only several api service
 
   @Test
@@ -46,6 +46,6 @@ class TvApiServiceTest : BaseApiServiceTest() {
       )
 
       val request = mockWebServer.takeRequest()
-      assertThat(request.path).contains("language=en-US")
+      assertTrue(request.path.orEmpty().contains("language=en-US"))
     }
 }

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/testutils/PagingSourceTestHelper.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/testutils/PagingSourceTestHelper.kt
@@ -3,11 +3,11 @@ package com.waffiq.bazz_movies.core.network.testutils
 import androidx.paging.PagingConfig
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.network.utils.common.Constants.INITIAL_PAGE_INDEX
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import retrofit2.HttpException
 
@@ -64,7 +64,7 @@ object PagingSourceTestHelper {
     // perform load operation and verify results
     val result = pagingSource.load(params)
     if (result is PagingSource.LoadResult.Error) {
-      assertThat(result.throwable).isInstanceOf(expectedException)
+      assertTrue(expectedException.isInstance(result.throwable))
     } else {
       fail("Expected LoadResult.Error but got $result")
     }
@@ -90,9 +90,9 @@ object PagingSourceTestHelper {
 
     // perform load operation and verify results
     val result = pagingSource.load(params)
-    assertThat(result).isInstanceOf(PagingSource.LoadResult.Error::class.java)
+    assertTrue(result is PagingSource.LoadResult.Error)
     val errorResult = result as PagingSource.LoadResult.Error
-    assertThat(errorResult.throwable).isInstanceOf(HttpException::class.java)
+    assertTrue(errorResult.throwable is HttpException)
     assertEquals(errorResult.throwable.message, expectedMessage)
   }
 

--- a/core/uihelper/build.gradle.kts
+++ b/core/uihelper/build.gradle.kts
@@ -18,5 +18,4 @@ dependencies {
   testImplementation(libs.androidx.test.core)
   testImplementation(libs.mockk)
   testImplementation(libs.robolectric)
-  testImplementation(libs.truth)
 }

--- a/core/uihelper/src/test/kotlin/com/waffiq/bazz_movies/core/uihelper/utils/GenericViewPagerAdapterTest.kt
+++ b/core/uihelper/src/test/kotlin/com/waffiq/bazz_movies/core/uihelper/utils/GenericViewPagerAdapterTest.kt
@@ -3,7 +3,6 @@ package com.waffiq.bazz_movies.core.uihelper.utils
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
-import com.google.common.truth.Truth.assertThat
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -52,9 +51,9 @@ class GenericViewPagerAdapterTest {
 
   @Test
   fun createFragment_whenCalled_returnsCorrectType() {
-    assertThat(adapter.createFragment(0)).isInstanceOf(TestFragment1::class.java)
-    assertThat(adapter.createFragment(1)).isInstanceOf(TestFragment2::class.java)
-    assertThat(adapter.createFragment(2)).isInstanceOf(TestFragment3::class.java)
+    assertTrue(adapter.createFragment(0) is TestFragment1)
+    assertTrue(adapter.createFragment(1) is TestFragment2)
+    assertTrue(adapter.createFragment(2) is TestFragment3)
   }
 
   @Test
@@ -124,7 +123,7 @@ class GenericViewPagerAdapterTest {
     )
 
     assertEquals(1, singleAdapter.itemCount)
-    assertThat(singleAdapter.createFragment(0)).isInstanceOf(TestFragment1::class.java)
+    assertTrue(singleAdapter.createFragment(0) is TestFragment1)
     assertTrue(singleAdapter.containsItem(TestFragment1::class.java.name.hashCode().toLong()))
   }
 

--- a/docs/BAZZMoviesTesting.md
+++ b/docs/BAZZMoviesTesting.md
@@ -38,8 +38,7 @@ coroutines, and assertions.
 ### Assertions
 
 - [JUnit4](https://github.com/junit-team/junit4) → default assertions
-- [Truth](https://github.com/google/truth)
-  and [Kotest assertions](https://github.com/kotest/kotest) → human-readable checks
+- [Kotest assertions](https://github.com/kotest/kotest) → human-readable checks
 
 ## Test Naming Convention
 

--- a/feature/detail/build.gradle.kts
+++ b/feature/detail/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
   testImplementation(libs.mockito.core)
   testImplementation(libs.mockk)
   testImplementation(libs.robolectric)
-  testImplementation(libs.truth)
   testImplementation(libs.turbine)
 
   androidTestImplementation(libs.androidx.junit.ktx)

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/testutils/BaseMediaDetailViewModelTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/testutils/BaseMediaDetailViewModelTest.kt
@@ -3,7 +3,6 @@ package com.waffiq.bazz_movies.feature.detail.testutils
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.paging.AsyncPagingDataDiffer
 import androidx.paging.PagingData
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.data.domain.usecase.composite.MediaStateUseCase
 import com.waffiq.bazz_movies.core.data.domain.usecase.composite.PostActionUseCase
 import com.waffiq.bazz_movies.core.data.domain.usecase.listmovie.GetListMoviesUseCase
@@ -48,6 +47,8 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 
@@ -205,24 +206,18 @@ abstract class BaseMediaDetailViewModelTest {
 
     // Assertions
     expectedStates?.let {
-      assertThat(collectedStates)
-        .containsExactlyElementsIn(it)
-        .inOrder()
+      assertEquals(it, collectedStates)
     }
 
     // first loading state always true because default value
     expectedLoadingStates?.let {
-      assertThat(collectedLoadingStates)
-        .containsExactlyElementsIn(it)
-        .inOrder()
+      assertEquals(it, collectedLoadingStates)
     }
 
     expectedErrors?.let {
-      assertThat(collectedErrors)
-        .containsExactlyElementsIn(it)
-        .inOrder()
+      assertEquals(it, collectedErrors)
     } ?: run {
-      assertThat(collectedErrors).isEmpty()
+      assertTrue(collectedErrors.isEmpty())
     }
 
     verifyBlock()

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/ui/viewmodel/DetailMovieViewModelTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/ui/viewmodel/DetailMovieViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.waffiq.bazz_movies.feature.detail.ui.viewmodel
 
 import androidx.paging.PagingData
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.models.Outcome
 import com.waffiq.bazz_movies.feature.detail.testutils.BaseMediaDetailViewModelTest
 import io.mockk.coEvery
@@ -162,7 +161,7 @@ class DetailMovieViewModelTest : BaseMediaDetailViewModelTest() {
       pagingFlow = viewModel.recommendations,
       runBlock = { viewModel.getMovieRecommendation(movieId) },
       itemAssertions = { snapshot ->
-        assertThat(snapshot).containsExactly(mockMediaItem)
+        assertTrue(snapshot.contains(mockMediaItem))
       },
     )
   }

--- a/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/ui/viewmodel/DetailTvViewModelTest.kt
+++ b/feature/detail/src/test/kotlin/com/waffiq/bazz_movies/feature/detail/ui/viewmodel/DetailTvViewModelTest.kt
@@ -1,13 +1,13 @@
 package com.waffiq.bazz_movies.feature.detail.ui.viewmodel
 
 import androidx.paging.PagingData
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.feature.detail.testutils.BaseMediaDetailViewModelTest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DetailTvViewModelTest : BaseMediaDetailViewModelTest() {
@@ -140,7 +140,7 @@ class DetailTvViewModelTest : BaseMediaDetailViewModelTest() {
       pagingFlow = viewModel.recommendations,
       runBlock = { viewModel.getTvRecommendation(tvId) },
       itemAssertions = { snapshot ->
-        assertThat(snapshot).containsExactly(mockMediaItem)
+        assertTrue(snapshot.contains(mockMediaItem))
       },
     )
   }

--- a/feature/favorite/build.gradle.kts
+++ b/feature/favorite/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
   testImplementation(libs.kotlinx.coroutines.test)
   testImplementation(libs.mockk)
   testImplementation(libs.robolectric) // used to test FavoriteViewPagerAdapter
-  testImplementation(libs.truth)
   testImplementation(libs.turbine)
 
   // Allow JUnit4 tests on JUnit5 runner
@@ -35,5 +34,4 @@ dependencies {
   androidTestImplementation(libs.androidx.test.runner)
   androidTestImplementation(libs.kotlinx.coroutines.test)
   androidTestImplementation(libs.mockk.android)
-  androidTestImplementation(libs.truth)
 }

--- a/feature/favorite/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/favorite/testutils/BaseFavoriteFragmentTestHelper.kt
+++ b/feature/favorite/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/favorite/testutils/BaseFavoriteFragmentTestHelper.kt
@@ -17,7 +17,6 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.snackbar.Snackbar
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.common.utils.Constants.NAN
 import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.common.utils.Event
@@ -61,6 +60,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.receiveAsFlow
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import javax.inject.Inject
@@ -230,21 +230,21 @@ abstract class BaseFavoriteFragmentTestHelper {
   protected fun Int.assertViewPagerPosition(expected: Int) {
     onView(withId(this)).check { view, _ ->
       val vp = view as ViewPager2
-      assertThat(vp.currentItem).isEqualTo(expected)
+      assertEquals(expected, vp.currentItem)
     }
   }
 
   protected fun Int.assertViewPagerUserInputEnabled(expected: Boolean) {
     onView(withId(this)).check { view, _ ->
       val vp = view as ViewPager2
-      assertThat(vp.isUserInputEnabled).isEqualTo(expected)
+      assertEquals(expected, vp.isUserInputEnabled)
     }
   }
 
   protected fun Int.assertViewPagerItemCount(expected: Int) {
     onView(withId(this)).check { view, _ ->
       val vp = view as ViewPager2
-      assertThat(vp.adapter?.itemCount).isEqualTo(expected)
+      assertEquals(expected, vp.adapter?.itemCount)
     }
   }
 

--- a/feature/favorite/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/favorite/ui/FavoriteFragmentTest.kt
+++ b/feature/favorite/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/favorite/ui/FavoriteFragmentTest.kt
@@ -6,7 +6,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayout
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.designsystem.R.string.movies
 import com.waffiq.bazz_movies.core.designsystem.R.string.tv_series
 import com.waffiq.bazz_movies.core.favoritewatchlist.R.id.tabs
@@ -17,6 +16,7 @@ import com.waffiq.bazz_movies.core.instrumentationtest.CustomViewMatchers.isDisp
 import com.waffiq.bazz_movies.core.instrumentationtest.Helper.shortDelay
 import com.waffiq.bazz_movies.feature.favorite.testutils.BaseFavoriteFragmentTestHelper
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -39,7 +39,7 @@ class FavoriteFragmentTest : BaseFavoriteFragmentTestHelper() {
   fun tabLayout_whenCreated_shouldHaveCorrectNumberOfTabs() {
     onView(withId(tabs)).check { view, _ ->
       val tabLayout = view as TabLayout
-      assertThat(tabLayout.tabCount).isEqualTo(2)
+      assertEquals(2, tabLayout.tabCount)
     }
   }
 
@@ -76,7 +76,7 @@ class FavoriteFragmentTest : BaseFavoriteFragmentTestHelper() {
     tv_series.performTextClick()
     onView(withId(view_pager)).check { view, _ ->
       val viewPager = view as ViewPager2
-      assertThat(viewPager.currentItem).isEqualTo(1)
+      assertEquals(1, viewPager.currentItem)
     }
   }
 

--- a/feature/favorite/src/test/kotlin/com/waffiq/bazz_movies/feature/favorite/testutils/Helper.kt
+++ b/feature/favorite/src/test/kotlin/com/waffiq/bazz_movies/feature/favorite/testutils/Helper.kt
@@ -3,14 +3,13 @@ package com.waffiq.bazz_movies.feature.favorite.testutils
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import app.cash.turbine.test
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.common.utils.Event
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 
 /**
  * Helper object for testing PagingData flows and ViewModel LiveData events.
@@ -32,7 +31,7 @@ object Helper {
 
       if (expected != null) {
         val item = awaitItem()
-        assertThat(item).isEqualTo(expected)
+        assertEquals(expected, item)
       } else {
         // Expect no emissions
         expectNoEvents()
@@ -87,7 +86,7 @@ object Helper {
         val currentValue = liveData.value as Event<*>
         assertEquals(currentValue.peekContent(), expected)
       } else {
-        assertThat(collectedData).containsExactly(expected)
+        assertTrue(collectedData.contains(expected))
         assertEquals(liveData.value, expected)
       }
     } ?: assertTrue(collectedData.isEmpty())

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -43,5 +43,4 @@ dependencies {
   androidTestImplementation(libs.androidx.test.runner)
   androidTestImplementation(libs.kotlinx.coroutines.test)
   androidTestImplementation(libs.mockk.android)
-  androidTestImplementation(libs.truth)
 }

--- a/feature/list/build.gradle.kts
+++ b/feature/list/build.gradle.kts
@@ -24,7 +24,6 @@ dependencies {
   testImplementation(libs.mockk)
   testImplementation(libs.robolectric)
   testImplementation(libs.turbine)
-  testImplementation(libs.truth)
   testRuntimeOnly(libs.junit.vintage)
 
   androidTestImplementation(libs.androidx.junit.ktx)

--- a/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/ui/adapter/ListAdapterTest.kt
+++ b/feature/list/src/test/kotlin/com/waffiq/bazz_movies/feature/list/ui/adapter/ListAdapterTest.kt
@@ -7,7 +7,6 @@ import android.widget.FrameLayout
 import androidx.paging.PagingData
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.common.utils.Constants.MOVIE_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.common.utils.Constants.TV_MEDIA_TYPE
 import com.waffiq.bazz_movies.core.designsystem.R.style.Base_Theme_BAZZ_movies
@@ -188,8 +187,7 @@ class ListAdapterTest {
   fun onCreateViewHolder_returnsGridViewHolder_whenViewTypeGrid() {
     setupAdapter()
 
-    val holder = adapter.onCreateViewHolder(parent, ListAdapter.VIEW_TYPE_GRID)
-    assertThat(holder).isInstanceOf(ListAdapter.GridViewHolder::class.java)
+    val holder = getHolder(ListAdapter.VIEW_TYPE_GRID)
     assertTrue(holder is ListAdapter.GridViewHolder)
   }
 
@@ -197,8 +195,7 @@ class ListAdapterTest {
   fun onCreateViewHolder_returnsListViewHolder_whenViewTypeList() {
     setupAdapter()
 
-    val holder = adapter.onCreateViewHolder(parent, ListAdapter.VIEW_TYPE_LIST)
-    assertThat(holder).isInstanceOf(ListAdapter.ListViewHolder::class.java)
+    val holder = getHolder(ListAdapter.VIEW_TYPE_LIST)
     assertTrue(holder is ListAdapter.ListViewHolder)
   }
 
@@ -263,7 +260,7 @@ class ListAdapterTest {
       setupGridLayout()
       submitPagingAndWait(mediaMovieItem)
 
-      val holder = adapter.onCreateViewHolder(parent, ListAdapter.VIEW_TYPE_GRID)
+      val holder = getHolder(ListAdapter.VIEW_TYPE_GRID)
       adapter.onBindViewHolder(holder, 0)
 
       // trigger click to proves bind() was called
@@ -281,7 +278,7 @@ class ListAdapterTest {
       setupListLayout()
       submitPagingAndWait(mediaMovieItem)
 
-      val holder = adapter.onCreateViewHolder(parent, ListAdapter.VIEW_TYPE_LIST)
+      val holder = getHolder(ListAdapter.VIEW_TYPE_LIST)
       adapter.onBindViewHolder(holder, 0)
 
       // perform click to check if its list layout
@@ -290,6 +287,8 @@ class ListAdapterTest {
 
       verify(navigator).openDetails(any(), eq(mediaMovieItem.copy(mediaType = "movie")))
     }
+
+  private fun getHolder(viewType: Int) = adapter.onCreateViewHolder(parent, viewType)
 
   private fun setupListLayout() {
     adapter.setGridMode(false)

--- a/feature/person/build.gradle.kts
+++ b/feature/person/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
   testImplementation(libs.mockito.core)
   testImplementation(libs.mockk)
   testImplementation(libs.robolectric)
-  testImplementation(libs.truth)
   testImplementation(libs.turbine)
 
   androidTestImplementation(libs.androidx.uiautomator)

--- a/feature/person/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivityTest.kt
+++ b/feature/person/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivityTest.kt
@@ -248,7 +248,7 @@ class PersonActivityTest : BasePersonActivityTest() {
 
   @Test
   fun swipeRefresh_whenScroll_runsCorrectly() {
-    context.launchPersonActivity { activityScenario ->
+    context.launchPersonActivity { _ ->
       uiAutomator {
         // scroll down so the heigh for scroll up is enough
         device.swipe(

--- a/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivity.kt
+++ b/feature/person/src/main/kotlin/com/waffiq/bazz_movies/feature/person/ui/PersonActivity.kt
@@ -207,7 +207,7 @@ class PersonActivity : AppCompatActivity() {
     binding.tvBorn.text = birthInfo.ifEmpty { getString(no_data) }
   }
 
-  private fun showSocialMediaPerson(externalIds: ExternalIDPerson?){
+  private fun showSocialMediaPerson(externalIds: ExternalIDPerson?) {
     if (externalIds == null) {
       binding.viewGroupSocialMedia.isVisible = false
       return

--- a/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/testutils/BasePersonViewModelTest.kt
+++ b/feature/person/src/test/kotlin/com/waffiq/bazz_movies/feature/person/testutils/BasePersonViewModelTest.kt
@@ -2,7 +2,6 @@ package com.waffiq.bazz_movies.feature.person.testutils
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.LiveData
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.common.utils.Event
 import com.waffiq.bazz_movies.core.models.Outcome
 import com.waffiq.bazz_movies.core.test.MainDispatcherRule
@@ -20,6 +19,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 
@@ -111,13 +113,13 @@ abstract class BasePersonViewModelTest {
     advanceUntilIdle()
 
     expectedSuccess?.let {
-      assertThat(successData).containsExactly(it)
-      assertThat(liveData.value).isEqualTo(it)
+      assertTrue(successData.contains(it))
+      assertEquals(liveData.value, it)
     }
 
     expectError?.let {
       val error = personViewModel.errorState.value?.getContentIfNotHandled()
-      assertThat(error).isEqualTo(it)
+      assertEquals(error, it)
     }
 
     if (checkLoading) {
@@ -134,20 +136,20 @@ abstract class BasePersonViewModelTest {
   ) {
     when {
       expectedSuccess != null -> {
-        assertThat(collectedLoadingStates).contains(true)
-        assertThat(collectedLoadingStates.last()).isFalse()
-        assertThat(personViewModel.loadingState.value).isFalse()
+        assertTrue(collectedLoadingStates.contains(true))
+        assertFalse(collectedLoadingStates.last())
+        assertEquals(false, personViewModel.loadingState.value)
       }
 
       expectError != null -> {
-        assertThat(collectedLoadingStates).contains(true)
-        assertThat(collectedLoadingStates.last()).isFalse()
-        assertThat(personViewModel.loadingState.value).isFalse()
+        assertTrue(collectedLoadingStates.contains(true))
+        assertFalse(collectedLoadingStates.last())
+        assertEquals(false, personViewModel.loadingState.value)
       }
 
       else -> {
         if (collectedLoadingStates.isNotEmpty()) {
-          assertThat(collectedLoadingStates).contains(true)
+          assertTrue(collectedLoadingStates.contains(true))
         }
       }
     }

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -38,5 +38,4 @@ dependencies {
   androidTestImplementation(libs.androidx.test.runner)
   androidTestImplementation(libs.kotlinx.coroutines.test)
   androidTestImplementation(libs.mockk.android)
-  androidTestImplementation(libs.truth)
 }

--- a/feature/search/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/search/ui/SearchFragmentTest.kt
+++ b/feature/search/src/androidTest/kotlin/com/waffiq/bazz_movies/feature/search/ui/SearchFragmentTest.kt
@@ -18,7 +18,6 @@ import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.android.material.R.id.open_search_view_edit_text
-import com.google.common.truth.Truth.assertThat
 import com.waffiq.bazz_movies.core.designsystem.R.id.btn_try_again
 import com.waffiq.bazz_movies.core.designsystem.R.id.progress_circular
 import com.waffiq.bazz_movies.core.designsystem.R.string.clear_all
@@ -58,6 +57,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -274,9 +275,9 @@ class SearchFragmentTest : SearchFragmentTestHelper by DefaultFragmentTestHelper
     onView(withId(rv_search))
       .check { view, _ ->
         val recyclerView = view as RecyclerView
-        assertThat(recyclerView.layoutManager).isInstanceOf(LinearLayoutManager::class.java)
+        assertTrue(recyclerView.layoutManager is LinearLayoutManager)
         val layoutManager = recyclerView.layoutManager as LinearLayoutManager
-        assertThat(layoutManager.orientation).isEqualTo(LinearLayoutManager.VERTICAL)
+        assertEquals(layoutManager.orientation, LinearLayoutManager.VERTICAL)
       }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,7 +85,6 @@ mockitoKotlin = "6.3.0"
 mockito = "5.23.0"
 robolectric = "4.16.1"
 androidxTest = "1.7.0"
-truth = "1.4.5"
 turbine = "1.2.1"
 uiautomator = "2.4.0"
 
@@ -204,7 +203,6 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" } # use for unit test
 
 # Other Testing Libraries
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-truth = { module = "com.google.truth:truth", version.ref = "truth" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 # Image Loading


### PR DESCRIPTION
### Changes Made

- Replace Google Truth assertions with JUnit assertions to improve consistency across the test suite