### PR TITLE
feat: apply default strict without keywords to discovery queries

### DIFF
--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/constants/Keyword.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/constants/Keyword.kt
@@ -8,25 +8,37 @@ enum class Keyword(val id: String) {
 
   // strictly keywords
   BISEXUAL_MAN("168812"),
-  GAY_ROMANCE("240305"),
-  GAY_RELATIONSHIP("265777"),
   BOYS_LOVE("289844"),
-  GIRLS_LOVE("280003"),
-  LESBIAN("264386"),
-  LESBIAN_RELATIONSHIP("9833"),
-
-  // could be added, but many series have this theme
-  // but not the main focus, so we choose exclude it
-  LGBT("158718"),
-
-  // used for without keyboard to get anime, strictly
   ECCHI("195669"),
   EROTIC("256466"),
+  GAY_RELATIONSHIP("265777"),
+  GAY_ROMANCE("240305"),
+  GIRLS_LOVE("280003"),
   HENTAI("198385"),
+  LESBIAN("264386"),
+  LESBIAN_RELATIONSHIP("9833"),
   SOFTCORE("155477"),
+
+  // could be added, but many movie/series have this theme but not the main focus,
+  // so we choose exclude it
+  LGBT("158718"),
   ;
 
     companion object {
     fun List<Keyword>.toKeywordQuery() = joinToString("|") { it.id }
+
+    val STRICT_KEYWORDS = listOf(
+      BISEXUAL_MAN,
+      BOYS_LOVE,
+      ECCHI,
+      EROTIC,
+      GAY_RELATIONSHIP,
+      GAY_ROMANCE,
+      GIRLS_LOVE,
+      HENTAI,
+      LESBIAN,
+      LESBIAN_RELATIONSHIP,
+      SOFTCORE,
+    )
   }
 }

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/asian/AsianRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/asian/AsianRemoteDataSource.kt
@@ -4,20 +4,9 @@ import androidx.paging.PagingData
 import com.waffiq.bazz_movies.core.coroutines.IoDispatcher
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Genre.ANIMATION
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Genre.REALITY
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.BISEXUAL_MAN
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.BOYS_LOVE
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.COSTUME_DRAMA
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.DONGHUA
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.ECCHI
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.EROTIC
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.GAY_RELATIONSHIP
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.GAY_ROMANCE
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.GIRLS_LOVE
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.HENTAI
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.LESBIAN
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.LESBIAN_RELATIONSHIP
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.ROMANCE
-import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.SOFTCORE
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Region.CHINA
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Region.INDONESIA
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Region.JAPAN
@@ -49,7 +38,6 @@ class AsianRemoteDataSource @Inject constructor(
           genres = listOf(ANIMATION),
           originCountry = listOf(JAPAN),
           page = page,
-          withoutKeywords = ANIME_WITHOUT_KEYWORDS,
         ).toQueryMap(),
       ).results
     }.flow.flowOn(ioDispatcher)
@@ -63,7 +51,6 @@ class AsianRemoteDataSource @Inject constructor(
           page = page,
           firstAirDateGte = THREE_MONTHS.monthsAgo,
           firstAirDateLte = ONE_MONTH.monthsLater,
-          withoutKeywords = ANIME_WITHOUT_KEYWORDS,
         ).toQueryMap(),
       ).results
     }.flow.flowOn(ioDispatcher)
@@ -86,7 +73,6 @@ class AsianRemoteDataSource @Inject constructor(
           originCountry = ASIAN_REGION,
           page = page,
           withoutGenres = ROMANCE_DRAMA_WITHOUT_GENRES,
-          withoutKeywords = TV_STRICT_KEYWORDS,
         ).toQueryMap(),
       ).results
     }.flow.flowOn(ioDispatcher)
@@ -119,19 +105,6 @@ class AsianRemoteDataSource @Inject constructor(
     const val REALITY_SHOW_TYPE = "3"
 
     val ASIAN_REGION = listOf(CHINA, INDONESIA, JAPAN, KOREA, MALAYSIA, TAIWAN, THAILAND)
-
-    val TV_STRICT_KEYWORDS = listOf(
-      BISEXUAL_MAN,
-      GAY_ROMANCE,
-      GAY_RELATIONSHIP,
-      BOYS_LOVE,
-      GIRLS_LOVE,
-      LESBIAN,
-      LESBIAN_RELATIONSHIP,
-    )
-
-    val ANIME_WITHOUT_KEYWORDS =
-      (listOf(ECCHI, EROTIC, HENTAI, SOFTCORE) + TV_STRICT_KEYWORDS).distinct()
 
     val ROMANCE_DRAMA_WITHOUT_GENRES = listOf(ANIMATION, REALITY)
   }

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/query/DiscoverMovieParams.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/query/DiscoverMovieParams.kt
@@ -2,6 +2,7 @@ package com.waffiq.bazz_movies.core.network.data.remote.query
 
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Genre
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword
+import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.Companion.STRICT_KEYWORDS
 import com.waffiq.bazz_movies.core.network.data.remote.constants.SortBy
 
 data class DiscoverMovieParams(
@@ -13,6 +14,7 @@ data class DiscoverMovieParams(
   val releaseDateGte: String? = null,
   val releaseDateLte: String? = null,
   val watchRegion: String? = null,
+  val withoutKeywords: List<Keyword>? = STRICT_KEYWORDS,
   val sortBy: String = SortBy.POPULARITY_DESC,
   val includeAdult: Boolean = false,
   val language: String = "en-US",

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/query/DiscoverQueryMapper.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/query/DiscoverQueryMapper.kt
@@ -30,6 +30,7 @@ fun DiscoverMovieParams.toQueryMap(): Map<String, String> =
     genre?.let { put(WITH_GENRES, it) }
     keywords?.let { put(WITH_KEYWORDS, it.toKeywordQuery()) }
     keyword?.let { put(WITH_KEYWORDS, it) }
+    withoutKeywords?.let { put(WITHOUT_KEYWORDS, it.toKeywordQuery()) }
 
     releaseDateGte?.let { put(RELEASE_DATE_GTE, it) }
     releaseDateLte?.let { put(RELEASE_DATE_LTE, it) }

--- a/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/query/DiscoverTvParams.kt
+++ b/core/network/src/main/kotlin/com/waffiq/bazz_movies/core/network/data/remote/query/DiscoverTvParams.kt
@@ -2,6 +2,7 @@ package com.waffiq.bazz_movies.core.network.data.remote.query
 
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Genre
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword
+import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.Companion.STRICT_KEYWORDS
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Region
 import com.waffiq.bazz_movies.core.network.data.remote.constants.SortBy
 
@@ -17,7 +18,7 @@ data class DiscoverTvParams(
   val watchRegion: String? = null,
   val type: String? = null,
   val withoutGenres: List<Genre>? = null,
-  val withoutKeywords: List<Keyword>? = null,
+  val withoutKeywords: List<Keyword>? = STRICT_KEYWORDS,
   val sortBy: String = SortBy.POPULARITY_DESC,
   val includeAdult: Boolean = false,
   val language: String = "en-US",

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/asian/AsianRemoteDataSourceTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/datasource/asian/AsianRemoteDataSourceTest.kt
@@ -2,16 +2,15 @@ package com.waffiq.bazz_movies.core.network.data.remote.datasource.asian
 
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Genre.ANIMATION
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.COSTUME_DRAMA
+import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.Companion.STRICT_KEYWORDS
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.DONGHUA
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.ROMANCE
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Region.JAPAN
-import com.waffiq.bazz_movies.core.network.data.remote.datasource.asian.AsianRemoteDataSource.Companion.ANIME_WITHOUT_KEYWORDS
 import com.waffiq.bazz_movies.core.network.data.remote.datasource.asian.AsianRemoteDataSource.Companion.ASIAN_REGION
 import com.waffiq.bazz_movies.core.network.data.remote.datasource.asian.AsianRemoteDataSource.Companion.ONE_MONTH
 import com.waffiq.bazz_movies.core.network.data.remote.datasource.asian.AsianRemoteDataSource.Companion.REALITY_SHOW_TYPE
 import com.waffiq.bazz_movies.core.network.data.remote.datasource.asian.AsianRemoteDataSource.Companion.ROMANCE_DRAMA_WITHOUT_GENRES
 import com.waffiq.bazz_movies.core.network.data.remote.datasource.asian.AsianRemoteDataSource.Companion.THREE_MONTHS
-import com.waffiq.bazz_movies.core.network.data.remote.datasource.asian.AsianRemoteDataSource.Companion.TV_STRICT_KEYWORDS
 import com.waffiq.bazz_movies.core.network.data.remote.query.DiscoverTvParams
 import com.waffiq.bazz_movies.core.network.data.remote.query.toQueryMap
 import com.waffiq.bazz_movies.core.network.testutils.BaseMediaDataSourceTest
@@ -31,7 +30,7 @@ class AsianRemoteDataSourceTest : BaseMediaDataSourceTest() {
         page = 1,
         firstAirDateGte = THREE_MONTHS.monthsAgo,
         firstAirDateLte = ONE_MONTH.monthsLater,
-        withoutKeywords = ANIME_WITHOUT_KEYWORDS,
+        withoutKeywords = STRICT_KEYWORDS,
       ).toQueryMap()
 
       verifyTvDiscovery(asianRemoteDataSource.getAnimeThisSeason(), query)
@@ -44,7 +43,7 @@ class AsianRemoteDataSourceTest : BaseMediaDataSourceTest() {
         genres = listOf(ANIMATION),
         originCountry = listOf(JAPAN),
         page = 1,
-        withoutKeywords = ANIME_WITHOUT_KEYWORDS,
+        withoutKeywords = STRICT_KEYWORDS,
       ).toQueryMap()
 
       verifyTvDiscovery(asianRemoteDataSource.getAnimeAllTime(), query)
@@ -66,7 +65,7 @@ class AsianRemoteDataSourceTest : BaseMediaDataSourceTest() {
         originCountry = ASIAN_REGION,
         page = 1,
         withoutGenres = ROMANCE_DRAMA_WITHOUT_GENRES,
-        withoutKeywords = TV_STRICT_KEYWORDS,
+        withoutKeywords = STRICT_KEYWORDS,
       ).toQueryMap()
 
       verifyTvDiscovery(asianRemoteDataSource.getAsianRomance(), query)

--- a/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/query/DiscoverParamsExtTest.kt
+++ b/core/network/src/test/kotlin/com/waffiq/bazz_movies/core/network/data/remote/query/DiscoverParamsExtTest.kt
@@ -3,6 +3,7 @@ package com.waffiq.bazz_movies.core.network.data.remote.query
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Genre
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Genre.Companion.toGenreQuery
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword
+import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.Companion.STRICT_KEYWORDS
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Keyword.Companion.toKeywordQuery
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Region
 import com.waffiq.bazz_movies.core.network.data.remote.constants.Region.Companion.toRegionQuery
@@ -22,6 +23,7 @@ class DiscoverParamsExtTest {
     assertEquals("1", result["page"])
     assertEquals("false", result["include_adult"])
     assertEquals("en-US", result["language"])
+    assertEquals(STRICT_KEYWORDS.toKeywordQuery(), result["without_keywords"])
     assertEquals(SortBy.POPULARITY_DESC, result["sort_by"])
   }
 
@@ -63,15 +65,13 @@ class DiscoverParamsExtTest {
         Keyword.DONGHUA,
         Keyword.ROMANCE,
       ),
+      withoutKeywords = null,
     )
 
     val result = params.toQueryMap()
 
     assertEquals(
-      listOf(
-        Keyword.DONGHUA,
-        Keyword.ROMANCE,
-      ).toKeywordQuery(),
+      listOf(Keyword.DONGHUA, Keyword.ROMANCE).toKeywordQuery(),
       result["with_keywords"],
     )
   }
@@ -143,6 +143,7 @@ class DiscoverParamsExtTest {
         Genre.ANIMATION,
         Genre.DRAMA,
       ),
+      withoutKeywords = null,
     )
 
     val result = params.toQueryMap()
@@ -237,7 +238,6 @@ class DiscoverParamsExtTest {
     assertFalse(result.containsKey("with_keywords"))
     assertFalse(result.containsKey("with_origin_country"))
     assertFalse(result.containsKey("without_genres"))
-    assertFalse(result.containsKey("without_keywords"))
     assertFalse(result.containsKey("first_air_date.gte"))
     assertFalse(result.containsKey("first_air_date.lte"))
     assertFalse(result.containsKey("watch_region"))


### PR DESCRIPTION
### Changes Made

- Use default strict keywords for all queries (movie & tv discovery)
- Prevent accidently shows improper media when search by genre/keywords